### PR TITLE
Replace SpreadsheetView with regular TableView

### DIFF
--- a/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
@@ -6,56 +6,50 @@ package de.gsi.dataset;
  */
 public interface EditableDataSet extends DataSet {
 
-    /**
-     * @param name the new data set name
-     */
-    public void setName(String name);
+	/**
+	 * @param name the new data set name
+	 * @return itself (fluent design)
+	 */
+	public EditableDataSet setName(final String name);
 
-    /**
-     * modify point in the the data set
-     *
-     * @param index
-     *            data point index at which the new data point should be added
-     * @param x
-     *            horizontal coordinate of the new data point
-     * @param y
-     *            vertical coordinate of the new data point
-     * @return itself (fluent design)
-     */
-    public EditableDataSet set(final int index, final double x, final double y);
+	/**
+	 * modify point in the the data set
+	 *
+	 * @param index data point index at which the new data point should be added
+	 * @param x     horizontal coordinate of the new data point
+	 * @param y     vertical coordinate of the new data point
+	 * @return itself (fluent design)
+	 */
+	public EditableDataSet set(final int index, final double x, final double y);
 
-    /**
-     * add point to the data set
-     *
-     * @param index
-     *            data point index at which the new data point should be added
-     * @param x
-     *            horizontal coordinate of the new data point
-     * @param y
-     *            vertical coordinate of the new data point
-     * @return itself (fluent design)
-     */
-    public EditableDataSet add(final int index, final double x, final double y);
+	/**
+	 * add point to the data set
+	 *
+	 * @param index data point index at which the new data point should be added
+	 * @param x     horizontal coordinate of the new data point
+	 * @param y     vertical coordinate of the new data point
+	 * @return itself (fluent design)
+	 */
+	public EditableDataSet add(final int index, final double x, final double y);
 
-    /**
-     * remove point from data set
-     *
-     * @param index
-     *            data point which should be removed
-     * @return itself (fluent design)
-     */
-    public EditableDataSet remove(final int index);
+	/**
+	 * remove point from data set
+	 *
+	 * @param index data point which should be removed
+	 * @return itself (fluent design)
+	 */
+	public EditableDataSet remove(final int index);
 
-    /**
-     * 
-     * @return edit constraints for data set
-     */
-    public EditConstraints getEditConstraints();
-    
-    /**
-     * 
-     * @param constraints new edit constraints
-     * @return itself (fluent design)
-     */
-    public EditableDataSet setEditConstraints(EditConstraints constraints);
+	/**
+	 * 
+	 * @return edit constraints for data set
+	 */
+	public EditConstraints getEditConstraints();
+
+	/**
+	 * 
+	 * @param constraints new edit constraints
+	 * @return itself (fluent design)
+	 */
+	public EditableDataSet setEditConstraints(final EditConstraints constraints);
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -12,35 +12,44 @@ import org.slf4j.LoggerFactory;
 
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSetMetaData;
+import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.event.EventListener;
 import de.gsi.dataset.event.UpdateEvent;
+import de.gsi.dataset.event.UpdatedMetaDataEvent;
 
 /**
  * <p>
- * The abstract implementation of DataSet interface that provides implementation of some methods.
+ * The abstract implementation of DataSet interface that provides implementation
+ * of some methods.
  * </p>
  * <ul>
  * <li>It maintains the name of the DataSet
- * <li>It maintains a list of DataSetListener objects and provides methods that can be used to dispatch DataSetEvent
- * events.
+ * <li>It maintains a list of DataSetListener objects and provides methods that
+ * can be used to dispatch DataSetEvent events.
  * <li>It maintains ranges of X and Y values.
  * <li>It gives a possibility to specify an undefined value.
  * </ul>
- * @param <D> java generics handling of DataSet for derived classes (needed for fluent design)
+ * 
+ * @param <D> java generics handling of DataSet for derived classes (needed for
+ *            fluent design)
  */
 public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends AbstractStylable<D>
         implements DataSet, DataSetMetaData {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataSet.class);
     protected String name;
-    protected final List<EventListener> updateListeners = new LinkedList<>();    
+    protected final List<EventListener> updateListeners = new LinkedList<>();
     protected final ReentrantLock lock = new ReentrantLock();
     boolean autoNotification = true;
     protected DataRange xRange = new DataRange();
     protected DataRange yRange = new DataRange();
-    private final Map<String, String> metaInfoMap = new ConcurrentHashMap<>();
+    protected Map<Integer, String> dataLabels = new ConcurrentHashMap<>();
+    protected Map<Integer, String> dataStyles = new ConcurrentHashMap<>();
+    protected EditConstraints editConstraints;
+    protected final Map<String, String> metaInfoMap = new ConcurrentHashMap<>();
 
     /**
      * default constructor
+     * 
      * @param name the default name of the data set (meta data)
      */
     public AbstractDataSet(final String name) {
@@ -56,10 +65,13 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * Sets the name of data set (meta data)
+     * 
      * @param name the new name
+     * @return itself (fluent design)
      */
-    public void setName(final String name) {
+    public D setName(final String name) {
         this.name = name;
+        return getThis();
     }
 
     @Override
@@ -78,10 +90,10 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
         lock.unlock();
         return getThis();
     }
-    
+
     public List<EventListener> updateEventListener() {
         return updateListeners;
-    }     
+    }
 
     @Override
     public D setAutoNotifaction(final boolean flag) {
@@ -175,6 +187,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * Computes limits (ranges) of this DataSet.
+     * 
      * @return itself (fluent design)
      */
     protected D computeLimits() {
@@ -215,8 +228,10 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
     }
 
     /**
-     * Gets the index of the data point closest to the given x coordinate. The index returned may be less then zero or
-     * larger the the number of data points in the data set, if the x coordinate lies outside the range of the data set.
+     * Gets the index of the data point closest to the given x coordinate. The
+     * index returned may be less then zero or larger the the number of data
+     * points in the data set, if the x coordinate lies outside the range of the
+     * data set.
      *
      * @param x the x position of the data point
      * @return the index of the data point
@@ -226,7 +241,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
         if (this.getDataCount() == 0) {
             return 0;
         }
-        
+
         if (!Double.isFinite(x)) {
             return 0;
         }
@@ -356,54 +371,152 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
         return searchIndex;
     }
 
-	/**
-	 * Notifies listeners that the data has been invalidated. If the data is added
-	 * to the chart, it triggers repaint.
-	 * 
-	 * @param event the change event
-	 *
-	 * @return itself (fluent design)
-	 */
-	public D fireInvalidated(final UpdateEvent event) {
-		if (!autoNotification || updateEventListener().isEmpty()) {
-			return getThis();
-		}
-
-		if (!xRange.isDefined() || !yRange.isDefined()) {
-			computeLimits();
-		}
-
-		// TODO: check whether Platform is proper usage within DataSet
-		// executeFireInvalidated();
-
-//        if (Platform.isFxApplicationThread()) {
-//        	invokeListener(event);
-//        } else {
-//            Platform.runLater(() -> invokeListener(event));
-//        }
-
-		invokeListener(event);
-
-		return getThis();
-	}
-
     /**
-     * Returns label of a data point specified by the index. The label can be used as a category name if
-     * CategoryStepsDefinition is used or for annotations displayed for data points.
+     * Notifies listeners that the data has been invalidated. If the data is
+     * added to the chart, it triggers repaint.
+     * 
+     * @param event the change event
      *
-     * @param index data point index
-     * @return label of a data point specified by the index or <code>null</code> if none label has been specified for
-     *         this data point.
+     * @return itself (fluent design)
      */
-    @Override
-    public String getDataLabel(final int index) {
-        return getName() + "(" + index + "," + getX(index) + "," + getY(index) + ")";
+    public D fireInvalidated(final UpdateEvent event) {
+        if (!autoNotification || updateEventListener().isEmpty()) {
+            return getThis();
+        }
+
+        if (!xRange.isDefined() || !yRange.isDefined()) {
+            computeLimits();
+        }
+
+        invokeListener(event);
+
+        return getThis();
     }
 
     @Override
     public String toString() {
         return getClass().getName() + " [dataCnt=" + getDataCount() + ", xRange=" + getXRange() + ", yRange="
                 + getYRange() + "]";
+    }
+
+    /**
+     * adds a custom new data label for a point The label can be used as a
+     * category name if CategoryStepsDefinition is used or for annotations
+     * displayed for data points.
+     *
+     * @param index of the data point
+     * @param label for the data point specified by the index
+     * @return the previously set label or <code>null</code> if no label has
+     *         been specified
+     */
+    public String addDataLabel(final int index, final String label) {
+        lock();
+        final String retVal = dataLabels.put(index, label);
+        unlock();
+        fireInvalidated(new UpdatedMetaDataEvent(this, "added label"));
+        return retVal;
+    }
+
+    /**
+     * remove a custom data label for a point The label can be used as a
+     * category name if CategoryStepsDefinition is used or for annotations
+     * displayed for data points.
+     *
+     * @param index of the data point
+     * @return the previously set label or <code>null</code> if no label has
+     *         been specified
+     */
+    public String removeDataLabel(final int index) {
+        lock();
+        final String retVal = dataLabels.remove(index);
+        unlock();
+        fireInvalidated(new UpdatedMetaDataEvent(this, "removed label"));
+        return retVal;
+    }
+
+    /**
+     * Returns label of a data point specified by the index. The label can be
+     * used as a category name if CategoryStepsDefinition is used or for
+     * annotations displayed for data points.
+     *
+     * @param index data point index
+     * @return label of a data point specified by the index or <code>null</code>
+     *         if none label has been specified for this data point.
+     */
+    protected String getDefaultDataLabel(final int index) {
+        return getName() + "(" + index + "," + getX(index) + "," + getY(index) + ")";
+    }
+
+    /**
+     * Returns label of a data point specified by the index. The label can be
+     * used as a category name if CategoryStepsDefinition is used or for
+     * annotations displayed for data points.
+     *
+     * @param index of the data label
+     * @return data point label specified by the index or <code>null</code> if
+     *         no label has been specified
+     */
+    @Override
+    public String getDataLabel(final int index) {
+        final String dataLabel = dataLabels.get(index);
+        if (dataLabel != null) {
+            return dataLabel;
+        }
+
+        return getDefaultDataLabel(index);
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @param style string for the data point specific CSS-styling
+     * @return itself (fluent interface)
+     */
+    public String addDataStyle(final int index, final String style) {
+        lock();
+        final String retVal = dataStyles.put(index, style);
+        unlock();
+        fireInvalidated(new UpdatedMetaDataEvent(this, "added style"));
+        return retVal;
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @return itself (fluent interface)
+     */
+    public String removeStyle(final int index) {
+        lock();
+        final String retVal = dataStyles.remove(index);
+        lock();
+        fireInvalidated(new UpdatedMetaDataEvent(this, "removed style"));
+        return retVal;
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @return user-specific data set style description (ie. may be set by user)
+     */
+    public String getStyle(final int index) {
+        return dataStyles.get(index);
+    }
+
+    public EditConstraints getEditConstraints() {
+        return editConstraints;
+    }
+
+    public D setEditConstraints(final EditConstraints constraints) {
+        lock();
+        editConstraints = constraints;
+        unlock();
+        return fireInvalidated(new UpdatedMetaDataEvent(this, "new edit constraints"));
     }
 
     @Override
@@ -413,16 +526,16 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     @Override
     public List<String> getInfoList() {
-        return Collections.<String> emptyList();
+        return Collections.<String>emptyList();
     }
 
     @Override
     public List<String> getWarningList() {
-        return Collections.<String> emptyList();
+        return Collections.<String>emptyList();
     }
 
     @Override
     public List<String> getErrorList() {
-        return Collections.<String> emptyList();
+        return Collections.<String>emptyList();
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
@@ -1,6 +1,7 @@
 package de.gsi.dataset.spi;
 
 import de.gsi.dataset.DataSetError;
+import de.gsi.dataset.event.UpdateEvent;
 
 /**
  * <p>
@@ -18,7 +19,7 @@ import de.gsi.dataset.DataSetError;
  * @author rstein
  * @param <D> java generics handling of DataSet for derived classes (needed for fluent design)
  */
-public abstract class AbstractErrorDataSet<D extends AbstractDataSet<D>> extends AbstractDataSet<D>
+public abstract class AbstractErrorDataSet<D extends AbstractErrorDataSet<D>> extends AbstractDataSet<D>
         implements DataSetError {
     private ErrorType errorType = ErrorType.NO_ERROR;
 
@@ -39,6 +40,24 @@ public abstract class AbstractErrorDataSet<D extends AbstractDataSet<D>> extends
     protected D getThis() {
         return (D) this;
     }
+    
+    @Override
+    public D lock() {
+        lock.lock();
+        return getThis();
+    }
+
+    @Override
+    public D unlock() {
+        lock.unlock();
+        return getThis();
+    }
+    
+    @Override
+	public D fireInvalidated(final UpdateEvent event) {
+		super.fireInvalidated(event);
+		return getThis();
+	}
 
     /**
      * return the DataSetError.ErrorType of the dataset

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
@@ -216,7 +216,7 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> {
     private class InternalDataSet extends DoubleDataSet {
 
         public InternalDataSet(DataSet ds) {
-            super(ds.getName(), ds.getXValues(), ds.getYValues(), true);
+            super(ds.getName(), ds.getXValues(), ds.getYValues(), ds.getDataCount(), true);
             //      xValues = new double[ds.getDataCount()];
             //      yValues = new double[ds.getDataCount()];
             //      for (int i=0;i<yValues.length;i++)

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataSetBuilder.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataSetBuilder.java
@@ -1,0 +1,114 @@
+package de.gsi.dataset.spi;
+
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.utils.AssertUtils;
+
+public class DataSetBuilder {
+    protected String name;
+    protected double[] xValues;
+    protected double[] yValues;
+    protected double[] yErrorsPos;
+    protected double[] yErrorsNeg;
+    protected int initialCapacity = -1;
+
+    /**
+     * default DataSet factory
+     */
+    public DataSetBuilder() {
+        this("default data set");
+    }
+
+    /**
+     * default DataSet factory
+     * 
+     * @param dataSetName data set name
+     */
+    public DataSetBuilder(final String dataSetName) {
+        super();
+        this.setName(dataSetName);
+    }
+
+    public final DataSetBuilder setName(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public final DataSetBuilder setXValuesNoCopy(final double[] xValues) { // NOPMD
+        // direct storage is on purpose
+        this.xValues = xValues;
+        return this;
+    }
+
+    public final DataSetBuilder setXValues(final double[] xValues) {
+        final int size = initialCapacity < 0 ? xValues.length : Math.min(initialCapacity, xValues.length);
+        this.xValues = new double[size];
+        System.arraycopy(xValues, 0, this.xValues, 0, size);
+        return this;
+    }
+
+    public final DataSetBuilder setYValuesNoCopy(final double[] yValues) { // NOPMD
+        // direct storage is on purpose
+        this.yValues = yValues;
+        return this;
+    }
+
+    public final DataSetBuilder setYValues(final double[] yValues) {
+        final int size = initialCapacity < 0 ? yValues.length : Math.min(initialCapacity, yValues.length);
+        this.yValues = new double[size];
+        System.arraycopy(yValues, 0, this.yValues, 0, size);
+        return this;
+    }
+
+    public final DataSetBuilder setYPosErrorNoCopy(final double[] yErrorValuesPos) { // NOPMD
+        // direct storage is on purpose
+        this.yErrorsPos = yErrorValuesPos;
+        return this;
+    }
+
+    public final DataSetBuilder setYPosError(final double[] yErrorValuesPos) {
+        final int size = initialCapacity < 0 ? yErrorValuesPos.length
+                : Math.min(initialCapacity, yErrorValuesPos.length);
+        this.yErrorsPos = new double[size];
+        System.arraycopy(yErrorValuesPos, 0, this.yErrorsPos, 0, size);
+        return this;
+    }
+
+    public DataSetBuilder setYNegErrorNoCopy(final double[] yErrorValuesNeg) { // NOPMD
+        // direct storage is on purpose
+        this.yErrorsNeg = yErrorValuesNeg;
+        return this;
+    }
+
+    public DataSetBuilder setYNegError(final double[] yErrorValuesNeg) {
+        final int size = initialCapacity < 0 ? yErrorValuesNeg.length
+                : Math.min(initialCapacity, yErrorValuesNeg.length);
+        this.yErrorsNeg = new double[size];
+        System.arraycopy(yErrorValuesNeg, 0, this.yErrorsNeg, 0, size);
+        return this;
+    }
+
+    public DataSet build() {
+        final String dsName = name == null ? ("DataSet@" + System.currentTimeMillis()) : name;
+        if (xValues == null && yValues == null) {
+            // no X/Y arrays provided
+            return new DefaultDataSet(dsName, Math.max(initialCapacity, 0));
+        }
+        // either at least X or Y array provided
+        final double[] dsX = xValues == null ? new double[yValues.length] : xValues;
+        final double[] dsY = yValues == null ? new double[xValues.length] : yValues;
+        final int minArrays = Math.min(dsX.length, dsY.length);
+        final int size = initialCapacity < 0 ? minArrays : Math.min(minArrays, initialCapacity);
+
+        if (yErrorsNeg == null && yErrorsPos == null) {
+            // no error arrays -> build non-error data set
+            return new DefaultDataSet(dsName, dsX, dsY, size, false);
+        }
+        // at least one error array has been provided
+        final double[] dsYep = yErrorsPos == null ? yErrorsNeg : yErrorsPos;
+        final double[] dsYen = yErrorsNeg == null ? yErrorsPos : yErrorsNeg;
+        AssertUtils.equalDoubleArrays(xValues, yErrorsPos, size);
+        AssertUtils.equalDoubleArrays(xValues, yErrorsNeg, size);
+
+        return new DefaultErrorDataSet(dsName, dsX, dsY, dsYen, dsYep, size, false);
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultDataSet.java
@@ -1,395 +1,73 @@
 package de.gsi.dataset.spi;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.event.AddedDataEvent;
-import de.gsi.dataset.event.RemovedDataEvent;
-import de.gsi.dataset.event.UpdatedDataEvent;
-import de.gsi.dataset.event.UpdatedMetaDataEvent;
-import de.gsi.dataset.spi.utils.DoublePoint;
-import de.gsi.dataset.spi.utils.Tuple;
-import de.gsi.dataset.utils.AssertUtils;
 
 /**
- * Implementation of the <code>DataSet</code> interface which keeps the x,y
- * values in an observable list. It provides methods allowing easily manipulate
- * of data points. <br>
- * User provides X and Y coordinates or only Y coordinates. In the former case X
- * coordinates have value of data point index.
+ * Redirect to the reference implementation declared as 'default'.
+ * 
+ * This implementation should have a good performance and applicability for most
+ * use-cases. Presently it is based on the @see DoubleDataSet implementation.
+ * 
+ * @see DoubleDataSet for the reference implementation
+ * @see DoubleErrorDataSet for an implementation with asymmetric errors in Y
  *
  * @author rstein
  */
-public class DefaultDataSet extends AbstractDataSet<DefaultDataSet> implements DataSet {
-    protected Map<Integer, String> dataLabels = new ConcurrentHashMap<>();
-    protected Map<Integer, String> dataStyles = new ConcurrentHashMap<>();
-    protected ArrayList<DoublePoint> data = new ArrayList<>();
+public class DefaultDataSet extends DoubleDataSet {
 
     /**
      * Creates a new instance of <code>DefaultDataSet</code>.
      *
-     * @param name
-     *            name of this DataSet.
-     * @throws IllegalArgumentException
-     *             if <code>name</code> is <code>null</code>
+     * @param name name of this DataSet.
+     * @throws IllegalArgumentException if <code>name</code> is
+     *             <code>null</code>
      */
     public DefaultDataSet(final String name) {
-        super(name);
+        super(name, 0);
     }
 
     /**
-     * Creates a new instance of <code>DefaultDataSet</code>. X coordinates are
-     * equal to data points indices. <br>
-     * Note: The provided array is not copied (data set operates on the
-     * specified array object) thus the array should not be modified outside of
-     * this data set.
+     * Creates a new instance of <code>DefaultDataSet</code> as copy of another
+     * (deep-copy).
      *
-     * @param name
-     *            name of this data set.
-     * @param yValues
-     *            Y coordinates
-     * @throws IllegalArgumentException
-     *             if any of parameters is <code>null</code>
+     * @param another name of this DataSet.
      */
-    public DefaultDataSet(final String name, final double[] yValues) {
-        this(name);
-        AssertUtils.notNull("Y data", yValues);
+    public DefaultDataSet(final DataSet another) {
+        super(another);
+    }
 
-        for (Integer i = 0; i < yValues.length; i++) {
-            data.add(new DoublePoint((double) i, yValues[i]));
-        }
+    /**
+     * Creates a new instance of <code>DefaultDataSet</code>.
+     *
+     * @param name name of this DataSet.
+     * @param initalSize initial buffer size
+     * @throws IllegalArgumentException if <code>name</code> is
+     *             <code>null</code>
+     */
+    public DefaultDataSet(final String name, final int initalSize) {
+        super(name, initalSize);
     }
 
     /**
      * <p>
      * Creates a new instance of <code>DefaultDataSet</code>.
      * </p>
-     * Note: The provided arrays are not copied (data set operates on specified
-     * array objects) thus these array should not be modified outside of this
-     * data set.
+     * The user than specify via the copy parameter, whether the dataset
+     * operates directly on the input arrays themselves or on a copies of the
+     * input arrays. If the dataset operates directly on the input arrays, these
+     * arrays must not be modified outside of this data set.
      *
-     * @param name
-     *            name of this data set.
-     * @param xValues
-     *            X coordinates
-     * @param yValues
-     *            Y coordinates
-     * @throws IllegalArgumentException
-     *             if any of parameters is <code>null</code> or if arrays with
-     *             coordinates have different lengths
+     * @param name name of this data set.
+     * @param xValues X coordinates
+     * @param yValues Y coordinates
+     * @param initalSize initial buffer size
+     * @param deepCopy if true, the input array is copied
+     * @throws IllegalArgumentException if any of parameters is
+     *             <code>null</code> or if arrays with coordinates have
+     *             different lengths
      */
-    public DefaultDataSet(final String name, final double[] xValues, final double[] yValues) {
-        this(name);
-        AssertUtils.notNull("X data", xValues);
-        AssertUtils.notNull("Y data", yValues);
-        AssertUtils.equalDoubleArrays(xValues, yValues);
-        for (Integer i = 0; i < yValues.length; i++) {
-            data.add(new DoublePoint(xValues[i], yValues[i]));
-        }
+    public DefaultDataSet(final String name, final double[] xValues, final double[] yValues, final int initalSize, final boolean deepCopy) {
+        super(name, xValues, yValues, initalSize, deepCopy);
     }
 
-    /**
-     * <p>
-     * Creates a new instance of <code>DefaultDataSet</code>.
-     * </p>
-     *
-     * @param name
-     *            name of this data set.
-     * @param values
-     *            list of data points to set
-     * @throws IllegalArgumentException
-     *             if any of parameters is <code>null</code> or if arrays with
-     *             coordinates have different lengths
-     */
-    public DefaultDataSet(final String name, final List<DoublePoint> values) {
-        this(name);
-        AssertUtils.notNull("values", values);
-        data.clear();
-        data.addAll(values);
-    }
-
-    /**
-     * 
-     * @return data label map for given data point
-     */
-    public Map<Integer, String> getDataLabelMap() {
-        return dataLabels;
-    }
-
-    /**
-     * 
-     * @return data style map (CSS-styling)
-     */
-    public Map<Integer, String> getDataStyleMap() {
-        return dataStyles;
-    }
-
-    /**
-     * 
-     * @return list containing data point definition
-     */
-    public List<DoublePoint> getData() {
-        return data;
-    }
-
-    @Override
-    public int getDataCount() {
-        return data.size();
-    }
-
-    /**
-     * clear all data points
-     * @return itself (fluent design)
-     */
-    public DefaultDataSet clearData() {
-        lock().setAutoNotifaction(false);
-
-        data.clear();
-
-        xRange.empty();
-        yRange.empty();
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new RemovedDataEvent(this, "clearData()"));
-    }
-
-    @Override
-    public double getX(final int index) {
-        return data.get(index).getX();
-    }
-
-    @Override
-    public double getY(final int index) {
-        return data.get(index).getY();
-    }
-
-    /**
-     * replaces values of all existing data points
-     * @param values new data points
-     * @return itself (fluent design)
-     */
-    public DefaultDataSet set(final List<DoublePoint> values) {
-        AssertUtils.notNull("values", values);
-        lock().setAutoNotifaction(false);
-
-        data.clear();
-        data.addAll(values);
-
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new UpdatedDataEvent(this));
-    }
-
-    /**
-     * sets new value of existing data point
-     * @param index data point index
-     * @param x new horizontal value
-     * @param y new vertical value
-     * @return itself (fluent design)
-     */
-    public DefaultDataSet set(final int index, final double x, final double y) {
-        lock();
-        AssertUtils.indexInBounds(index, getDataCount());
-        data.get(index).set(x, y);
-
-        xRange.add(x);
-        yRange.add(y);
-
-        return unlock().fireInvalidated(new UpdatedDataEvent(this));
-    }
-
-    /**
-     * Add point to the DoublePoints object
-     *
-     * @param x
-     *            coordinate
-     * @param y
-     *            coordinate
-     * @return itself
-     */
-    public DefaultDataSet add(final double x, final double y) {
-        lock();
-        data.add(new DoublePoint(x, y));
-
-        xRange.add(x);
-        yRange.add(y);
-
-        return unlock().fireInvalidated(new AddedDataEvent(this));
-    }
-
-    /**
-     * remvove sub-range of data points
-     * @param fromIndex start index
-     * @param toIndex stop index
-     * @return itself (fluent design)
-     */
-    public DefaultDataSet remove(final int fromIndex, final int toIndex) {
-        lock().setAutoNotifaction(false);
-        AssertUtils.indexInBounds(fromIndex, getDataCount(), "fromIndex");
-        AssertUtils.indexInBounds(toIndex, getDataCount(), "toIndex");
-        AssertUtils.indexOrder(fromIndex, "fromIndex", toIndex, "toIndex");
-
-        data.subList(fromIndex, toIndex).clear();
-
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new RemovedDataEvent(this));
-    }
-
-    /**
-     * Removes from this data set points with specified indices.
-     *
-     * @param indices
-     *            array of indices to be removed
-     * @return itself
-     */
-    public DefaultDataSet remove(final int[] indices) {
-        lock();
-        setAutoNotifaction(false);
-        AssertUtils.notNull("Indices array", indices);
-        if (indices.length == 0) {
-            return unlock();
-        }
-
-        final List<Tuple<Double, Double>> tupleTobeRemovedReferences = new ArrayList<>();
-        for (final int indexToRemove : indices) {
-            tupleTobeRemovedReferences.add(data.get(indexToRemove));
-        }
-        data.removeAll(tupleTobeRemovedReferences);
-
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-        super.computeLimits();
-        return setAutoNotifaction(true).unlock().fireInvalidated(new UpdatedDataEvent(this));
-    }
-
-    /**
-     * <p>
-     * Initialises the data set with specified data.
-     * </p>
-     * Note: The method copies values from specified double arrays.
-     *
-     * @param xValues
-     *            X coordinates
-     * @param yValues
-     *            Y coordinates
-     * @return itself
-     */
-    public DefaultDataSet add(final double[] xValues, final double[] yValues) {
-        lock().setAutoNotifaction(false);
-        AssertUtils.notNull("X coordinates", xValues);
-        AssertUtils.notNull("Y coordinates", yValues);
-        AssertUtils.equalDoubleArrays(xValues, yValues);
-
-        data.clear();
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-        for (int i = 0; i < xValues.length; i++) {
-            data.add(new DoublePoint(xValues[i], yValues[i]));
-            xRange.add(xValues[i]);
-            yRange.add(yValues[i]);
-        }
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new AddedDataEvent(this));
-    }
-
-    /**
-     * adds a custom new data label for a point The label can be used as a
-     * category name if CategoryStepsDefinition is used or for annotations
-     * displayed for data points.
-     *
-     * @param index
-     *            of the data point
-     * @param label
-     *            for the data point specified by the index
-     * @return the previously set label or <code>null</code> if no label has
-     *         been specified
-     */
-    public String addDataLabel(final int index, final String label) {
-        final String retVal = dataLabels.put(index, label);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "added label"));
-        return retVal;
-    }
-
-    /**
-     * remove a custom data label for a point The label can be used as a
-     * category name if CategoryStepsDefinition is used or for annotations
-     * displayed for data points.
-     *
-     * @param index
-     *            of the data point
-     * @return the previously set label or <code>null</code> if no label has
-     *         been specified
-     */
-    public String removeDataLabel(final int index) {
-        final String retVal = dataLabels.remove(index);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "removed label"));        
-        return retVal;
-    }
-
-    /**
-     * Returns label of a data point specified by the index. The label can be
-     * used as a category name if CategoryStepsDefinition is used or for
-     * annotations displayed for data points.
-     *
-     * @param index
-     *            of the data label
-     * @return data point label specified by the index or <code>null</code> if
-     *         no label has been specified
-     */
-    @Override
-    public String getDataLabel(final int index) {
-        final String dataLabel = dataLabels.get(index);
-        if (dataLabel != null) {
-            return dataLabel;
-        }
-
-        return super.getDataLabel(index);
-    }
-
-    /**
-     * A string representation of the CSS style associated with this specific
-     * {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index
-     *            the index of the specific data point
-     * @param style for the given data point (CSS-styling)
-     * @return itself (fluent interface)
-     */
-    public String addDataStyle(final int index, final String style) {
-        final String retVal = dataStyles.put(index, style);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "added style"));
-        return retVal;        
-    }
-
-    /**
-     * A string representation of the CSS style associated with this specific
-     * {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index
-     *            the index of the specific data point
-     * @return itself (fluent interface)
-     */
-    public String removeStyle(final int index) {
-        final String retVal = dataStyles.remove(index);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "removed style"));        
-        return retVal;
-    }
-
-    /**
-     * A string representation of the CSS style associated with this specific
-     * {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index
-     *            the index of the specific data point
-     * @return user-specific data set style description (ie. may be set by user)
-     */
-    @Override
-    public String getStyle(final int index) {
-        return dataStyles.get(index);
-    }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultErrorDataSet.java
@@ -1,574 +1,70 @@
 package de.gsi.dataset.spi;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import de.gsi.dataset.DataSetError;
-import de.gsi.dataset.event.AddedDataEvent;
-import de.gsi.dataset.event.RemovedDataEvent;
-import de.gsi.dataset.event.UpdatedDataEvent;
-import de.gsi.dataset.event.UpdatedMetaDataEvent;
-import de.gsi.dataset.spi.utils.DoublePointError;
-import de.gsi.dataset.utils.AssertUtils;
+import de.gsi.dataset.DataSet;
 
 /**
- * Default implementation of <code>DataSet</code> and <code>DataSetError</code> interface. User provides X and Y
- * coordinates or only Y coordinates. In the former case X coordinates have value of data point index.
+ * Redirect to the reference implementation declared as 'default'.
+ * 
+ * This implementation should have a good performance and applicability for most
+ * use-cases. Presently it is based on the @see DoubleDataSet implementation.
+ * 
+ * @see DoubleErrorDataSet for the reference implementation
+ * @see DoubleDataSet for an implementation without asymmetric errors in Y
  *
- * @see de.gsi.dataset.DataSet
- * @see de.gsi.dataset.DataSetError
  * @author rstein
  */
-public class DefaultErrorDataSet extends AbstractErrorDataSet<DefaultErrorDataSet> implements DataSetError {
-    protected Map<Integer, String> dataLabels = new ConcurrentHashMap<>();
-    protected Map<Integer, String> dataStyles = new ConcurrentHashMap<>();
-    protected ArrayList<DoublePointError> data = new ArrayList<>();
+public class DefaultErrorDataSet extends DoubleErrorDataSet {
 
     /**
-     * Creates a new instance of <code>DefaultDataSet</code>.
+     * Creates a new instance of <code>DefaultErrorDataSet</code>.
      *
      * @param name name of this DataSet.
-     * @throws IllegalArgumentException if <code>name</code> is <code>null</code>
      */
     public DefaultErrorDataSet(final String name) {
-        super(name);
-        setErrorType(ErrorType.XY);
+        super(name, 0);
     }
 
     /**
-     * Creates a new instance of <code>DefaultDataSet</code>. X coordinates are equal to data points indices. <br>
-     * Note: The provided array is not copied (data set operates on the specified array object) thus the array should
-     * not be modified outside of this data set.
+     * Creates a new instance of <code>DefaultErrorDataSet</code>.
      *
-     * @param name name of this data set.
-     * @param yValues Y coordinates
-     * @throws IllegalArgumentException if any of parameters is <code>null</code>
+     * @param name name of this DataSet.
+     * @param initalSize maximum capacity of buffer
+     * @throws IllegalArgumentException if <code>name</code> is
+     *             <code>null</code>
      */
-    public DefaultErrorDataSet(final String name, final double[] yValues) {
-        this(name);
-        AssertUtils.notNull("Y data", yValues);
-
-        for (int i = 0; i < yValues.length; i++) {
-            data.add(new DoublePointError(i, yValues[i], 0, 0));
-        }
+    public DefaultErrorDataSet(final String name, final int initalSize) {
+        super(name, initalSize);
+    }
+    
+    /**
+     * Creates a new instance of <code>DoubleDataSet</code> as copy of another
+     * (deep-copy).
+     *
+     * @param another name of this DataSet.
+     */
+    public DefaultErrorDataSet(final DataSet another) {
+        super(another);
     }
 
     /**
      * <p>
-     * Creates a new instance of <code>DefaultDataSet</code>.
+     * Creates a new instance of <code>DefaultErrorDataSet</code>.
      * </p>
-     * Note: The provided arrays are not copied (data set operates on specified array objects) thus these array should
-     * not be modified outside of this data set.
      *
      * @param name name of this data set.
      * @param xValues X coordinates
      * @param yValues Y coordinates
-     * @throws IllegalArgumentException if any of parameters is <code>null</code> or if arrays with coordinates have
-     *             different lengths
-     */
-    public DefaultErrorDataSet(final String name, final double[] xValues, final double[] yValues) {
-        this(name);
-        AssertUtils.notNull("X data", xValues);
-        AssertUtils.notNull("Y data", yValues);
-        AssertUtils.equalDoubleArrays(xValues, yValues);
-
-        for (int i = 0; i < yValues.length; i++) {
-            data.add(new DoublePointError(xValues[i], yValues[i], 0, 0));
-        }
-    }
-
-    /**
-     * <p>
-     * Creates a new instance of <code>DefaultDataSet</code>.
-     * </p>
-     * Note: The provided arrays are not copied (data set operates on specified array objects) thus these array should
-     * not be modified outside of this data set.
-     *
-     * @param name name of this data set.
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param xErrors symmetric X coordinate errors
-     * @param yErrors symmetric Y coordinate errors N.B. all errors are assumed to be positive
-     * @throws IllegalArgumentException if any of parameters is <code>null</code> or if arrays with coordinates have
+     * @param yErrorsNeg Y negative coordinate error
+     * @param yErrorsPos Y positive coordinate error
+     * @param nData how many data points are relevant to be taken
+     * @param deepCopy if true, the input array is copied
+     * @throws IllegalArgumentException if any of parameters is
+     *             <code>null</code> or if arrays with coordinates have
      *             different lengths
      */
     public DefaultErrorDataSet(final String name, final double[] xValues, final double[] yValues,
-            final double[] xErrors, final double[] yErrors) {
-        super(name);
-        AssertUtils.notNull("X data", xValues);
-        AssertUtils.notNull("Y data", yValues);
-        AssertUtils.notNull("X error data", xErrors);
-        AssertUtils.notNull("Y error data", yErrors);
-        AssertUtils.equalDoubleArrays(xValues, yValues);
-        AssertUtils.equalDoubleArrays(xValues, xErrors);
-        AssertUtils.equalDoubleArrays(xValues, yErrors);
-
-        for (int i = 0; i < yValues.length; i++) {
-            data.add(new DoublePointError(xValues[i], yValues[i], xErrors[i], yErrors[i]));
-        }
-    }
-
-    /**
-     * <p>
-     * Creates a new instance of <code>DefaultDataSet</code>.
-     * </p>
-     * Note: The provided arrays are not copied (data set operates on specified array objects) thus these array should
-     * not be modified outside of this data set.
-     *
-     * @param name name of this data set.
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param yErrors symmetric Y coordinate errors N.B. all errors are assumed to be positive
-     * @throws IllegalArgumentException if any of parameters is <code>null</code> or if arrays with coordinates have
-     *             different lengths
-     */
-    public DefaultErrorDataSet(final String name, final double[] xValues, final double[] yValues,
-            final double[] yErrors) {
-        this(name);
-        AssertUtils.notNull("X data", xValues);
-        AssertUtils.notNull("Y data", yValues);
-        AssertUtils.notNull("Y error data", yErrors);
-        AssertUtils.equalDoubleArrays(xValues, yValues);
-        AssertUtils.equalDoubleArrays(xValues, yErrors);
-
-        for (int i = 0; i < yValues.length; i++) {
-            data.add(new DoublePointError(xValues[i], yValues[i], 0.0, yErrors[i]));
-        }
-    }
-
-    /**
-     * 
-     * @return data label map for given data point
-     */
-    public Map<Integer, String> getDataLabelMap() {
-        return dataLabels;
-    }
-
-    /**
-     * 
-     * @return data style map (CSS-styling)
-     */
-    public Map<Integer, String> getDataStyleMap() {
-        return dataStyles;
-    }
-
-    /**
-     * 
-     * @return list containing data point definition
-     */
-    public List<DoublePointError> getData() {
-        return data;
-    }
-
-    @Override
-    public int getDataCount() {
-        return data.size();
-    }
-
-    /**
-     * @return the x coordinate
-     */
-    @Override
-    public double getX(final int i) {
-        return data.get(i).getX();
-    }
-
-    /**
-     * @return the y coordinate
-     */
-    @Override
-    public double getY(final int i) {
-        return data.get(i).getY();
-    }
-
-    /**
-     * @see DataSetError#getXErrorNegative(int)
-     * @return the negative error of the x coordinate
-     */
-    @Override
-    public double getXErrorNegative(final int index) {
-        return data.get(index).getErrorX();
-    }
-
-    /**
-     * @see DataSetError#getXErrorPositive(int)
-     * @return the positive error of the x coordinate
-     */
-    @Override
-    public double getXErrorPositive(final int index) {
-        return data.get(index).getErrorX();
-    }
-
-    /**
-     * @see DataSetError#getYErrorNegative(int)
-     * @return the negative error of the y coordinate
-     */
-    @Override
-    public double getYErrorNegative(final int index) {
-        return data.get(index).getErrorY();
-    }
-
-    /**
-     * @see DataSetError#getYErrorPositive(int)
-     * @return the positive error of the y coordinate
-     */
-    @Override
-    public double getYErrorPositive(final int index) {
-        return data.get(index).getErrorY();
-    }
-
-    /**
-     * Sets the point with index to the new coordinate
-     *
-     * @param index the point index of the data set
-     * @param x the horizontal coordinate of the data point
-     * @param y the vertical coordinate of the data point
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final int index, final double x, final double y) {
-        return set(index, x, y, 0, 0);
-    }
-
-    /**
-     * clears all data points
-     * @return itself (fluent design)
-     */
-    public DefaultErrorDataSet clearData() {
-        lock().setAutoNotifaction(false);
-        data.clear();
-        xRange.empty();
-        yRange.empty();
-//        xRange.setMax(Double.NaN);
-//        yRange.setMax(Double.NaN);
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new RemovedDataEvent(this, "clearData()"));
-    }
-
-    /**
-     * Sets the point with index to the new coordinate
-     *
-     * @param index the point index of the data set
-     * @param x the horizontal coordinate of the data point
-     * @param y the vertical coordinate of the data point
-     * @param dx the horizontal error
-     * @param dy the vertical error N.B. assumes symmetric errors
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final int index, final double x, final double y, final double dx, final double dy) {
-        lock();
-        data.get(index).set(x, y, dy, dy);
-
-        xRange.add(x - dx);
-        xRange.add(x + dx);
-        yRange.add(y - dy);
-        yRange.add(y + dy);
-
-        return unlock().fireInvalidated(new UpdatedDataEvent(this));
-    }
-
-    /**
-     * <p>
-     * Initialises the data set with specified data.
-     * </p>
-     * Note: The method copies values from specified double arrays.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param xErrors symmetric X coordinate errors
-     * @param yErrors symmetric Y coordinate errors
-     * @param count number of points to be taken from specified arrays.
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final double[] xValues, final double[] yValues, final double[] xErrors,
-            final double[] yErrors, final int count) {
-        lock().setAutoNotifaction(false);
-
-        AssertUtils.notNull("X coordinates", xValues);
-        AssertUtils.notNull("Y coordinates", yValues);
-
-        if (xValues.length < count || yValues.length < count || xErrors.length < count || yErrors.length < count) {
-            throw new IllegalArgumentException("Arrays with coordinates must have length >= count!");
-        }
-
-        for (int i = 0; i < xValues.length; i++) {
-            final double x = xValues[i];
-            final double y = yValues[i];
-            final double dx = xErrors[i];
-            final double dy = yValues[i];
-            xRange.add(x - dx);
-            xRange.add(x + dx);
-            yRange.add(y - dy);
-            yRange.add(y + dy);
-            data.add(new DoublePointError(x, y, dx, dy));
-        }
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new UpdatedDataEvent(this));
-    }
-
-    /**
-     * <p>
-     * Initialises the data set with specified data.
-     * </p>
-     * Note: The method copies values from specified double arrays.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param count number of points to be taken from specified arrays.
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final double[] xValues, final double[] yValues, final int count) {
-        return this.set(xValues, yValues, new double[count], new double[count], count);
-    }
-
-    /**
-     * <p>
-     * Initialises the data set with specified data.
-     * </p>
-     * Note: The method copies values from specified double arrays.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param yErrors symmetric Y coordinate errors
-     * @param count number of points to be taken from specified arrays.
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final double[] xValues, final double[] yValues, final double[] yErrors,
-            final int count) {
-        return this.set(xValues, yValues, new double[count], yErrors, count);
-    }
-
-    /**
-     * <p>
-     * Initialises the data set with specified data.
-     * </p>
-     * Note: The method copies values from specified double arrays.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @return itself
-     */
-    public DefaultErrorDataSet set(final double[] xValues, final double[] yValues) {
-        final int ndim = xValues.length;
-        return this.set(xValues, yValues, new double[ndim], new double[ndim], ndim);
-    }
-
-    /**
-     * @param x coordinate
-     * @param y coordinate
-     * @return itself
-     */
-    public DefaultErrorDataSet add(final double x, final double y) {
-        return add(x, y, 0, 0);
-    }
-
-    /**
-     * add new point
-     *
-     * @param x horizontal point coordinate
-     * @param y vertical point coordinate
-     * @param ex horizontal point error
-     * @param ey vertical point error Note: point errors are expected to be positive
-     * @return itself
-     */
-    public DefaultErrorDataSet add(final double x, final double y, final double ex, final double ey) {
-        lock();
-        data.add(new DoublePointError(x, y, ex, ey));
-
-        xRange.add(x - ex);
-        xRange.add(x + ex);
-        yRange.add(y - ey);
-        yRange.add(y + ey);
-
-        return unlock().fireInvalidated(new AddedDataEvent(this));
-    }
-
-    /**
-     * Adds data points to this data set. <br>
-     * If <code>usingXValues</code> flag is set to false - array with X coordinates is not taken into account (may be
-     * <code>null</code>) otherwise both arrays must be non-null and have the same length.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @return itself
-     */
-    public DefaultErrorDataSet add(final double[] xValues, final double[] yValues) {
-        return this.add(xValues, yValues, new double[yValues.length], new double[yValues.length]);
-    }
-
-    /**
-     * Adds data points to this data set. <br>
-     * If <code>usingXValues</code> flag is set to false - array with X coordinates is not taken into account (may be
-     * <code>null</code>) otherwise both arrays must be non-null and have the same length.
-     *
-     * @param xValues X coordinates
-     * @param yValues Y coordinates
-     * @param xErrors horizontal errors
-     * @param yErrors vertical errors
-     * @return itself
-     */
-    public DefaultErrorDataSet add(final double[] xValues, final double[] yValues, final double[] xErrors,
-            final double[] yErrors) {
-        lock().setAutoNotifaction(false);
-        AssertUtils.notNull("X data", xValues);
-        AssertUtils.notNull("X error data", xErrors);
-        AssertUtils.notNull("Y data", yValues);
-        AssertUtils.notNull("Y error data", yValues);
-
-        for (int i = 0; i < xValues.length; i++) {
-            final double x = xValues[i];
-            final double y = yValues[i];
-            final double ex = xErrors[i];
-            final double ey = yErrors[i];
-            data.add(new DoublePointError(x, y, ex, ey));
-
-            xRange.add(x - ex);
-            xRange.add(x + ex);
-            yRange.add(y - ey);
-            yRange.add(y + ey);
-        }
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new AddedDataEvent(this));
-    }
-
-    /**
-     * remove sub-range of data points
-     * @param fromIndex start index
-     * @param toIndex stop index
-     * @return itself (fluent design)
-     */
-    public DefaultErrorDataSet remove(final int fromIndex, final int toIndex) {
-        lock().setAutoNotifaction(false);
-        AssertUtils.indexInBounds(fromIndex, getDataCount(), "fromIndex");
-        AssertUtils.indexInBounds(toIndex, getDataCount(), "toIndex");
-        AssertUtils.indexOrder(fromIndex, "fromIndex", toIndex, "toIndex");
-
-        data.subList(fromIndex, toIndex).clear();
-
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new RemovedDataEvent(this));
-    }
-
-    /**
-     * Removes from this data set points with specified indices.
-     *
-     * @param indices array of indicices to be removed
-     * @return itself
-     */
-    public DefaultErrorDataSet remove(final int[] indices) {
-        lock().setAutoNotifaction(false);
-        AssertUtils.notNull("Indices array", indices);
-        if (indices.length == 0) {
-            return unlock();
-        }
-
-        final List<DoublePointError> tupleTobeRemovedReferences = new ArrayList<>();
-        for (final int indexToRemove : indices) {
-            tupleTobeRemovedReferences.add(data.get(indexToRemove));
-        }
-        data.removeAll(tupleTobeRemovedReferences);
-
-        xRange.setMax(Double.NaN);
-        yRange.setMax(Double.NaN);
-        super.computeLimits();
-
-        return setAutoNotifaction(true).unlock().fireInvalidated(new RemovedDataEvent(this));
-    }
-
-    /**
-     * adds a custom new data label for a point The label can be used as a
-     * category name if CategoryStepsDefinition is used or for annotations
-     * displayed for data points.
-     *
-     * @param index
-     *            of the data point
-     * @param label
-     *            for the data point specified by the index
-     * @return the previously set label or <code>null</code> if no label has
-     *         been specified
-     */
-    public String addDataLabel(final int index, final String label) {
-        final String retVal = dataLabels.put(index, label);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "added label"));
-        return retVal;
-    }
-
-    /**
-     * remove a custom data label for a point The label can be used as a
-     * category name if CategoryStepsDefinition is used or for annotations
-     * displayed for data points.
-     *
-     * @param index
-     *            of the data point
-     * @return the previously set label or <code>null</code> if no label has
-     *         been specified
-     */
-    public String removeDataLabel(final int index) {
-        final String retVal = dataLabels.remove(index);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "removed label"));        
-        return retVal;
-    }
-
-    /**
-     * Returns label of a data point specified by the index.
-     * The label can be used as a category name if CategoryStepsDefinition is used or for annotations displayed for data
-     * points.
-     *
-     * @param index of the data label
-     * @return data point label specified by the index or <code>null</code> if no label has been specified
-     */
-    @Override
-    public String getDataLabel(final int index) {
-        final String dataLabel = dataLabels.get(index);
-        if (dataLabel != null) {
-            return dataLabel;
-        }
-
-        return super.getDataLabel(index);
-    }
-
-    /**
-     * A string representation of the CSS style associated with this specific
-     * {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index
-     *            the index of the specific data point
-     * @param style of the given data point (CSS-styling)
-     * @return itself (fluent interface)
-     */
-    public String addDataStyle(final int index, final String style) {
-        final String retVal = dataStyles.put(index, style);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "added style"));
-        return retVal;        
-    }
-
-    /**
-     * A string representation of the CSS style associated with this specific
-     * {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index
-     *            the index of the specific data point
-     * @return itself (fluent interface)
-     */
-    public String removeStyle(final int index) {
-        final String retVal = dataStyles.remove(index);
-        this.fireInvalidated(new UpdatedMetaDataEvent(this, "removed style"));        
-        return retVal;
-    }
-
-    /**
-     * A string representation of the CSS style associated with this
-     * specific {@code DataSet} data point. @see #getStyle()
-     *
-     * @param index the index of the specific data point
-     * @return user-specific data set style description (ie. may be set by user)
-     */
-    @Override
-    public String getStyle(final int index) {
-        return dataStyles.get(index);
+            final double[] yErrorsNeg, final double[] yErrorsPos, final int nData, final boolean deepCopy) {
+        super(name, xValues, yValues, yErrorsNeg, yErrorsPos, nData, deepCopy);
     }
 
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
@@ -1,0 +1,498 @@
+package de.gsi.dataset.spi;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.EditableDataSet;
+import de.gsi.dataset.event.AddedDataEvent;
+import de.gsi.dataset.event.RemovedDataEvent;
+import de.gsi.dataset.event.UpdatedDataEvent;
+import de.gsi.dataset.utils.AssertUtils;
+
+/**
+ * Implementation of the <code>DataSet</code> interface which stores x,y values
+ * in two separate arrays. It provides methods allowing easily manipulate of
+ * data points. <br>
+ * User provides X and Y coordinates or only Y coordinates. In the former case X
+ * coordinates have value of data point index. This version being optimised for
+ * native float arrays.
+ * 
+ * @see DoubleErrorDataSet for an equivalent implementation with asymmetric
+ *      errors in Y
+ *
+ * @author rstein
+ */
+public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements EditableDataSet {
+	protected float[] xValues;
+	protected float[] yValues;
+	protected int dataMaxIndex; // <= xValues.length, stores the actually used
+	// data array size
+
+	// helper routines:
+	public static float[] toFloats(final double[] input) {
+		float[] floatArray = new float[input.length];
+		for (int i = 0; i < input.length; i++) {
+			floatArray[i] = (float) input[i];
+		}
+		return floatArray;
+	}
+	
+	/**
+     * Creates a new instance of <code>FloatDataSet</code>.
+     *
+     * @param name name of this DataSet.
+     * @throws IllegalArgumentException if <code>name</code> is <code>null</code>
+     */
+    public FloatDataSet(final String name) {
+        this(name, 0);
+    }
+	
+	public static double[] toDoubles(final float[] input) {
+		double[] doubleArray = new double[input.length];
+		for (int i = 0; i < input.length; i++) {
+			doubleArray[i] = input[i];
+		}
+		return doubleArray;
+	}
+
+	/**
+	 * Creates a new instance of <code>FloatDataSet</code> as copy of another
+	 * (deep-copy).
+	 *
+	 * @param another name of this DataSet.
+	 */
+	public FloatDataSet(final DataSet another) {
+		this("");
+		another.lock();
+		this.setName(another.getName());
+		this.set(another); // NOPMD by rstein on 25/06/19 07:42
+		another.unlock();
+	}
+
+	/**
+	 * Creates a new instance of <code>FloatDataSet</code>.
+	 *
+	 * @param name       name of this DataSet.
+	 * @param initalSize initial buffer size
+	 * @throws IllegalArgumentException if <code>name</code> is <code>null</code>
+	 */
+	public FloatDataSet(final String name, final int initalSize) {
+		super(name);
+		AssertUtils.gtEqThanZero("initalSize", initalSize);
+		xValues = new float[initalSize];
+		yValues = new float[initalSize];
+		dataMaxIndex = 0;
+	}
+
+	/**
+	 * <p>
+	 * Creates a new instance of <code>FloatDataSet</code>.
+	 * </p>
+	 * The user than specify via the copy parameter, whether the dataset operates
+	 * directly on the input arrays themselves or on a copies of the input arrays.
+	 * If the dataset operates directly on the input arrays, these arrays must not
+	 * be modified outside of this data set.
+	 *
+	 * @param name    name of this data set.
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param initalSize initial buffer size
+	 * @param copy    if true, the input array is copied
+	 * @throws IllegalArgumentException if any of parameters is <code>null</code> or
+	 *                                  if arrays with coordinates have different
+	 *                                  lengths
+	 */
+	public FloatDataSet(final String name, final float[] xValues, final float[] yValues, final int initalSize, final boolean copy) {
+		this(name);
+		AssertUtils.notNull("X data", xValues);
+		AssertUtils.notNull("Y data", yValues);
+		AssertUtils.gtEqThanZero("initalSize", initalSize);		
+		AssertUtils.equalFloatArrays(xValues, yValues, initalSize);
+		if (copy) {
+			this.xValues = new float[initalSize];
+			this.yValues = new float[initalSize];
+			System.arraycopy(xValues, 0, this.xValues, 0, Math.min(xValues.length, initalSize));
+			System.arraycopy(yValues, 0, this.yValues, 0, Math.min(xValues.length, initalSize));
+		} else {
+			this.xValues = xValues;
+			this.yValues = yValues;
+		}
+		dataMaxIndex = initalSize;
+	}
+
+	/**
+	 * 
+	 * @return data label map for given data point
+	 */
+	public Map<Integer, String> getDataLabelMap() {
+		return dataLabels;
+	}
+
+	/**
+	 * 
+	 * @return data style map (CSS-styling)
+	 */
+	public Map<Integer, String> getDataStyleMap() {
+		return dataStyles;
+	}
+
+	@Override
+	public double[] getXValues() {
+		return toDoubles(xValues);
+	}
+
+	@Override
+	public double[] getYValues() {
+		return toDoubles(yValues);
+	}
+
+	@Override
+	public int getDataCount() {
+		return Math.min(dataMaxIndex, xValues.length);
+	}
+
+	/**
+	 * clear all data points
+	 * 
+	 * @return itself (fluent design)
+	 */
+	public FloatDataSet clearData() {
+		lock();
+
+		dataMaxIndex = 0;
+		Arrays.fill(xValues, 0.0f);
+		Arrays.fill(yValues, 0.0f);
+		dataLabels.isEmpty();
+		dataStyles.isEmpty();
+
+		xRange.empty();
+		yRange.empty();
+
+		return unlock().fireInvalidated(new RemovedDataEvent(this, "clearData()"));
+	}
+
+	@Override
+	public double getX(final int index) {
+		return xValues[index];
+	}
+
+	@Override
+	public double getY(final int index) {
+		return yValues[index];
+	}
+
+	@Override
+	public FloatDataSet set(final int index, final double x, final double y) {
+		lock();
+		try {
+			xValues[index] = (float) x;
+			yValues[index] = (float) y;
+			dataMaxIndex = Math.max(index, dataMaxIndex);
+
+			xRange.add(x);
+			yRange.add(y);
+		} finally {
+			unlock();
+		}
+
+		return fireInvalidated(new UpdatedDataEvent(this));
+	}
+
+	/**
+	 * Add point to the end of the data set
+	 *
+	 * @param x index
+	 * @param y index
+	 * @return itself
+	 */
+	public FloatDataSet add(final float x, final float y) {
+		return add(this.getDataCount(), x, y, null);
+	}
+
+	/**
+	 * Add point to the storage container
+	 *
+	 * @param x     index
+	 * @param y     index
+	 * @param label the data label
+	 * @return itself
+	 */
+	public FloatDataSet add(final float x, final float y, final String label) {
+		return add(this.getDataCount(), x, y, label);
+	}
+
+	/**
+	 * add point to the data set
+	 *
+	 * @param index data point index at which the new data point should be added
+	 * @param x     horizontal coordinate of the new data point
+	 * @param y     vertical coordinate of the new data point
+	 * @return itself (fluent design)
+	 */
+	@Override
+	public FloatDataSet add(final int index, final double x, final double y) {
+		return add(index, (float)x, (float)y, null);
+	}
+
+	/**
+	 * add point to the data set
+	 *
+	 * @param index data point index at which the new data point should be added
+	 * @param x     horizontal coordinate of the new data point
+	 * @param y     vertical coordinate of the new data point
+	 * @param label data point label (see CategoryAxis)
+	 * @return itself (fluent design)
+	 */
+	public FloatDataSet add(final int index, final float x, final float y, final String label) {
+		lock();
+		final int indexAt = Math.max(0, Math.min(index, getDataCount() + 1));
+
+		// enlarge array if necessary
+		final int minArraySize = Math.min(xValues.length - 1, yValues.length - 1);
+		if (dataMaxIndex > minArraySize) {
+			final float[] xValuesNew = new float[dataMaxIndex + 1];
+			final float[] yValuesNew = new float[dataMaxIndex + 1];
+
+			// copy old data before required index
+			System.arraycopy(xValues, 0, xValuesNew, 0, indexAt);
+			System.arraycopy(yValues, 0, yValuesNew, 0, indexAt);
+
+			// copy old data after required index
+			System.arraycopy(xValues, indexAt, xValuesNew, indexAt + 1, xValues.length - indexAt);
+			System.arraycopy(yValues, indexAt, yValuesNew, indexAt + 1, yValues.length - indexAt);
+
+			// shift old label and style keys
+			for (int i = xValues.length; i >= indexAt; i--) {
+				final String oldLabelData = dataLabels.get(i);
+				if (oldLabelData != null) {
+					dataLabels.put(i + 1, oldLabelData);
+					dataLabels.remove(i);
+				}
+
+				final String oldStyleData = dataStyles.get(i);
+				if (oldStyleData != null) {
+					dataStyles.put(i + 1, oldStyleData);
+					dataStyles.remove(i);
+				}
+			}
+
+			xValues = xValuesNew;
+			yValues = yValuesNew;
+		}
+
+		xValues[indexAt] = x;
+		yValues[indexAt] = y;
+		if (label != null && !label.isEmpty()) {
+			addDataLabel(indexAt, label);
+		}
+		dataMaxIndex++;
+
+		xRange.add(x);
+		yRange.add(y);
+
+		return unlock().fireInvalidated(new AddedDataEvent(this));
+	}
+
+	/**
+	 * removes sub-range of data points
+	 * 
+	 * @param fromIndex start index
+	 * @param toIndex   stop index
+	 * @return itself (fluent design)
+	 */
+	public FloatDataSet remove(final int fromIndex, final int toIndex) {
+		lock();
+		AssertUtils.indexInBounds(fromIndex, getDataCount(), "fromIndex");
+		AssertUtils.indexInBounds(toIndex, getDataCount(), "toIndex");
+		AssertUtils.indexOrder(fromIndex, "fromIndex", toIndex, "toIndex");
+		final int diffLength = toIndex - fromIndex;
+		final int newLength = xValues.length - diffLength;
+		final float[] xValuesNew = new float[newLength];
+		final float[] yValuesNew = new float[newLength];
+
+		System.arraycopy(xValues, 0, xValuesNew, 0, fromIndex);
+		System.arraycopy(yValues, 0, yValuesNew, 0, fromIndex);
+		System.arraycopy(xValues, toIndex, xValuesNew, fromIndex, newLength - fromIndex);
+		System.arraycopy(yValues, toIndex, yValuesNew, fromIndex, newLength - fromIndex);
+		xValues = xValuesNew;
+		yValues = yValuesNew;
+
+		// remove old label and style keys
+		for (int i = 0; i < diffLength; i++) {
+			final String oldLabelData = dataLabels.get(toIndex + i);
+			if (oldLabelData != null) {
+				dataLabels.put(fromIndex + i, oldLabelData);
+				dataLabels.remove(toIndex + i);
+			}
+
+			final String oldStyleData = dataStyles.get(toIndex + i);
+			if (oldStyleData != null) {
+				dataStyles.put(fromIndex + i, oldStyleData);
+				dataStyles.remove(toIndex + i);
+			}
+		}
+
+		dataMaxIndex = Math.max(0, dataMaxIndex - diffLength);
+
+		xRange.empty();
+		yRange.empty();
+
+		return unlock().fireInvalidated(new RemovedDataEvent(this));
+	}
+
+	/**
+	 * remove point from data set
+	 *
+	 * @param index data point which should be removed
+	 * @return itself (fluent design)
+	 */
+	@Override
+	public EditableDataSet remove(final int index) {
+		return remove(index, index + 1);
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified float arrays.
+	 *
+	 * @param xValuesNew X coordinates
+	 * @param yValuesNew Y coordinates
+	 * @return itself
+	 */
+	public FloatDataSet add(final float[] xValuesNew, final float[] yValuesNew) {
+		lock();
+		AssertUtils.notNull("X coordinates", xValuesNew);
+		AssertUtils.notNull("Y coordinates", yValuesNew);
+		AssertUtils.equalFloatArrays(xValuesNew, yValuesNew);
+
+		final int newLength = this.getDataCount() + xValuesNew.length;
+		// need to allocate new memory
+		if (newLength > xValues.length) {
+			final float[] xValuesNewAlloc = new float[newLength];
+			final float[] yValuesNewAlloc = new float[newLength];
+
+			// copy old data
+			System.arraycopy(xValues, 0, xValuesNewAlloc, 0, getDataCount());
+			System.arraycopy(yValues, 0, yValuesNewAlloc, 0, getDataCount());
+
+			xValues = xValuesNewAlloc;
+			yValues = yValuesNewAlloc;
+		}
+
+		// N.B. getDataCount() should equal dataMaxIndex here
+		System.arraycopy(xValuesNew, 0, xValues, getDataCount(), xValuesNew.length);
+		System.arraycopy(yValuesNew, 0, yValues, getDataCount(), xValuesNew.length);
+
+		dataMaxIndex = Math.max(0, dataMaxIndex + xValuesNew.length);
+		computeLimits();
+
+		return unlock().fireInvalidated(new AddedDataEvent(this));
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified float arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param copy    true: makes an internal copy, false: use the pointer as is
+	 *                (saves memory allocation
+	 * @return itself
+	 */
+	public FloatDataSet set(final float[] xValues, final float[] yValues, final boolean copy) {
+		lock();
+		AssertUtils.notNull("X coordinates", xValues);
+		AssertUtils.notNull("Y coordinates", yValues);
+		AssertUtils.equalFloatArrays(xValues, yValues);
+
+		if (!copy) {
+			this.xValues = xValues;
+			this.yValues = yValues;
+			dataMaxIndex = xValues.length;
+			computeLimits();
+
+			return unlock().fireInvalidated(new UpdatedDataEvent(this));
+		}
+
+		if (xValues.length == this.xValues.length) {
+			System.arraycopy(xValues, 0, this.xValues, 0, getDataCount());
+			System.arraycopy(yValues, 0, this.yValues, 0, getDataCount());
+		} else {
+			/*
+			 * copy into new arrays, forcing array length equal to the xValues length
+			 */
+			this.xValues = Arrays.copyOf(xValues, xValues.length);
+			this.yValues = Arrays.copyOf(yValues, xValues.length);
+		}
+		dataMaxIndex = xValues.length;
+		computeLimits();
+
+		return unlock().fireInvalidated(new UpdatedDataEvent(this));
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified float arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @return itself
+	 */
+	public FloatDataSet set(final float[] xValues, final float[] yValues) {
+		return set(xValues, yValues, true);
+	}
+
+	/**
+	 * clear old data and overwrite with data from 'other' data set
+	 * 
+	 * @param other the source data set
+	 * @return itself (fluent design)
+	 */
+	public FloatDataSet set(final DataSet other) {
+		return set(other, true);
+	}
+
+	/**
+	 * clear old data and overwrite with data from 'other' data set
+	 * 
+	 * @param other the source data set
+	 * @param copy  true: data is passed as a copy, false: data is passed by
+	 *              reference
+	 * @return itself (fluent design)
+	 */
+	public FloatDataSet set(final DataSet other, final boolean copy) {
+		lock();
+		other.lock();
+		final boolean oldAuto = isAutoNotification();
+		setAutoNotifaction(false);
+
+		// deep copy data point labels and styles
+		dataLabels.clear();
+		for (int index = 0; index < other.getDataCount(); index++) {
+			final String label = other.getDataLabel(index);
+			if (label != null && !label.isEmpty()) {
+				this.addDataLabel(index, label);
+			}
+		}
+		dataStyles.clear();
+		for (int index = 0; index < other.getDataCount(); index++) {
+			final String style = other.getStyle(index);
+			if (style != null && !style.isEmpty()) {
+				this.addDataStyle(index, style);
+			}
+		}
+		this.setStyle(other.getStyle());
+
+		this.set(toFloats(other.getXValues()), toFloats(other.getYValues()), false);
+		setAutoNotifaction(oldAuto);
+		other.unlock();
+		return unlock().fireInvalidated(new UpdatedDataEvent(this));
+	}
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
@@ -17,10 +17,10 @@ import de.gsi.dataset.event.UpdatedDataEvent;
 public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
 
     protected int dataCount;
-    //    protected double xmin;
-    //    protected double xmax;
-    //    protected double ymin;
-    //    protected double ymax;
+    // protected double xmin;
+    // protected double xmax;
+    // protected double ymin;
+    // protected double ymax;
     protected final ArrayList<DataSet> list = new ArrayList<>();
 
     /**
@@ -32,8 +32,8 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
     }
 
     /**
-     * Returns a copy of the dataset. However, in contrast to a deep copy only the references to the contained dataset
-     * are copied.
+     * Returns a copy of the dataset. However, in contrast to a deep copy only
+     * the references to the contained dataset are copied.
      * 
      * @return copy of the dataset
      */
@@ -43,10 +43,10 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
         d.dataCount = dataCount;
         d.xRange = xRange;
         d.yRange = yRange;
-        //    d.xmin = xmin;
-        //    d.xmax = xmax;
-        //    d.ymin = ymin;
-        //    d.ymax = ymax;
+        // d.xmin = xmin;
+        // d.xmax = xmax;
+        // d.ymin = ymin;
+        // d.ymax = ymax;
         d.list.addAll(list);
         return d;
     }
@@ -64,7 +64,7 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
         try {
             dataCount = 0;
             list.clear();
-            fireInvalidated(new UpdatedDataEvent(this,"clear()"));
+            fireInvalidated(new UpdatedDataEvent(this, "clear()"));
         } finally {
             unlock();
         }
@@ -72,11 +72,15 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
 
     /**
      * adds new custom x and y array values (internally generates a new DataSet)
+     * 
      * @param xValues new X coordinates
      * @param yValues new Y coordinates
      */
     public void add(final double[] xValues, final double[] yValues) {
-        final DoubleDataSet set = new DoubleDataSet(String.format("Fragement #%d", list.size() + 1), xValues, yValues);
+        // TODO: harald -> please check whether this is supposed to be deep copy
+        // (true) or by reference (false) hand over (assumption here is 'by reference/pointer' -> remove this comment once checked
+        final DoubleDataSet set = new DoubleDataSet(String.format("Fragement #%d", list.size() + 1), xValues, yValues,
+                xValues.length, false);
         add(set);
     }
 
@@ -95,7 +99,7 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
             unlock();
         }
         computeLimits();
-        fireInvalidated(new AddedDataEvent(this,"added data set"));
+        fireInvalidated(new AddedDataEvent(this, "added data set"));
     }
 
     /**
@@ -211,104 +215,106 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> {
         }
     }
 
-    //  @Override
-    //  public void opScale(double f)
-    //  {
-    //    lock();
-    //    try
-    //    {
-    //      for (AbstractTraceDataSet ds : list) ds.opScale(f);
-    //      updateLimits();
-    //      fireInvalidated();
-    //    }
-    //    finally
-    //    {
-    //      unlock();
-    //    }
-    //  }
+    // @Override
+    // public void opScale(double f)
+    // {
+    // lock();
+    // try
+    // {
+    // for (AbstractTraceDataSet ds : list) ds.opScale(f);
+    // updateLimits();
+    // fireInvalidated();
+    // }
+    // finally
+    // {
+    // unlock();
+    // }
+    // }
     //
-    //  @Override
-    //  public void opAdd(AbstractTraceDataSet ds)
-    //  {
-    //    if (!isCompatible(ds)) throw new IllegalArgumentException("Datasets do not match");
-    //    lock();
-    //    try
-    //    {
-    //      FragmentedDataSet fds = (FragmentedDataSet)ds;
-    //      for (int i=0;i<list.size();i++) list.get(i).opAdd(fds.list.get(i));
-    //      updateLimits();
-    //      fireInvalidated();
-    //    }
-    //    finally
-    //    {
-    //      unlock();
-    //    }
-    //  }
+    // @Override
+    // public void opAdd(AbstractTraceDataSet ds)
+    // {
+    // if (!isCompatible(ds)) throw new IllegalArgumentException("Datasets do
+    // not match");
+    // lock();
+    // try
+    // {
+    // FragmentedDataSet fds = (FragmentedDataSet)ds;
+    // for (int i=0;i<list.size();i++) list.get(i).opAdd(fds.list.get(i));
+    // updateLimits();
+    // fireInvalidated();
+    // }
+    // finally
+    // {
+    // unlock();
+    // }
+    // }
     //
-    //  @Override
-    //  public void opSub(AbstractTraceDataSet ds)
-    //  {
-    //    if (!isCompatible(ds)) throw new IllegalArgumentException("Datasets do not match");
-    //    lock();
-    //    try
-    //    {
-    //      FragmentedDataSet fds = (FragmentedDataSet)ds;
-    //      for (int i=0;i<list.size();i++) list.get(i).opSub(fds.list.get(i));
-    //      updateLimits();
-    //      fireInvalidated();
-    //    }
-    //    finally
-    //    {
-    //      unlock();
-    //    }
-    //  }
+    // @Override
+    // public void opSub(AbstractTraceDataSet ds)
+    // {
+    // if (!isCompatible(ds)) throw new IllegalArgumentException("Datasets do
+    // not match");
+    // lock();
+    // try
+    // {
+    // FragmentedDataSet fds = (FragmentedDataSet)ds;
+    // for (int i=0;i<list.size();i++) list.get(i).opSub(fds.list.get(i));
+    // updateLimits();
+    // fireInvalidated();
+    // }
+    // finally
+    // {
+    // unlock();
+    // }
+    // }
 
-    //  public AbstractDataSet subset(int from)
-    //  {
-    //    FragmentedDataSet d = new FragmentedDataSet(getName());
-    //    d.dataCount = 0;
-    ////    d.setXOffset(getXOffset()+from*getXScale());
-    ////    d.setXScale(getXScale());
-    //    d.xmin = xmin;
-    //    d.xmax = xmax;
-    //    d.ymin = ymin;
-    //    d.ymax = ymax;
-    //    for (AbstractDataSet set : list)
-    //    {
-    //      if (set.getDataCount() < from)
-    //      {
-    //        from -= set.getDataCount();
-    //      }
-    //      else
-    //      {
-    //        AbstractTraceDataSet ds = set.deepCopy();
-    //        if (from > 0)
-    //        {
-    //          ds = (AbstractTraceDataSet)ds.subset(from);
-    //          from = 0;
-    //        }
-    //        d.list.add(ds);
-    //        d.dataCount += set.getDataCount();
-    //      }
-    //    }
-    //    d.computeLimits();
-    //    return d;
-    //  }
+    // public AbstractDataSet subset(int from)
+    // {
+    // FragmentedDataSet d = new FragmentedDataSet(getName());
+    // d.dataCount = 0;
+    //// d.setXOffset(getXOffset()+from*getXScale());
+    //// d.setXScale(getXScale());
+    // d.xmin = xmin;
+    // d.xmax = xmax;
+    // d.ymin = ymin;
+    // d.ymax = ymax;
+    // for (AbstractDataSet set : list)
+    // {
+    // if (set.getDataCount() < from)
+    // {
+    // from -= set.getDataCount();
+    // }
+    // else
+    // {
+    // AbstractTraceDataSet ds = set.deepCopy();
+    // if (from > 0)
+    // {
+    // ds = (AbstractTraceDataSet)ds.subset(from);
+    // from = 0;
+    // }
+    // d.list.add(ds);
+    // d.dataCount += set.getDataCount();
+    // }
+    // }
+    // d.computeLimits();
+    // return d;
+    // }
 
-    //  public boolean isCompatible(AbstractDataSet ds)
-    //  {
-    //    if (!(ds instanceof FragmentedDataSet)) return false;
-    //    lock();
-    //    try
-    //    {
-    //      FragmentedDataSet fds = (FragmentedDataSet)ds;
-    //      if (list.size() != fds.list.size()) return false;
-    //      return true;
-    //    }
-    //    finally
-    //    {
-    //      unlock();
-    //    }
-    //  }
+    // public boolean isCompatible(AbstractDataSet ds)
+    // {
+    // if (!(ds instanceof FragmentedDataSet)) return false;
+    // lock();
+    // try
+    // {
+    // FragmentedDataSet fds = (FragmentedDataSet)ds;
+    // if (list.size() != fds.list.size()) return false;
+    // return true;
+    // }
+    // finally
+    // {
+    // unlock();
+    // }
+    // }
 
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
@@ -1,0 +1,389 @@
+package de.gsi.dataset.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.event.AddedDataEvent;
+import de.gsi.dataset.event.RemovedDataEvent;
+import de.gsi.dataset.event.UpdatedDataEvent;
+import de.gsi.dataset.event.UpdatedMetaDataEvent;
+import de.gsi.dataset.spi.utils.DoublePoint;
+import de.gsi.dataset.spi.utils.Tuple;
+import de.gsi.dataset.utils.AssertUtils;
+
+/**
+ * Implementation of the <code>DataSet</code> interface which keeps the x,y
+ * values in an observable list. It provides methods allowing easily manipulate
+ * of data points. <br>
+ * User provides X and Y coordinates or only Y coordinates. In the former case X
+ * coordinates have value of data point index.
+ *
+ * N.B. this is a classic list-based implementation. This is a "simple" implementation but 
+ * has a poorer performance compared to Default- and Double-based DataSets @see DoubleDataSet 
+ *
+ * @author rstein
+ * @deprecated due to poorer CPU performance (this is kept for reference reasons)
+ */
+public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet {
+    protected Map<Integer, String> dataLabels = new ConcurrentHashMap<>();
+    protected Map<Integer, String> dataStyles = new ConcurrentHashMap<>();
+    protected ArrayList<DoublePoint> data = new ArrayList<>();
+
+    /**
+     * Creates a new instance of <code>CustomDataSet</code>.
+     *
+     * @param name name of this DataSet.
+     * @throws IllegalArgumentException if <code>name</code> is
+     *             <code>null</code>
+     */
+    public ListDataSet(final String name) {
+        super(name);
+    }
+
+    /**
+     * Creates a new instance of <code>CustomDataSet</code>. X coordinates are
+     * equal to data points indices. <br>
+     * Note: The provided array is not copied (data set operates on the
+     * specified array object) thus the array should not be modified outside of
+     * this data set.
+     *
+     * @param name name of this data set.
+     * @param yValues Y coordinates
+     * @throws IllegalArgumentException if any of parameters is
+     *             <code>null</code>
+     */
+    public ListDataSet(final String name, final double[] yValues) {
+        this(name);
+        AssertUtils.notNull("Y data", yValues);
+
+        for (Integer i = 0; i < yValues.length; i++) {
+            data.add(new DoublePoint((double) i, yValues[i]));
+        }
+    }
+
+    /**
+     * <p>
+     * Creates a new instance of <code>CustomDataSet</code>.
+     * </p>
+     * Note: The provided arrays are not copied (data set operates on specified
+     * array objects) thus these array should not be modified outside of this
+     * data set.
+     *
+     * @param name name of this data set.
+     * @param xValues X coordinates
+     * @param yValues Y coordinates
+     * @throws IllegalArgumentException if any of parameters is
+     *             <code>null</code> or if arrays with coordinates have
+     *             different lengths
+     */
+    public ListDataSet(final String name, final double[] xValues, final double[] yValues) {
+        this(name);
+        AssertUtils.notNull("X data", xValues);
+        AssertUtils.notNull("Y data", yValues);
+        AssertUtils.equalDoubleArrays(xValues, yValues);
+        for (Integer i = 0; i < yValues.length; i++) {
+            data.add(new DoublePoint(xValues[i], yValues[i]));
+        }
+    }
+
+    /**
+     * <p>
+     * Creates a new instance of <code>CustomDataSet</code>.
+     * </p>
+     *
+     * @param name name of this data set.
+     * @param values list of data points to set
+     * @throws IllegalArgumentException if any of parameters is
+     *             <code>null</code> or if arrays with coordinates have
+     *             different lengths
+     */
+    public ListDataSet(final String name, final List<DoublePoint> values) {
+        this(name);
+        AssertUtils.notNull("values", values);
+        data.clear();
+        data.addAll(values);
+    }
+
+    /**
+     * 
+     * @return data label map for given data point
+     */
+    public Map<Integer, String> getDataLabelMap() {
+        return dataLabels;
+    }
+
+    /**
+     * 
+     * @return data style map (CSS-styling)
+     */
+    public Map<Integer, String> getDataStyleMap() {
+        return dataStyles;
+    }
+
+    /**
+     * 
+     * @return list containing data point definition
+     */
+    public List<DoublePoint> getData() {
+        return data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return data.size();
+    }
+
+    /**
+     * clear all data points
+     * 
+     * @return itself (fluent design)
+     */
+    public ListDataSet clearData() {
+        lock().setAutoNotifaction(false);
+
+        data.clear();
+
+        xRange.empty();
+        yRange.empty();
+
+        return unlock().fireInvalidated(new RemovedDataEvent(this, "clearData()"));
+    }
+
+    @Override
+    public double getX(final int index) {
+        return data.get(index).getX();
+    }
+
+    @Override
+    public double getY(final int index) {
+        return data.get(index).getY();
+    }
+
+    /**
+     * replaces values of all existing data points
+     * 
+     * @param values new data points
+     * @return itself (fluent design)
+     */
+    public ListDataSet set(final List<DoublePoint> values) {
+        AssertUtils.notNull("values", values);
+        lock();
+
+        data.clear();
+        data.addAll(values);
+
+        xRange.setMax(Double.NaN);
+        yRange.setMax(Double.NaN);
+        
+        computeLimits();
+
+        return unlock().fireInvalidated(new UpdatedDataEvent(this));
+    }
+
+    /**
+     * sets new value of existing data point
+     * 
+     * @param index data point index
+     * @param x new horizontal value
+     * @param y new vertical value
+     * @return itself (fluent design)
+     */
+    public ListDataSet set(final int index, final double x, final double y) {
+        lock();
+        AssertUtils.indexInBounds(index, getDataCount());
+        data.get(index).set(x, y);
+
+        xRange.add(x);
+        yRange.add(y);
+
+        return unlock().fireInvalidated(new UpdatedDataEvent(this));
+    }
+
+    /**
+     * Add point to the DoublePoints object
+     *
+     * @param x coordinate
+     * @param y coordinate
+     * @return itself
+     */
+    public ListDataSet add(final double x, final double y) {
+        lock();
+        data.add(new DoublePoint(x, y));
+
+        xRange.add(x);
+        yRange.add(y);
+
+        return unlock().fireInvalidated(new AddedDataEvent(this));
+    }
+
+    /**
+     * remvove sub-range of data points
+     * 
+     * @param fromIndex start index
+     * @param toIndex stop index
+     * @return itself (fluent design)
+     */
+    public ListDataSet remove(final int fromIndex, final int toIndex) {
+        lock();
+        AssertUtils.indexInBounds(fromIndex, getDataCount(), "fromIndex");
+        AssertUtils.indexInBounds(toIndex, getDataCount(), "toIndex");
+        AssertUtils.indexOrder(fromIndex, "fromIndex", toIndex, "toIndex");
+
+        data.subList(fromIndex, toIndex).clear();
+
+        xRange.setMax(Double.NaN);
+        yRange.setMax(Double.NaN);
+
+        return unlock().fireInvalidated(new RemovedDataEvent(this));
+    }
+
+    /**
+     * Removes from this data set points with specified indices.
+     *
+     * @param indices array of indices to be removed
+     * @return itself
+     */
+    public ListDataSet remove(final int[] indices) {
+        lock();
+        AssertUtils.notNull("Indices array", indices);
+        if (indices.length == 0) {
+            return unlock();
+        }
+
+        final List<Tuple<Double, Double>> tupleTobeRemovedReferences = new ArrayList<>();
+        for (final int indexToRemove : indices) {
+            tupleTobeRemovedReferences.add(data.get(indexToRemove));
+        }
+        data.removeAll(tupleTobeRemovedReferences);
+
+        xRange.setMax(Double.NaN);
+        yRange.setMax(Double.NaN);
+        super.computeLimits();
+
+        return unlock().fireInvalidated(new UpdatedDataEvent(this));
+    }
+
+    /**
+     * <p>
+     * Initialises the data set with specified data.
+     * </p>
+     * Note: The method copies values from specified double arrays.
+     *
+     * @param xValues X coordinates
+     * @param yValues Y coordinates
+     * @return itself
+     */
+    public ListDataSet add(final double[] xValues, final double[] yValues) {
+        lock().setAutoNotifaction(false);
+        AssertUtils.notNull("X coordinates", xValues);
+        AssertUtils.notNull("Y coordinates", yValues);
+        AssertUtils.equalDoubleArrays(xValues, yValues);
+
+        data.clear();
+        xRange.setMax(Double.NaN);
+        yRange.setMax(Double.NaN);
+        for (int i = 0; i < xValues.length; i++) {
+            data.add(new DoublePoint(xValues[i], yValues[i]));
+            xRange.add(xValues[i]);
+            yRange.add(yValues[i]);
+        }
+
+        return setAutoNotifaction(true).unlock().fireInvalidated(new AddedDataEvent(this));
+    }
+
+    /**
+     * adds a custom new data label for a point The label can be used as a
+     * category name if CategoryStepsDefinition is used or for annotations
+     * displayed for data points.
+     *
+     * @param index of the data point
+     * @param label for the data point specified by the index
+     * @return the previously set label or <code>null</code> if no label has
+     *         been specified
+     */
+    public String addDataLabel(final int index, final String label) {
+        lock();
+        final String retVal = dataLabels.put(index, label);
+        unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "added label"));
+        return retVal;
+    }
+
+    /**
+     * remove a custom data label for a point The label can be used as a
+     * category name if CategoryStepsDefinition is used or for annotations
+     * displayed for data points.
+     *
+     * @param index of the data point
+     * @return the previously set label or <code>null</code> if no label has
+     *         been specified
+     */
+    public String removeDataLabel(final int index) {
+        lock();
+        final String retVal = dataLabels.remove(index);
+        unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "removed label"));
+        return retVal;
+    }
+
+    /**
+     * Returns label of a data point specified by the index. The label can be
+     * used as a category name if CategoryStepsDefinition is used or for
+     * annotations displayed for data points.
+     *
+     * @param index of the data label
+     * @return data point label specified by the index or <code>null</code> if
+     *         no label has been specified
+     */
+    @Override
+    public String getDataLabel(final int index) {
+        final String dataLabel = dataLabels.get(index);
+        if (dataLabel != null) {
+            return dataLabel;
+        }
+
+        return super.getDataLabel(index);
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @param style for the given data point (CSS-styling)
+     * @return itself (fluent interface)
+     */
+    public String addDataStyle(final int index, final String style) {
+        lock();
+        final String retVal = dataStyles.put(index, style);
+        unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "added style"));
+        return retVal;
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @return itself (fluent interface)
+     */
+    public String removeStyle(final int index) {
+        lock();
+        final String retVal = dataStyles.remove(index);
+        unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "removed style"));
+        return retVal;
+    }
+
+    /**
+     * A string representation of the CSS style associated with this specific
+     * {@code DataSet} data point. @see #getStyle()
+     *
+     * @param index the index of the specific data point
+     * @return user-specific data set style description (ie. may be set by user)
+     */
+    @Override
+    public String getStyle(final int index) {
+        return dataStyles.get(index);
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
@@ -1,0 +1,595 @@
+package de.gsi.dataset.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import de.gsi.dataset.DataSetError;
+import de.gsi.dataset.event.AddedDataEvent;
+import de.gsi.dataset.event.RemovedDataEvent;
+import de.gsi.dataset.event.UpdatedDataEvent;
+import de.gsi.dataset.event.UpdatedMetaDataEvent;
+import de.gsi.dataset.spi.utils.DoublePointError;
+import de.gsi.dataset.utils.AssertUtils;
+
+/**
+ * Default implementation of <code>DataSet</code> and <code>DataSetError</code>
+ * interface. User provides X and Y coordinates or only Y coordinates. In the
+ * former case X coordinates have value of data point index. Symmetric errors in
+ * X and Y are implemented
+ * 
+ * N.B. this is a classic list-based implementation. This is a "simple"
+ * implementation but has a poorer performance compared to Default- and
+ * Double-based DataSets @see DoubleDataSet
+ * 
+ * @see DoubleErrorDataSet for the reference implementation
+ * @see DoubleDataSet for an implementation without asymmetric error handling
+ *
+ * @see de.gsi.dataset.DataSet
+ * @see de.gsi.dataset.DataSetError
+ * @author rstein
+ * @deprecated due to poorer CPU performance (this is kept for reference
+ *             reasons)
+ */
+public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> implements DataSetError {
+	protected Map<Integer, String> dataLabels = new ConcurrentHashMap<>();
+	protected Map<Integer, String> dataStyles = new ConcurrentHashMap<>();
+	protected ArrayList<DoublePointError> data = new ArrayList<>();
+
+	/**
+	 * Creates a new instance of <code>DefaultDataSet</code>.
+	 *
+	 * @param name name of this DataSet.
+	 * @throws IllegalArgumentException if <code>name</code> is <code>null</code>
+	 */
+	public ListErrorDataSet(final String name) {
+		super(name);
+		setErrorType(ErrorType.XY);
+	}
+
+	/**
+	 * Creates a new instance of <code>DefaultDataSet</code>. X coordinates are
+	 * equal to data points indices. <br>
+	 * Note: The provided array is not copied (data set operates on the specified
+	 * array object) thus the array should not be modified outside of this data set.
+	 *
+	 * @param name    name of this data set.
+	 * @param yValues Y coordinates
+	 * @throws IllegalArgumentException if any of parameters is <code>null</code>
+	 */
+	public ListErrorDataSet(final String name, final double[] yValues) {
+		this(name);
+		AssertUtils.notNull("Y data", yValues);
+
+		for (int i = 0; i < yValues.length; i++) {
+			data.add(new DoublePointError(i, yValues[i], 0, 0));
+		}
+	}
+
+	/**
+	 * <p>
+	 * Creates a new instance of <code>DefaultDataSet</code>.
+	 * </p>
+	 * Note: The provided arrays are not copied (data set operates on specified
+	 * array objects) thus these array should not be modified outside of this data
+	 * set.
+	 *
+	 * @param name    name of this data set.
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @throws IllegalArgumentException if any of parameters is <code>null</code> or
+	 *                                  if arrays with coordinates have different
+	 *                                  lengths
+	 */
+	public ListErrorDataSet(final String name, final double[] xValues, final double[] yValues) {
+		this(name);
+		AssertUtils.notNull("X data", xValues);
+		AssertUtils.notNull("Y data", yValues);
+		AssertUtils.equalDoubleArrays(xValues, yValues);
+
+		for (int i = 0; i < yValues.length; i++) {
+			data.add(new DoublePointError(xValues[i], yValues[i], 0, 0));
+		}
+	}
+
+	/**
+	 * <p>
+	 * Creates a new instance of <code>DefaultDataSet</code>.
+	 * </p>
+	 * Note: The provided arrays are not copied (data set operates on specified
+	 * array objects) thus these array should not be modified outside of this data
+	 * set.
+	 *
+	 * @param name    name of this data set.
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param xErrors symmetric X coordinate errors
+	 * @param yErrors symmetric Y coordinate errors N.B. all errors are assumed to
+	 *                be positive
+	 * @throws IllegalArgumentException if any of parameters is <code>null</code> or
+	 *                                  if arrays with coordinates have different
+	 *                                  lengths
+	 */
+	public ListErrorDataSet(final String name, final double[] xValues, final double[] yValues, final double[] xErrors,
+			final double[] yErrors) {
+		super(name);
+		AssertUtils.notNull("X data", xValues);
+		AssertUtils.notNull("Y data", yValues);
+		AssertUtils.notNull("X error data", xErrors);
+		AssertUtils.notNull("Y error data", yErrors);
+		AssertUtils.equalDoubleArrays(xValues, yValues);
+		AssertUtils.equalDoubleArrays(xValues, xErrors);
+		AssertUtils.equalDoubleArrays(xValues, yErrors);
+
+		for (int i = 0; i < yValues.length; i++) {
+			data.add(new DoublePointError(xValues[i], yValues[i], xErrors[i], yErrors[i]));
+		}
+	}
+
+	/**
+	 * <p>
+	 * Creates a new instance of <code>DefaultDataSet</code>.
+	 * </p>
+	 * Note: The provided arrays are not copied (data set operates on specified
+	 * array objects) thus these array should not be modified outside of this data
+	 * set.
+	 *
+	 * @param name    name of this data set.
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param yErrors symmetric Y coordinate errors N.B. all errors are assumed to
+	 *                be positive
+	 * @throws IllegalArgumentException if any of parameters is <code>null</code> or
+	 *                                  if arrays with coordinates have different
+	 *                                  lengths
+	 */
+	public ListErrorDataSet(final String name, final double[] xValues, final double[] yValues, final double[] yErrors) {
+		this(name);
+		AssertUtils.notNull("X data", xValues);
+		AssertUtils.notNull("Y data", yValues);
+		AssertUtils.notNull("Y error data", yErrors);
+		AssertUtils.equalDoubleArrays(xValues, yValues);
+		AssertUtils.equalDoubleArrays(xValues, yErrors);
+
+		for (int i = 0; i < yValues.length; i++) {
+			data.add(new DoublePointError(xValues[i], yValues[i], 0.0, yErrors[i]));
+		}
+	}
+
+	/**
+	 * 
+	 * @return data label map for given data point
+	 */
+	public Map<Integer, String> getDataLabelMap() {
+		return dataLabels;
+	}
+
+	/**
+	 * 
+	 * @return data style map (CSS-styling)
+	 */
+	public Map<Integer, String> getDataStyleMap() {
+		return dataStyles;
+	}
+
+	/**
+	 * 
+	 * @return list containing data point definition
+	 */
+	public List<DoublePointError> getData() {
+		return data;
+	}
+
+	@Override
+	public int getDataCount() {
+		return data.size();
+	}
+
+	/**
+	 * @return the x coordinate
+	 */
+	@Override
+	public double getX(final int i) {
+		return data.get(i).getX();
+	}
+
+	/**
+	 * @return the y coordinate
+	 */
+	@Override
+	public double getY(final int i) {
+		return data.get(i).getY();
+	}
+
+	/**
+	 * @see DataSetError#getXErrorNegative(int)
+	 * @return the negative error of the x coordinate
+	 */
+	@Override
+	public double getXErrorNegative(final int index) {
+		return data.get(index).getErrorX();
+	}
+
+	/**
+	 * @see DataSetError#getXErrorPositive(int)
+	 * @return the positive error of the x coordinate
+	 */
+	@Override
+	public double getXErrorPositive(final int index) {
+		return data.get(index).getErrorX();
+	}
+
+	/**
+	 * @see DataSetError#getYErrorNegative(int)
+	 * @return the negative error of the y coordinate
+	 */
+	@Override
+	public double getYErrorNegative(final int index) {
+		return data.get(index).getErrorY();
+	}
+
+	/**
+	 * @see DataSetError#getYErrorPositive(int)
+	 * @return the positive error of the y coordinate
+	 */
+	@Override
+	public double getYErrorPositive(final int index) {
+		return data.get(index).getErrorY();
+	}
+
+	/**
+	 * Sets the point with index to the new coordinate
+	 *
+	 * @param index the point index of the data set
+	 * @param x     the horizontal coordinate of the data point
+	 * @param y     the vertical coordinate of the data point
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final int index, final double x, final double y) {
+		return set(index, x, y, 0, 0);
+	}
+
+	/**
+	 * clears all data points
+	 * 
+	 * @return itself (fluent design)
+	 */
+	public ListErrorDataSet clearData() {
+		lock();
+		data.clear();
+		xRange.empty();
+		yRange.empty();
+
+		return unlock().fireInvalidated(new RemovedDataEvent(this, "clearData()"));
+	}
+
+	/**
+	 * Sets the point with index to the new coordinate
+	 *
+	 * @param index the point index of the data set
+	 * @param x     the horizontal coordinate of the data point
+	 * @param y     the vertical coordinate of the data point
+	 * @param dx    the horizontal error
+	 * @param dy    the vertical error N.B. assumes symmetric errors
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final int index, final double x, final double y, final double dx, final double dy) {
+		lock();
+		data.get(index).set(x, y, dy, dy);
+
+		xRange.add(x - dx);
+		xRange.add(x + dx);
+		yRange.add(y - dy);
+		yRange.add(y + dy);
+
+		return unlock().fireInvalidated(new UpdatedDataEvent(this));
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified double arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param xErrors symmetric X coordinate errors
+	 * @param yErrors symmetric Y coordinate errors
+	 * @param count   number of points to be taken from specified arrays.
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final double[] xValues, final double[] yValues, final double[] xErrors,
+			final double[] yErrors, final int count) {
+		lock();
+
+		AssertUtils.notNull("X coordinates", xValues);
+		AssertUtils.notNull("Y coordinates", yValues);
+
+		if (xValues.length < count || yValues.length < count || xErrors.length < count || yErrors.length < count) {
+			throw new IllegalArgumentException("Arrays with coordinates must have length >= count!");
+		}
+
+		for (int i = 0; i < xValues.length; i++) {
+			final double x = xValues[i];
+			final double y = yValues[i];
+			final double dx = xErrors[i];
+			final double dy = yValues[i];
+			xRange.add(x - dx);
+			xRange.add(x + dx);
+			yRange.add(y - dy);
+			yRange.add(y + dy);
+			data.add(new DoublePointError(x, y, dx, dy));
+		}
+
+		return unlock().fireInvalidated(new UpdatedDataEvent(this));
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified double arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param count   number of points to be taken from specified arrays.
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final double[] xValues, final double[] yValues, final int count) {
+		return this.set(xValues, yValues, new double[count], new double[count], count);
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified double arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param yErrors symmetric Y coordinate errors
+	 * @param count   number of points to be taken from specified arrays.
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final double[] xValues, final double[] yValues, final double[] yErrors,
+			final int count) {
+		return set(xValues, yValues, new double[count], yErrors, count);
+	}
+
+	/**
+	 * <p>
+	 * Initialises the data set with specified data.
+	 * </p>
+	 * Note: The method copies values from specified double arrays.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @return itself
+	 */
+	public ListErrorDataSet set(final double[] xValues, final double[] yValues) {
+		final int ndim = xValues.length;
+		return set(xValues, yValues, new double[ndim], new double[ndim], ndim);
+	}
+
+	/**
+	 * @param x coordinate
+	 * @param y coordinate
+	 * @return itself
+	 */
+	public ListErrorDataSet add(final double x, final double y) {
+		return add(x, y, 0, 0);
+	}
+
+	/**
+	 * add new point
+	 *
+	 * @param x  horizontal point coordinate
+	 * @param y  vertical point coordinate
+	 * @param ex horizontal point error
+	 * @param ey vertical point error Note: point errors are expected to be positive
+	 * @return itself
+	 */
+	public ListErrorDataSet add(final double x, final double y, final double ex, final double ey) {
+		lock();
+		data.add(new DoublePointError(x, y, ex, ey));
+
+		xRange.add(x - ex);
+		xRange.add(x + ex);
+		yRange.add(y - ey);
+		yRange.add(y + ey);
+
+		return unlock().fireInvalidated(new AddedDataEvent(this));
+	}
+
+	/**
+	 * Adds data points to this data set. <br>
+	 * If <code>usingXValues</code> flag is set to false - array with X coordinates
+	 * is not taken into account (may be <code>null</code>) otherwise both arrays
+	 * must be non-null and have the same length.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @return itself
+	 */
+	public ListErrorDataSet add(final double[] xValues, final double[] yValues) {
+		return this.add(xValues, yValues, new double[yValues.length], new double[yValues.length]);
+	}
+
+	/**
+	 * Adds data points to this data set. <br>
+	 * If <code>usingXValues</code> flag is set to false - array with X coordinates
+	 * is not taken into account (may be <code>null</code>) otherwise both arrays
+	 * must be non-null and have the same length.
+	 *
+	 * @param xValues X coordinates
+	 * @param yValues Y coordinates
+	 * @param xErrors horizontal errors
+	 * @param yErrors vertical errors
+	 * @return itself
+	 */
+	public ListErrorDataSet add(final double[] xValues, final double[] yValues, final double[] xErrors,
+			final double[] yErrors) {
+		lock();
+		AssertUtils.notNull("X data", xValues);
+		AssertUtils.notNull("X error data", xErrors);
+		AssertUtils.notNull("Y data", yValues);
+		AssertUtils.notNull("Y error data", yValues);
+
+		for (int i = 0; i < xValues.length; i++) {
+			final double x = xValues[i];
+			final double y = yValues[i];
+			final double ex = xErrors[i];
+			final double ey = yErrors[i];
+			data.add(new DoublePointError(x, y, ex, ey));
+
+			xRange.add(x - ex);
+			xRange.add(x + ex);
+			yRange.add(y - ey);
+			yRange.add(y + ey);
+		}
+
+		return unlock().fireInvalidated(new AddedDataEvent(this));
+	}
+
+	/**
+	 * remove sub-range of data points
+	 * 
+	 * @param fromIndex start index
+	 * @param toIndex   stop index
+	 * @return itself (fluent design)
+	 */
+	public ListErrorDataSet remove(final int fromIndex, final int toIndex) {
+		lock();
+		AssertUtils.indexInBounds(fromIndex, getDataCount(), "fromIndex");
+		AssertUtils.indexInBounds(toIndex, getDataCount(), "toIndex");
+		AssertUtils.indexOrder(fromIndex, "fromIndex", toIndex, "toIndex");
+
+		data.subList(fromIndex, toIndex).clear();
+
+		xRange.setMax(Double.NaN);
+		yRange.setMax(Double.NaN);
+
+		return unlock().fireInvalidated(new RemovedDataEvent(this));
+	}
+
+	/**
+	 * Removes from this data set points with specified indices.
+	 *
+	 * @param indices array of indicices to be removed
+	 * @return itself
+	 */
+	public ListErrorDataSet remove(final int[] indices) {
+		lock();
+		AssertUtils.notNull("Indices array", indices);
+		if (indices.length == 0) {
+			return unlock();
+		}
+
+		final List<DoublePointError> tupleTobeRemovedReferences = new ArrayList<>();
+		for (final int indexToRemove : indices) {
+			tupleTobeRemovedReferences.add(data.get(indexToRemove));
+		}
+		data.removeAll(tupleTobeRemovedReferences);
+
+		xRange.setMax(Double.NaN);
+		yRange.setMax(Double.NaN);
+		computeLimits();
+
+		return unlock().fireInvalidated(new RemovedDataEvent(this));
+	}
+
+	/**
+	 * adds a custom new data label for a point The label can be used as a category
+	 * name if CategoryStepsDefinition is used or for annotations displayed for data
+	 * points.
+	 *
+	 * @param index of the data point
+	 * @param label for the data point specified by the index
+	 * @return the previously set label or <code>null</code> if no label has been
+	 *         specified
+	 */
+	public String addDataLabel(final int index, final String label) {
+		lock();
+		final String retVal = dataLabels.put(index, label);
+		unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "added label"));
+		return retVal;
+	}
+
+	/**
+	 * remove a custom data label for a point The label can be used as a category
+	 * name if CategoryStepsDefinition is used or for annotations displayed for data
+	 * points.
+	 *
+	 * @param index of the data point
+	 * @return the previously set label or <code>null</code> if no label has been
+	 *         specified
+	 */
+	public String removeDataLabel(final int index) {
+		lock();
+		final String retVal = dataLabels.remove(index);
+		unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "removed label"));
+		return retVal;
+	}
+
+	/**
+	 * Returns label of a data point specified by the index. The label can be used
+	 * as a category name if CategoryStepsDefinition is used or for annotations
+	 * displayed for data points.
+	 *
+	 * @param index of the data label
+	 * @return data point label specified by the index or <code>null</code> if no
+	 *         label has been specified
+	 */
+	@Override
+	public String getDataLabel(final int index) {
+		final String dataLabel = dataLabels.get(index);
+		if (dataLabel != null) {
+			return dataLabel;
+		}
+
+		return super.getDataLabel(index);
+	}
+
+	/**
+	 * A string representation of the CSS style associated with this specific
+	 * {@code DataSet} data point. @see #getStyle()
+	 *
+	 * @param index the index of the specific data point
+	 * @param style of the given data point (CSS-styling)
+	 * @return itself (fluent interface)
+	 */
+	public String addDataStyle(final int index, final String style) {
+		lock();
+		final String retVal = dataStyles.put(index, style);
+		unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "added style"));
+		return retVal;
+	}
+
+	/**
+	 * A string representation of the CSS style associated with this specific
+	 * {@code DataSet} data point. @see #getStyle()
+	 *
+	 * @param index the index of the specific data point
+	 * @return itself (fluent interface)
+	 */
+	public String removeStyle(final int index) {
+		lock();
+		final String retVal = dataStyles.remove(index);
+		unlock().fireInvalidated(new UpdatedMetaDataEvent(this, "removed style"));
+		return retVal;
+	}
+
+	/**
+	 * A string representation of the CSS style associated with this specific
+	 * {@code DataSet} data point. @see #getStyle()
+	 *
+	 * @param index the index of the specific data point
+	 * @return user-specific data set style description (ie. may be set by user)
+	 */
+	@Override
+	public String getStyle(final int index) {
+		return dataStyles.get(index);
+	}
+
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/AssertUtils.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/AssertUtils.java
@@ -136,9 +136,37 @@ public final class AssertUtils {
      * @param array1 to be checked
      * @param array2 to be checked
      */
-    public static <T> void equalDoubleArrays(final T[] array1, final T[] array2) {
+    public static <T> void equalArrays(final T[] array1, final T[] array2) {
         if (array1.length != array2.length) {
             throw new IllegalArgumentException("The double arrays must have the same length!");
+        }
+    }
+    
+    /**
+     * Asserts that the specified arrays have the same length.
+     * @param array1 to be checked
+     * @param array2 to be checked
+     */
+    public static void equalFloatArrays(final float[] array1, final float[] array2) {
+        if (array1.length != array2.length) {
+            throw new IllegalArgumentException("The float arrays must have the same length! length1 = " + array1.length
+                    + " vs. length2 = " + array2.length);
+        }
+    }
+
+    /**
+     * Asserts that the specified arrays have the same length or are at least min size.
+     * 
+     * @param array1 to be checked
+     * @param array2 to be checked
+     * @param nMinSize minimum required size
+     */
+    public static void equalFloatArrays(final float[] array1, final float[] array2, final int nMinSize) {
+        final int length1 = Math.min(nMinSize, array1.length);
+        final int length2 = Math.min(nMinSize, array2.length);
+        if (length1 != length2) {
+            throw new IllegalArgumentException("The double arrays must have the same length! length1 = " + array1.length
+                    + " vs. length2 = " + array2.length + " (nMinSize = " + nMinSize + ")");
         }
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ProcessingProfiler.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ProcessingProfiler.java
@@ -1,5 +1,7 @@
 package de.gsi.dataset.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -11,24 +13,24 @@ import org.slf4j.LoggerFactory;
  * @author rstein
  *
  */
-public final class ProcessingProfiler { // NOPMD nomen est omen et fix
+public final class ProcessingProfiler { // NOPMD nomen est omen
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessingProfiler.class);
     /**
      * boolean flag controlling whether diagnostics time-marks are taken or the
      * routine to be skipped
      */
-    private static boolean debugState;
+    protected static boolean debugState = false;
     /**
-     * boolean flag controlling whether the statistics/time differences are
-     * output to the logger/console or not
+     * boolean flag controlling whether the statistics/time differences are output
+     * to the logger/console or not
      */
-    private static boolean verboseOutput = true;
+    protected static boolean verboseOutput = true;
     /**
-     * boolean flag controlling whether the statistics/time differences are
-     * output to the logger/console or not
+     * boolean flag controlling whether the statistics/time differences are output
+     * to the logger/console or not
      */
-    private static boolean loggerOutput;
+    protected static boolean loggerOutput = false;
 
     private ProcessingProfiler() {
     }
@@ -37,57 +39,51 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
      * boolean flag controlling whether diagnostics time-marks are taken or the
      * routine to be skipped
      * 
-     * @param state
-     *            true: enable
+     * @param state true: enable
      */
     public static void setDebugState(final boolean state) {
         debugState = state;
     }
 
     /**
-     * 
-     * @return boolean flag controlling whether diagnostics time-marks are taken
-     *         or the routine to be skipped
+     * @return boolean flag controlling whether diagnostics time-marks are taken or
+     *         the routine to be skipped
      */
     public static boolean getDebugState() {
         return debugState;
     }
 
     /**
-     * boolean flag controlling whether the statistics/time differences are
-     * output to the logger/console or not
+     * boolean flag controlling whether the statistics/time differences are output
+     * to the logger/console or not
      * 
-     * @param state
-     *            true: enable
+     * @param state true: enable
      */
     public static void setVerboseOutputState(final boolean state) {
         verboseOutput = state;
     }
 
     /**
-     * 
-     * @return boolean flag controlling whether the statistics/time differences
-     *         are output to the logger/console or not
+     * @return boolean flag controlling whether the statistics/time differences are
+     *         output to the logger/console or not
      */
     public static boolean getVerboseOutputState() {
         return verboseOutput;
     }
 
     /**
-     * boolean flag controlling whether the statistics/time differences are
-     * output to the logger/console or not
+     * boolean flag controlling whether the statistics/time differences are output
+     * to the logger/console or not
      * 
-     * @param state
-     *            true: enable
+     * @param state true: enable
      */
     public static void setLoggerOutputState(final boolean state) {
         loggerOutput = state;
     }
 
     /**
-     * 
-     * @return boolean flag controlling whether the statistics/time differences
-     *         are output to the logger/console or not
+     * @return boolean flag controlling whether the statistics/time differences are
+     *         output to the logger/console or not
      */
     public static boolean getLoggerOutputState() {
         return loggerOutput;
@@ -97,9 +93,9 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
      * Returns the current value of the running Java Virtual Machine's
      * high-resolution time source, in nanoseconds.
      * <p>
-     * This method can only be used to measure elapsed time and is not related
-     * to any other notion of system or wall-clock time. The value returned
-     * represents nanoseconds since some fixed but arbitrary <i>origin</i> time.
+     * This method can only be used to measure elapsed time and is not related to
+     * any other notion of system or wall-clock time. The value returned represents
+     * nanoseconds since some fixed but arbitrary <i>origin</i> time.
      * <p>
      * the overhead of taking the time stamp is disabled via #debugProperty()
      *
@@ -113,7 +109,6 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
     }
 
     /**
-     * 
      * @param lastStamp reference time stamp
      * @return actual delay
      */
@@ -122,27 +117,32 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
     }
 
     /**
-     * @param recursionDepth
-     *            0 being the calling function
+     * @param recursionDepth 0 being the calling function
      * @return the 'class::function(line:xxx)' string
      */
-    public static String getCallingClassMethod(int recursionDepth) {
+    public static List<String> getCallingClassMethod(int... recursionDepth) {
+        ArrayList<String> list = new ArrayList<>();
         final StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
-        // this number needs to be corrected if this class is refactored
-        final int nLast = 2 + recursionDepth;
-        final StackTraceElement stackTraceElement = stacktrace[nLast];
-        final String fullClassName = stackTraceElement.getClassName();
-        final String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
-        final String methodName = stackTraceElement.getMethodName();
-        final int lineNumer = stackTraceElement.getLineNumber();
 
-        final String compoundName = new StringBuilder().append(simpleClassName).append("::").append(methodName)
-                .append("(line:").append(lineNumer).append(")").toString();
+        for (int i : recursionDepth) {
+            // this number needs to be corrected if this class is refactored
+            final int nLast = 2 + i;
+            final StringBuilder strBuilder = new StringBuilder();
+            final StackTraceElement stackTraceElement = stacktrace[nLast];
+            final String fullClassName = stackTraceElement.getClassName();
+            final String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
+            final String methodName = stackTraceElement.getMethodName();
+            final int lineNumer = stackTraceElement.getLineNumber();
 
-        return compoundName;
+            strBuilder.append(simpleClassName).append("::").append(methodName).append("(line:").append(lineNumer)
+                    .append(")");
+            list.add(strBuilder.toString());
+        }
+
+        return list;
     }
 
-    private static String getCallingClassMethod(String msg) {
+    protected static String getCallingClassMethod(String msg) {
         final StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
         // this number needs to be corrected if this class is refactored
         final int nLast = msg == null ? 4 : 3;
@@ -152,16 +152,14 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
         final String methodName = stackTraceElement.getMethodName();
         final int lineNumer = stackTraceElement.getLineNumber();
 
-        final String compoundName = new StringBuilder().append(simpleClassName).append("::").append(methodName)
-                .append("(line:").append(lineNumer).append(")").toString();
-
-        return compoundName;
+        return new StringBuilder().append(simpleClassName).append("::").append(methodName).append("(line:")
+                .append(lineNumer).append(")").toString();
     }
 
     /**
-     * 
      * @param lastStamp reference time stamp
-     * @param msg custom string message that should be printed alongside the time stamp
+     * @param msg custom string message that should be printed alongside the
+     *            time stamp
      * @return actual delay
      */
     public static long getTimeDiff(final long lastStamp, final String msg) {
@@ -170,8 +168,6 @@ public final class ProcessingProfiler { // NOPMD nomen est omen et fix
         }
         final long now = System.nanoTime();
         final double diff = TimeUnit.NANOSECONDS.toMillis(now - lastStamp);
-        // final StackTraceElement[] stacktrace =
-        // Thread.currentThread().getStackTrace();
         if (ProcessingProfiler.verboseOutput) {
             final String compoundName = getCallingClassMethod(msg);
             final String message = String.format("%-55s - time diff = %8.3f [ms] msg: '%s'", compoundName, diff,

--- a/chartfx-math/src/main/java/de/gsi/math/DataSetMath.java
+++ b/chartfx-math/src/main/java/de/gsi/math/DataSetMath.java
@@ -156,14 +156,14 @@ public final class DataSetMath {
             }
 
             return new DoubleErrorDataSet(functionName, newDataSet.getXValues(), yValues, eyn, eyp,
-                    newDataSet.getDataCount());
+                    newDataSet.getDataCount(), true);
         }
 
         final DoubleErrorDataSet retFunction = prevAverage.getDataCount() == 0
                 ? new DoubleErrorDataSet(functionName, newDataSet.getXValues(), newDataSet.getYValues(),
-                        errors(newDataSet, EYN), errors(newDataSet, EYP), newDataSet.getDataCount())
+                        errors(newDataSet, EYN), errors(newDataSet, EYP), newDataSet.getDataCount(), true)
                 : new DoubleErrorDataSet(prevAverage.getName(), prevAverage.getXValues(), prevAverage.getYValues(),
-                        errors(prevAverage, EYN), errors(prevAverage, EYP), newDataSet.getDataCount());
+                        errors(prevAverage, EYN), errors(prevAverage, EYP), newDataSet.getDataCount(), true);
 
         final double alpha = 1.0 / (1.0 + nUpdates);
         final boolean avg2Empty = prevAverage2.getDataCount() == 0;
@@ -208,12 +208,12 @@ public final class DataSetMath {
             if (dataSets.get(0) instanceof DataSetError) {
                 final DataSetError newFunction = (DataSetError) dataSets.get(0);
                 return new DoubleErrorDataSet(functionName, newFunction.getXValues(), newFunction.getYValues(),
-                        newFunction.getYErrorsNegative(), newFunction.getYErrorsPositive(), newFunction.getDataCount());
+                        newFunction.getYErrorsNegative(), newFunction.getYErrorsPositive(), newFunction.getDataCount(), true);
             }
 
             final DataSet newFunction = dataSets.get(0);
-            return new DoubleErrorDataSet(functionName, newFunction.getXValues(), newFunction.getYValues(),
-                    newFunction.getDataCount());
+            return new DoubleErrorDataSet(functionName, newFunction.getXValues(), newFunction.getYValues(), new double[newFunction.getDataCount()], new double[newFunction.getDataCount()],
+                    newFunction.getDataCount(), true);
         }
 
         final int nAvg = Math.min(nUpdates, dataSets.size());
@@ -265,7 +265,7 @@ public final class DataSetMath {
         String newName = INTEGRAL_SYMBOL + "(" + functionName + ")dyn";
         if (nLength <= 0) {
             return new DoubleErrorDataSet(function.getName(), function.getXValues(),
-                    new double[function.getDataCount()]);
+                    new double[function.getDataCount()],new double[function.getDataCount()],new double[function.getDataCount()],function.getDataCount(), true);
         }
 
         double xMinLocal = function.getXMin();
@@ -508,14 +508,14 @@ public final class DataSetMath {
         // TODO: add error propagation to normalised function error estimate
         if (integral == 0) {
             return new DoubleErrorDataSet(function.getName(), function.getXValues(),
-                    new double[function.getDataCount()]);
+                    new double[function.getDataCount()],new double[function.getDataCount()],new double[function.getDataCount()],function.getDataCount(), true);
         }
         final double[] xValues = function.getXValues();
         final double[] yValues = ArrayMath.divide(function.getYValues(), integral);
         final double[] eyp = ArrayMath.divide(errors(function, EYN), integral);
         final double[] eyn = ArrayMath.divide(errors(function, EYP), integral);
 
-        return new DoubleErrorDataSet(function.getName(), xValues, yValues, eyp, eyn, function.getDataCount());
+        return new DoubleErrorDataSet(function.getName(), xValues, yValues, eyp, eyn, function.getDataCount(), true);
     }
 
     public enum Filter {
@@ -801,30 +801,30 @@ public final class DataSetMath {
         switch (op) {
         case ADD:
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.add(y, value), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         case SUBTRACT:
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.subtract(y, value), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         case MULTIPLY:
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.multiply(y, value),
-                    ArrayMath.multiply(eyn, value), ArrayMath.multiply(eyp, value), function.getDataCount());
+                    ArrayMath.multiply(eyn, value), ArrayMath.multiply(eyp, value), function.getDataCount(), true);
         case DIVIDE:
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.divide(y, value),
-                    ArrayMath.divide(eyn, value), ArrayMath.divide(eyp, value), function.getDataCount());
+                    ArrayMath.divide(eyn, value), ArrayMath.divide(eyp, value), function.getDataCount(), true);
         case SQR:
             for (int i = 0; i < eyn.length; i++) {
                 eyn[i] = 2 * Math.abs(y[i]) * eyn[i];
                 eyp[i] = 2 * Math.abs(y[i]) * eyp[i];
             }
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.sqr(y), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         case SQRT:
             for (int i = 0; i < eyn.length; i++) {
                 eyn[i] = Math.sqrt(Math.abs(y[i])) * eyn[i];
                 eyp[i] = Math.sqrt(Math.abs(y[i])) * eyp[i];
             }
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.sqrt(y), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         case LOG10:
             norm = 1.0 / Math.log(10);
             for (int i = 0; i < eyn.length; i++) {
@@ -832,7 +832,7 @@ public final class DataSetMath {
                 eyp[i] = y[i] > 0 ? norm / Math.abs(y[i]) * eyp[i] : Double.NaN;
             }
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.tenLog10(y), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         case DB:
             norm = 20.0 / Math.log(10);
             for (int i = 0; i < eyn.length; i++) {
@@ -840,11 +840,11 @@ public final class DataSetMath {
                 eyp[i] = y[i] > 0 ? norm / Math.abs(y[i]) * eyp[i] : Double.NaN;
             }
             return new DoubleErrorDataSet(functionName, function.getXValues(), ArrayMath.decibel(y), eyn, eyp,
-                    function.getDataCount());
+                    function.getDataCount(), true);
         default:
             // return copy if nothing else matches
             return new DoubleErrorDataSet(functionName, function.getXValues(), function.getYValues(),
-                    errors(function, EYN), errors(function, EYP), function.getDataCount());
+                    errors(function, EYN), errors(function, EYP), function.getDataCount(), true);
         }
     }
 

--- a/chartfx-math/src/main/java/de/gsi/math/functions/Function1D.java
+++ b/chartfx-math/src/main/java/de/gsi/math/functions/Function1D.java
@@ -3,7 +3,7 @@ package de.gsi.math.functions;
 import java.security.InvalidParameterException;
 
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.spi.DefaultErrorDataSet;
 
 /**
  * generic one-dimensional function interface
@@ -12,7 +12,7 @@ import de.gsi.dataset.spi.DoubleErrorDataSet;
  */
 public interface Function1D extends Function {
 
-    double getValue(double x);
+    double getValue(final double x);
 
     default double[] getValues(final double[] x) {
         if (x == null) {
@@ -31,7 +31,7 @@ public interface Function1D extends Function {
      *            X coordinate for which the function should be evaluated
      */
     default DataSet getDataSetEstimate(final double[] xValues) {
-        return new DoubleErrorDataSet(getName(), xValues, getValues(xValues));
+        return new DefaultErrorDataSet(getName(), xValues, getValues(xValues), new double[xValues.length], new double[xValues.length], xValues.length, true);
     }
 
     /**

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/PolarPlotSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/PolarPlotSample.java
@@ -2,13 +2,13 @@ package de.gsi.chart.samples;
 
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
-import de.gsi.dataset.spi.DefaultErrorDataSet;
-import de.gsi.dataset.spi.DoubleDataSet;
 import de.gsi.chart.plugins.EditAxis;
 import de.gsi.chart.plugins.Zoomer;
 import de.gsi.chart.renderer.PolarTickStep;
 import de.gsi.chart.renderer.datareduction.DefaultDataReducer;
 import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.dataset.spi.DefaultDataSet;
+import de.gsi.dataset.spi.DefaultErrorDataSet;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
@@ -17,7 +17,7 @@ import javafx.stage.Stage;
 /**
  * small demo to experiment with polar plot geometries
  * 
- * @author steinhagen
+ * @author rstein
  */
 public class PolarPlotSample extends Application {
     private static final int N_SAMPLES = 10000;
@@ -52,7 +52,7 @@ public class PolarPlotSample extends Application {
         reducer.setMinPointPixelDistance(3);
 
         final DefaultErrorDataSet dataSet1 = new DefaultErrorDataSet("myData");
-        final DoubleDataSet dataSet2 = new DoubleDataSet("myData2");
+        final DefaultDataSet dataSet2 = new DefaultDataSet("myData2");
         renderer.getDatasets().addAll(dataSet1, dataSet2);
 
         for (int n = 0; n < PolarPlotSample.N_SAMPLES; n++) {

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/TimeAxisSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/TimeAxisSample.java
@@ -71,7 +71,7 @@ public class TimeAxisSample extends Application {
         final long startTime = ProcessingProfiler.getTimeStamp();
 
         dataSet.setAutoNotifaction(false);
-        dataSet.getData().clear();
+        dataSet.clearData();
         final double now = System.currentTimeMillis() / 1000.0 + 1; // N.B. '+1'
                                                                     // to check
                                                                     // for

--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/FloatToDoubleBenchmarkSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/FloatToDoubleBenchmarkSample.java
@@ -1,0 +1,94 @@
+package de.gsi.dataset.samples;
+
+import de.gsi.dataset.utils.ProcessingProfiler;
+import de.gsi.math.TRandom;
+
+public class FloatToDoubleBenchmarkSample {
+	private static final int N_DIM = 2000;
+	protected double[][] matrixD = new double[N_DIM][N_DIM];
+	protected float[][] matrixF;
+	protected double[] vectorInD;
+	protected float[] vectorInF;
+	protected double[] vectorOutD;
+	protected float[] vectorOutF;
+	
+	
+	public FloatToDoubleBenchmarkSample() {
+//		matrixD = new double[N_DIM][N_DIM];
+		matrixF = new float[N_DIM][N_DIM];
+		vectorInD = new double[N_DIM];
+		vectorInF = new float[N_DIM];
+		vectorOutD = new double[N_DIM];
+		vectorOutF = new float[N_DIM];
+		
+		TRandom rnd = new TRandom(0);
+		for (int i = 0; i < N_DIM; i++) {
+			for (int j = 0; j < N_DIM; j++) {
+				double val = rnd.Rndm() - 0.5;
+				matrixD[i][j] = val;
+				matrixF[i][j] = (float)val;
+			}
+			double val = rnd.Rndm() - 0.5;
+			vectorInD[i] = val;
+			vectorInF[i] = (float)val;
+		}
+		
+	}
+	
+	public void testMatrixVectorMultiplicationDouble(final int nIterations) {
+		long start = ProcessingProfiler.getTimeStamp();
+		for (int iter = 0; iter < nIterations; iter++) {
+			for (int i = 0; i < N_DIM; i++) {
+				vectorOutD[i] = 0.0;
+				for (int j = 0; j < N_DIM; j++) {
+					vectorOutD[i] += matrixD[i][j] * vectorInD[j];
+				}
+			}
+			// swap input with output to avoid JIT optimisation
+			vectorInD = vectorOutD;			
+		}
+		int rowSum = 0;
+		for (int i = 0; i < N_DIM; i++) {
+			rowSum += vectorOutD[i];
+		}
+		// printout sum to avoid JIT optimisation
+		ProcessingProfiler.getTimeDiff(start, "testMatrixVectorMultiplicationDouble() result = " + rowSum);
+	}
+	
+	public void testMatrixVectorMultiplicationFloat(final int nIterations) {
+		long start = ProcessingProfiler.getTimeStamp();
+		for (int iter = 0; iter < nIterations; iter++) {
+			for (int i = 0; i < N_DIM; i++) {
+				vectorOutF[i] = 0.0f;
+				for (int j = 0; j < N_DIM; j++) {
+					vectorOutF[i] += matrixF[i][j] * vectorInF[j];
+				}
+			}
+			// swap input with output to avoid JIT optimisation
+			vectorInF = vectorOutF;			
+		}
+		int rowSum = 0;
+		for (int i = 0; i < N_DIM; i++) {
+			rowSum += vectorOutF[i];
+		}
+		// printout sum to avoid JIT optimisation
+		ProcessingProfiler.getTimeDiff(start, "testMatrixVectorMultiplicationDouble() result = " + rowSum);
+	}
+	
+	public static void main(String[] args) {
+		ProcessingProfiler.setVerboseOutputState(true);
+		ProcessingProfiler.setDebugState(true);
+		
+		final int nIterations = 1000;
+		FloatToDoubleBenchmarkSample benchmark = new FloatToDoubleBenchmarkSample();
+		
+		benchmark.testMatrixVectorMultiplicationDouble(nIterations);
+		
+		benchmark.testMatrixVectorMultiplicationFloat(nIterations);
+
+		benchmark.testMatrixVectorMultiplicationDouble(nIterations);
+		
+		benchmark.testMatrixVectorMultiplicationFloat(nIterations);
+	}
+
+}

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/EMDSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/EMDSample.java
@@ -24,183 +24,184 @@ import javafx.scene.layout.VBox;
  * @author rstein TODO: some fixes in EMD necessary
  */
 public class EMDSample extends AbstractDemoApplication {
-	private static final int MAX_POINTS = 1024;
-	private static final boolean LOAD_EXAMPLE_DATA = true;
-	private DataSet3D dataset;
-	private DataSet[] fmodeDataSets = new DataSet[10];
-	private double[][] fmodeData = new double[10][];
-	private double[] yValues;
+    private static final int MAX_POINTS = 1024;
+    private static final boolean LOAD_EXAMPLE_DATA = true;
+    private DataSet3D dataset;
+    private DataSet[] fmodeDataSets = new DataSet[10];
+    private double[][] fmodeData = new double[10][];
+    private double[] yValues;
 
-	public void initData() {
-		if (LOAD_EXAMPLE_DATA) {
-			// show-room data
-			// case 1: chirped CPS tune acquisition, the horizontal, cross-term
-			// tune,
-			// and a reference tone above 0.45 are visible
-			// case 2: LHC B2 horizontal injection oscillations,
-			// recommendation to choose nu == 30
-			// -> injection synchrotron oscillations are visible
-			yValues =readDemoData(1);
-		} else {
-			yValues = loadSyntheticData();
-		}
-		createModeDataSet();
-	}
+    public void initData() {
+        if (LOAD_EXAMPLE_DATA) {
+            // show-room data
+            // case 1: chirped CPS tune acquisition, the horizontal, cross-term
+            // tune,
+            // and a reference tone above 0.45 are visible
+            // case 2: LHC B2 horizontal injection oscillations,
+            // recommendation to choose nu == 30
+            // -> injection synchrotron oscillations are visible
+            yValues = readDemoData(1);
+        } else {
+            yValues = loadSyntheticData();
+        }
+        createModeDataSet();
+    }
 
-	private double[] loadSyntheticData() {
-		// synthetic data
-		final double[] yModel = new double[MAX_POINTS];
+    private double[] loadSyntheticData() {
+        // synthetic data
+        final double[] yModel = new double[MAX_POINTS];
 
-		for (int i = 0; i < yValues.length; i++) {
-			final double x = i;
-			double offset = 0;
-			double error = 0.1 * RANDOM.nextGaussian();
+        for (int i = 0; i < yValues.length; i++) {
+            final double x = i;
+            double offset = 0;
+            double error = 0.1 * RANDOM.nextGaussian();
 
-			// linear chirp with discontinuity
-			offset = (i > 500) ? -20 : 0;
-			yModel[i] = (i > 100 && i < 700) ? 0.7 * Math.sin(TMath.TwoPi() * 2e-4 * x * (x + offset)) : 0;
+            // linear chirp with discontinuity
+            offset = (i > 500) ? -20 : 0;
+            yModel[i] = (i > 100 && i < 700) ? 0.7 * Math.sin(TMath.TwoPi() * 2e-4 * x * (x + offset)) : 0;
 
-			// single tone at 0.25
-			yModel[i] += (i > 50 && i < 500) ? 1.0 * Math.sin(TMath.TwoPi() * 0.25 * x) : 0;
-			// yModel[i] = Math.sin(TMath.TwoPi() * 0.3* x);
+            // single tone at 0.25
+            yModel[i] += (i > 50 && i < 500) ? 1.0 * Math.sin(TMath.TwoPi() * 0.25 * x) : 0;
+            // yModel[i] = Math.sin(TMath.TwoPi() * 0.3* x);
 
-			// modulation around 0.4
-			double mod = Math.cos(TMath.TwoPi() * 0.01 * x);
-			if (i < 470) {
-				mod = 0.0;
-			}
-			yModel[i] += (i > 300 && i < 900) ? 1.0 * Math.sin(TMath.TwoPi() * (0.4 - 5e-4 * mod) * x) : 0;
+            // modulation around 0.4
+            double mod = Math.cos(TMath.TwoPi() * 0.01 * x);
+            if (i < 470) {
+                mod = 0.0;
+            }
+            yModel[i] += (i > 300 && i < 900) ? 1.0 * Math.sin(TMath.TwoPi() * (0.4 - 5e-4 * mod) * x) : 0;
 
-			// quadratic chirp starting at 0.1
-			yModel[i] += 0.5 * Math.sin(TMath.TwoPi() * ((0.1 + 5e-8 * x * x) * x));
+            // quadratic chirp starting at 0.1
+            yModel[i] += 0.5 * Math.sin(TMath.TwoPi() * ((0.1 + 5e-8 * x * x) * x));
 
-			yModel[i] = yModel[i] + error;
-		}
-		return Arrays.copyOf(yModel, yModel.length);
-	}
+            yModel[i] = yModel[i] + error;
+        }
+        return Arrays.copyOf(yModel, yModel.length);
+    }
 
-	private void sleep(int millis) {
-		try {
-			Thread.sleep(millis);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-			Thread.currentThread().interrupt();
-		}
-	}
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
+        }
+    }
 
-	private DataSet3D createDataSet() {
-		final int nQuantx = 1024;
-		final int nQuanty = 1024;
+    private DataSet3D createDataSet() {
+        final int nQuantx = 1024;
+        final int nQuanty = 1024;
 
-		// the empirical-mode-decomposition (EEMD) computation
-		final EEMD trafoHHT = new EEMD();
+        // the empirical-mode-decomposition (EEMD) computation
+        final EEMD trafoHHT = new EEMD();
 
-		new Thread() {
-			@Override
-			public void run() {
-				dataset = trafoHHT.getScalogram(yValues, nQuantx, nQuanty);
-			}
-		}.start();
+        new Thread() {
+            @Override
+            public void run() {
+                dataset = trafoHHT.getScalogram(yValues, nQuantx, nQuanty);
+            }
+        }.start();
 
-		try {
-			do {
-				sleep(100);
-				int status = trafoHHT.getStatus();
-				if (status > 10) {
-					System.out.println(status + " % of computation done");
-				}
-			} while (trafoHHT.isBusy());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+        try {
+            do {
+                sleep(100);
+                int status = trafoHHT.getStatus();
+                if (status > 10) {
+                    System.out.println(status + " % of computation done");
+                }
+            } while (trafoHHT.isBusy());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
-		return dataset;
-	}
+        return dataset;
+    }
 
-	private void createModeDataSet() {
-		final EEMD trafoHHT = new EEMD();
-		MatrixD emd = trafoHHT.eemd(yValues, 0, 1.0);
+    private void createModeDataSet() {
+        final EEMD trafoHHT = new EEMD();
+        MatrixD emd = trafoHHT.eemd(yValues, 0, 1.0);
 
-		double[] time = new double[yValues.length];
-		for (int i = 0; i < time.length; i++) {
-			time[i] = i;
-		}
+        double[] time = new double[yValues.length];
+        for (int i = 0; i < time.length; i++) {
+            time[i] = i;
+        }
 
-		for (int nmode = 0; nmode < (emd.getColumnDimension() - 1); nmode++) {
-			String name = (nmode == 0) ? "raw" : ("mode" + nmode);
-			if (nmode < fmodeDataSets.length) {
-				fmodeData[nmode] = new double[time.length];
-				for (int j = 0; j < fmodeData[nmode].length; j++) {
-					fmodeData[nmode][j] = emd.get(j, nmode) - 5 * nmode;
-				}
-				System.out.printf("%s mean = %f\n", name,
-						(TMath.Mean(fmodeData[nmode]) + 2 * nmode) / TMath.PeakToPeak(fmodeData[nmode]));
-				fmodeDataSets[nmode] = new DefaultErrorDataSet(name, time, fmodeData[nmode]);
-			}
-		}
-	}
+        for (int nmode = 0; nmode < (emd.getColumnDimension() - 1); nmode++) {
+            String name = (nmode == 0) ? "raw" : ("mode" + nmode);
+            if (nmode < fmodeDataSets.length) {
+                fmodeData[nmode] = new double[time.length];
+                for (int j = 0; j < fmodeData[nmode].length; j++) {
+                    fmodeData[nmode][j] = emd.get(j, nmode) - 5 * nmode;
+                }
+                System.out.printf("%s mean = %f\n", name,
+                        (TMath.Mean(fmodeData[nmode]) + 2 * nmode) / TMath.PeakToPeak(fmodeData[nmode]));
+                fmodeDataSets[nmode] = new DefaultErrorDataSet(name, time, fmodeData[nmode], new double[time.length],
+                        new double[time.length], time.length, true);
+            }
+        }
+    }
 
-	@Override
-	public Node getContent() {
-		initData();
+    @Override
+    public Node getContent() {
+        initData();
 
-		final DemoChart chart1 = new DemoChart();
-		chart1.getXAxis().setLabel("time");
-		chart1.getXAxis().setUnit("turns");
-		chart1.getYAxis().setLabel("frequency");
-		chart1.getYAxis().setUnit("fs");
-		ContourDataSetRenderer contourChartRenderer = new ContourDataSetRenderer();
-		chart1.getRenderers().set(0, contourChartRenderer);
-		contourChartRenderer.setColorGradient(ColorGradient.RAINBOW);
-		// contourChartRenderer.setColorGradient(ColorGradient.JET);
-		// contourChartRenderer.setColorGradient(ColorGradient.TOPO_EXT);
+        final DemoChart chart1 = new DemoChart();
+        chart1.getXAxis().setLabel("time");
+        chart1.getXAxis().setUnit("turns");
+        chart1.getYAxis().setLabel("frequency");
+        chart1.getYAxis().setUnit("fs");
+        ContourDataSetRenderer contourChartRenderer = new ContourDataSetRenderer();
+        chart1.getRenderers().set(0, contourChartRenderer);
+        contourChartRenderer.setColorGradient(ColorGradient.RAINBOW);
+        // contourChartRenderer.setColorGradient(ColorGradient.JET);
+        // contourChartRenderer.setColorGradient(ColorGradient.TOPO_EXT);
 
-		contourChartRenderer.getDatasets().add(createDataSet());
+        contourChartRenderer.getDatasets().add(createDataSet());
 
-		final DemoChart chart2 = new DemoChart();
-		chart2.getXAxis().setLabel("time");
-		chart2.getXAxis().setUnit("turns");
-		chart2.getYAxis().setLabel("amplitude");
-		chart2.getYAxis().setUnit("[a.u.]");
-		for (int i = 0; i < fmodeDataSets.length; i++) {
-			if (fmodeDataSets[i] != null) {
-				chart2.getDatasets().add(fmodeDataSets[i]);
-			}
-		}
+        final DemoChart chart2 = new DemoChart();
+        chart2.getXAxis().setLabel("time");
+        chart2.getXAxis().setUnit("turns");
+        chart2.getYAxis().setLabel("amplitude");
+        chart2.getYAxis().setUnit("[a.u.]");
+        for (int i = 0; i < fmodeDataSets.length; i++) {
+            if (fmodeDataSets[i] != null) {
+                chart2.getDatasets().add(fmodeDataSets[i]);
+            }
+        }
 
-		return new VBox(chart1, chart2);
-	}
+        return new VBox(chart1, chart2);
+    }
 
-	private double[] readDemoData(int index) {
-		String fileName = index <= 1 ? "./rawDataCPS2.dat" : "./rawDataLHCInj.dat";
-		try {			
-			try (BufferedReader reader = new BufferedReader(
-					new InputStreamReader(EMDSample.class.getResourceAsStream(fileName)))) {
+    private double[] readDemoData(int index) {
+        String fileName = index <= 1 ? "./rawDataCPS2.dat" : "./rawDataLHCInj.dat";
+        try {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(EMDSample.class.getResourceAsStream(fileName)))) {
 
-				String line = reader.readLine();
-				int nDim = line == null ? 0 : Integer.parseInt(line);
-				double[] ret = new double[nDim];
-				for (int i = 0; i < nDim; i++) {
-					line = reader.readLine();
-					if (line == null) {
-						break;
-					}
-					String[] x = line.split("\t");
-					ret[i] = Double.parseDouble(x[1]);
-				}
+                String line = reader.readLine();
+                int nDim = line == null ? 0 : Integer.parseInt(line);
+                double[] ret = new double[nDim];
+                for (int i = 0; i < nDim; i++) {
+                    line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    String[] x = line.split("\t");
+                    ret[i] = Double.parseDouble(x[1]);
+                }
 
-				return ret;
-			}
+                return ret;
+            }
 
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
-		return new double[1000];
-	}
+        return new double[1000];
+    }
 
-	public static void main(final String[] args) {
-		Application.launch(args);
-	}
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
 
 }

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/FourierSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/FourierSample.java
@@ -3,8 +3,7 @@ package de.gsi.math.samples;
 import java.util.Arrays;
 
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.spi.DefaultErrorDataSet;
-import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.spi.DefaultDataSet;
 import de.gsi.math.TMath;
 import de.gsi.math.TRandom;
 import de.gsi.math.samples.utils.AbstractDemoApplication;
@@ -18,20 +17,25 @@ import javafx.scene.Node;
 import javafx.scene.layout.VBox;
 
 /**
- * example illustrating the discrete time fourier transform and Fast-Fourier transform and spectral interpolation
- * methods. Zoom into the peaks to see the details
+ * example illustrating the discrete time fourier transform and Fast-Fourier
+ * transform and spectral interpolation methods. Zoom into the peaks to see the
+ * details
  * 
  * @author rstein
  */
 public class FourierSample extends AbstractDemoApplication {
 
     private static final int MAX_POINTS = 512;
-    private DataSet fraw, fspectra1, fspectra2, fspectra3, fspectra4;
+    private DataSet fraw; 
+    private DataSet fspectra1;
+    private DataSet fspectra2; 
+    private DataSet fspectra3; 
+    private DataSet fspectra4;
     private final TRandom rnd = new TRandom(0);
 
-    private double computeSignal(double t) {
+    private double computeSignal(final double t) {
         double val = 0.0;
-        double error = rnd.Gaus(0.0, 0.2);
+        final double error = rnd.Gaus(0.0, 0.2);
         val += TMath.Sin(TMath.TwoPi() * 0.22 * t);
         val += Math.sin(TMath.TwoPi() * 3e-4 * t * t);
         val += Math.sin(TMath.TwoPi() * 0.05 * t);
@@ -48,7 +52,7 @@ public class FourierSample extends AbstractDemoApplication {
             xValues[i] = i;
             yValues[i] = computeSignal(xValues[i]);
         }
-        fraw = new DoubleErrorDataSet("raw data", xValues, yValues);
+        fraw = new DefaultDataSet("raw data", xValues, yValues, xValues.length, true);
 
         // equal-distance frequency spacing (as in FFT)
         double[] frequency1 = new double[yValues.length / 2];
@@ -73,40 +77,40 @@ public class FourierSample extends AbstractDemoApplication {
             frequency3[i] = i * scaling3;
         }
 
-        LombPeriodogram lombTrafo = new LombPeriodogram();
-        DiscreteTimeFourierTransform trafoDTFT = new DiscreteTimeFourierTransform();
-        DoubleFFT_1D fastFourierTrafo = new DoubleFFT_1D(yValues.length);
+        final LombPeriodogram lombTrafo = new LombPeriodogram();
+        final DiscreteTimeFourierTransform trafoDTFT = new DiscreteTimeFourierTransform();
+        final DoubleFFT_1D fastFourierTrafo = new DoubleFFT_1D(yValues.length);
 
         System.err.printf("compute spectrum for %d test frequencies\n", frequency1.length);
-        double[] lomb = lombTrafo.computePeridodogram(xValues, yValues, frequency2);
-        double[] dtft1 = trafoDTFT.computeMagnitudeSpectrum(xValues, yValues, frequency1);
-        double[] dtft2 = trafoDTFT.computeMagnitudeSpectrum(xValues, yValues, frequency2);
+        final double[] lomb = lombTrafo.computePeridodogram(xValues, yValues, frequency2);
+        final double[] dtft1 = trafoDTFT.computeMagnitudeSpectrum(xValues, yValues, frequency1);
+        final double[] dtft2 = trafoDTFT.computeMagnitudeSpectrum(xValues, yValues, frequency2);
 
         // N.B. since realForward computes the FFT in-place -> generate a copy
         double[] fftSpectra = Arrays.copyOf(yValues, yValues.length);
         fastFourierTrafo.realForward(fftSpectra);
         fftSpectra = SpectrumTools.interpolateSpectrum(fftSpectra, nOverSampling2);
-        double[] mag = SpectrumTools.computeMagnitudeSpectrum(fftSpectra, true);
+        final double[] mag = SpectrumTools.computeMagnitudeSpectrum(fftSpectra, true);
 
-        fspectra1 = new DefaultErrorDataSet("Lomb-spectra equidistant sampling", frequency2, lomb);
+        fspectra1 = new DefaultDataSet("Lomb-spectra equidistant sampling", frequency2, lomb, frequency2.length, true);
         fspectra1.setStyle("strokeWidth=0.5");
-        fspectra2 = new DefaultErrorDataSet("DT-FourierTransform spectra", frequency1, dtft1);
-        fspectra3 = new DefaultErrorDataSet("int. DT-FourierTransform spectra", frequency2, dtft2);
+        fspectra2 = new DefaultDataSet("DT-FourierTransform spectra", frequency1, dtft1, frequency1.length, true);
+        fspectra3 = new DefaultDataSet("int. DT-FourierTransform spectra", frequency2, dtft2, frequency2.length, true);
         System.err.printf("dim %d vs %d\n", frequency2.length, mag.length);
-        fspectra4 = new DefaultErrorDataSet("interpolated FFT", frequency3, mag);
+        fspectra4 = new DefaultDataSet("interpolated FFT", frequency3, mag, frequency3.length, true);
     }
 
     @Override
     public Node getContent() {
         initData();
-        DemoChart chart1 = new DemoChart();
+        final DemoChart chart1 = new DemoChart();
         chart1.getXAxis().setLabel("time");
         chart1.getXAxis().setUnit("s");
         chart1.getYAxis().setLabel("magnitude");
         chart1.getYAxis().setUnit("a.u.");
         chart1.getDatasets().add(fraw);
 
-        DemoChart chart2 = new DemoChart();
+        final DemoChart chart2 = new DemoChart();
         chart2.getXAxis().setLabel("frequency [fs]");
         chart2.getXAxis().setUnit("fs");
         chart2.getYAxis().setLabel("magnitude");

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/FrequencyFilterSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/FrequencyFilterSample.java
@@ -1,6 +1,6 @@
 package de.gsi.math.samples;
 
-import de.gsi.dataset.spi.DoubleDataSet;
+import de.gsi.dataset.spi.DefaultDataSet;
 import de.gsi.math.ArrayMath;
 import de.gsi.math.ArrayMath.FilterType;
 import de.gsi.math.DataSetMath;
@@ -31,7 +31,7 @@ public class FrequencyFilterSample extends AbstractDemoApplication {
             // yValues[i] = i < N_SAMPLES / 2 ? 0.0 : 1.0; // step
         }
         yValues[N_SAMPLES / 2] = N_SAMPLES; // dirac delta
-        DoubleDataSet dataSet = new DoubleDataSet("dirac", xValues, yValues);
+        DefaultDataSet dataSet = new DefaultDataSet("dirac", xValues, yValues, xValues.length, true);
 
         final DemoChart chartLP = new DemoChart();
         chartLP.getXAxis().setLabel("frequency");
@@ -39,16 +39,16 @@ public class FrequencyFilterSample extends AbstractDemoApplication {
         chartLP.getYAxis().setUnit("dB");
         chartLP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(dataSet));
 
-        DoubleDataSet butterWorthA = new DoubleDataSet("Butterworth(4th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 4, FilterType.LOW_PASS, 0));
+        DefaultDataSet butterWorthA = new DefaultDataSet("Butterworth(4th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 4, FilterType.LOW_PASS, 0), xValues.length, true);
         chartLP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthA));
 
-        DoubleDataSet butterWorthB = new DoubleDataSet("Butterworth(6th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 6, FilterType.LOW_PASS, 0));
+        DefaultDataSet butterWorthB = new DefaultDataSet("Butterworth(6th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 6, FilterType.LOW_PASS, 0), xValues.length, true);
         chartLP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthB));
 
-        DoubleDataSet butterWorthC = new DoubleDataSet("Butterworth(8th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 8, FilterType.LOW_PASS, 0));
+        DefaultDataSet butterWorthC = new DefaultDataSet("Butterworth(8th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 8, FilterType.LOW_PASS, 0), xValues.length, true);
         chartLP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthC));
 
         final DemoChart chartHP = new DemoChart();
@@ -57,16 +57,16 @@ public class FrequencyFilterSample extends AbstractDemoApplication {
         chartHP.getYAxis().setUnit("dB");
         chartHP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(dataSet));
 
-        DoubleDataSet butterWorthA2 = new DoubleDataSet("Butterworth(4th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 4, FilterType.HIGH_PASS, 0.0));
+        DefaultDataSet butterWorthA2 = new DefaultDataSet("Butterworth(4th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 4, FilterType.HIGH_PASS, 0.0), xValues.length, true);
         chartHP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthA2));
 
-        DoubleDataSet butterWorthB2 = new DoubleDataSet("Butterworth(6th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 6, FilterType.HIGH_PASS, 0.0));
+        DefaultDataSet butterWorthB2 = new DefaultDataSet("Butterworth(6th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 6, FilterType.HIGH_PASS, 0.0), xValues.length, true);
         chartHP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthB2));
 
-        DoubleDataSet butterWorthC2 = new DoubleDataSet("Butterworth(8th)", xValues,
-                ArrayMath.filterSignal(yValues, fcut, 8, FilterType.HIGH_PASS, 0.0));
+        DefaultDataSet butterWorthC2 = new DefaultDataSet("Butterworth(8th)", xValues,
+                ArrayMath.filterSignal(yValues, fcut, 8, FilterType.HIGH_PASS, 0.0), xValues.length, true);
         chartHP.getRenderer(0).getDatasets().addAll(DataSetMath.normalisedMagnitudeSpectrumDecibel(butterWorthC2));
 
         return new VBox(chartLP, chartHP);

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/GaussianFitSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/GaussianFitSample.java
@@ -1,13 +1,13 @@
 package de.gsi.math.samples;
 
 import de.gsi.dataset.DataSet;
+import de.gsi.dataset.spi.DefaultDataSet;
 import de.gsi.dataset.spi.DefaultErrorDataSet;
-import de.gsi.dataset.spi.DoubleErrorDataSet;
 import de.gsi.math.TMath;
-import de.gsi.math.samples.utils.AbstractDemoApplication;
-import de.gsi.math.samples.utils.DemoChart;
 import de.gsi.math.fitter.NonLinearRegressionFitter;
 import de.gsi.math.functions.AbstractFunction1D;
+import de.gsi.math.samples.utils.AbstractDemoApplication;
+import de.gsi.math.samples.utils.DemoChart;
 import javafx.application.Application;
 import javafx.scene.Node;
 
@@ -17,7 +17,6 @@ import javafx.scene.Node;
  * @author rstein
  */
 public class GaussianFitSample extends AbstractDemoApplication {
-
     private static final int MAX_POINTS = 101;
     private DataSet fmodel;
     private DataSet fdataOrig;
@@ -27,7 +26,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
         // user specific fitting function, here: normalised Gaussian Function
         // y := scale*1/sqrt(2*Pi*sigma^2)*exp(-0.5*(x-mu)^2/sigma^2)
         // ... MyGaussianFunction(name, double[]{mu, sigma, scale})
-        MyGaussianFunction func = new MyGaussianFunction("gauss1", new double[] { -3.0, 1.0, 10.0 });
+        final MyGaussianFunction func = new MyGaussianFunction("gauss1", new double[] { -3.0, 1.0, 10.0 });
         System.err.println("before fit");
         func.printParameters();
 
@@ -37,11 +36,11 @@ public class GaussianFitSample extends AbstractDemoApplication {
         double[] yErrors = new double[MAX_POINTS];
 
         for (int i = 0; i < xValues.length; i++) {
-            double error = 0.5 * RANDOM.nextGaussian();
+            final double error = 0.5 * RANDOM.nextGaussian();
             xValues[i] = (i - xValues.length / 2.0) * 30.0 / MAX_POINTS; // equidistant
                                                                          // sampling
 
-            double value = func.getValue(xValues[i]);
+            final double value = func.getValue(xValues[i]);
             // add some slope and offset to make the fit a bit more tricky
             // remember: in this example, the slope is not part of the fitting
             // check whether fit converged via chi^2
@@ -56,7 +55,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
 
         }
 
-        NonLinearRegressionFitter fitter = new NonLinearRegressionFitter(xValues, yValues, yErrors);
+        final NonLinearRegressionFitter fitter = new NonLinearRegressionFitter(xValues, yValues, yErrors);
 
         // initial estimates
         double[] start = new double[3];
@@ -71,18 +70,18 @@ public class GaussianFitSample extends AbstractDemoApplication {
         step[2] = 0.1; // initial step size for scale
         fitter.simplex(func, start, step);
 
-        double[] fittedParameter = fitter.getBestEstimates();
-        double[] fittedParameterError = fitter.getBestEstimatesErrors();
+        final double[] fittedParameter = fitter.getBestEstimates();
+        final double[] fittedParameterError = fitter.getBestEstimatesErrors();
 
         func.setParameterValues(fittedParameter);
         for (int i = 0; i < func.getParameterCount(); i++) {
-            double value = fittedParameter[i];
-            double error = fittedParameterError[i];
+            final double value = fittedParameter[i];
+            final double error = fittedParameterError[i];
             func.setParameterRange(i, value - error, value + error);
         }
 
-        double[] yPredicted = func.getValues(xValues);
-        double[] yPredictedError = new double[yPredicted.length];
+        final double[] yPredicted = func.getValues(xValues);
+        final double[] yPredictedError = new double[yPredicted.length];
 
         System.err.println("after fit");
         func.printParameters();
@@ -93,9 +92,11 @@ public class GaussianFitSample extends AbstractDemoApplication {
                     fittedParameter[i], fittedParameterError[i]);
         }
 
-        fmodel = new DoubleErrorDataSet("design model", xValues, yModel);
-        fdataOrig = new DefaultErrorDataSet("data seed with errors", xValues, yValues, yErrors);
-        fdataFitted = new DefaultErrorDataSet("fitted model", xValues, yPredicted, yPredictedError);
+        fmodel = new DefaultDataSet("design model", xValues, yModel, xValues.length, true);
+        fdataOrig = new DefaultErrorDataSet("data seed with errors", xValues, yValues, yErrors, yErrors, xValues.length,
+                true);
+        fdataFitted = new DefaultErrorDataSet("fitted model", xValues, yPredicted, yPredictedError, yPredictedError,
+                xValues.length, true);
 
         // plot fitting results
         /*
@@ -111,18 +112,19 @@ public class GaussianFitSample extends AbstractDemoApplication {
     public Node getContent() {
         initData();
 
-        DemoChart chart = new DemoChart();
+        final DemoChart chart = new DemoChart();
         chart.getRenderer(0).getDatasets().addAll(fmodel, fdataOrig, fdataFitted);
 
         return chart;
     }
 
     /**
-     * example fitting function y = scale/(sqrt(2*pi*sigma)*exp(- 0.5*(x-mu)^2/sigma^2)
+     * example fitting function y = scale/(sqrt(2*pi*sigma)*exp(-
+     * 0.5*(x-mu)^2/sigma^2)
      */
-    class MyGaussianFunction extends AbstractFunction1D {
+    protected class MyGaussianFunction extends AbstractFunction1D {
 
-        public MyGaussianFunction(String name, double[] parameter) {
+        public MyGaussianFunction(final String name, final double[] parameter) {
             super(name, new double[3]);
             // declare parameter names
             this.setParameterName(0, "mu");
@@ -145,13 +147,12 @@ public class GaussianFitSample extends AbstractDemoApplication {
         }
 
         @Override
-        public double getValue(double x) {
-            double mu = fparameter[0];
-            double sigma = fparameter[1];
-            double scale = fparameter[2];
-            double y = scale * 1.0 / (Math.sqrt(TMath.TwoPi()) * sigma)
-                    * Math.exp(-0.5 * Math.pow((x - mu) / sigma, 2));
-            return y;
+        public double getValue(final double x) {
+            final double mu = fparameter[0];
+            final double sigma = fparameter[1];
+            final double scale = fparameter[2];
+
+            return scale * 1.0 / (Math.sqrt(TMath.TwoPi()) * sigma) * Math.exp(-0.5 * Math.pow((x - mu) / sigma, 2));
         }
     }
 

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/IIRFilterSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/IIRFilterSample.java
@@ -8,10 +8,9 @@ import java.util.zip.ZipInputStream;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.spi.DoubleDataSet;
 import de.gsi.math.DataSetMath;
-import de.gsi.math.TRandom;
+import de.gsi.math.filter.iir.Butterworth;
 import de.gsi.math.samples.utils.AbstractDemoApplication;
 import de.gsi.math.samples.utils.DemoChart;
-import de.gsi.math.filter.iir.Butterworth;
 import javafx.application.Application;
 import javafx.scene.Node;
 import javafx.scene.layout.VBox;
@@ -22,9 +21,12 @@ public class IIRFilterSample extends AbstractDemoApplication {
     private final double sampling = 100e6;
     private final double center = 28e6;
     private final double width = 0.5e6;
-    private DataSet fraw, fraw1, fraw2;
-    private DataSet fspectra, fspectra1, fspectra2;
-    private final TRandom rnd = new TRandom(0);
+    private DataSet fraw;
+    private DataSet fraw1; 
+    private DataSet fraw2;
+    private DataSet fspectra;
+    private DataSet fspectra1; 
+    private DataSet fspectra2;
 
     private DataSet readDemoData(final int offset, final int nSamples) {
         final Butterworth bandPass = new Butterworth();

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/WaveletDenoising.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/WaveletDenoising.java
@@ -6,12 +6,12 @@ import java.util.Arrays;
 import java.util.Random;
 
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.spi.DefaultErrorDataSet;
+import de.gsi.dataset.spi.DefaultDataSet;
 import de.gsi.math.TMath;
 import de.gsi.math.TMathConstants;
+import de.gsi.math.functions.RandomWalkFunction;
 import de.gsi.math.samples.utils.AbstractDemoApplication;
 import de.gsi.math.samples.utils.DemoChart;
-import de.gsi.math.functions.RandomWalkFunction;
 import de.gsi.math.spectra.wavelet.CDFWavelet;
 import de.gsi.math.spectra.wavelet.FastWaveletTransform;
 import javafx.application.Application;
@@ -35,14 +35,14 @@ public class WaveletDenoising extends AbstractDemoApplication {
 
     private void initData() {
         // third order polynomial function
-        RandomWalkFunction func = new RandomWalkFunction("rand1", 0.1);
+        final RandomWalkFunction func = new RandomWalkFunction("rand1", 0.1);
 
         double[] xValues;
         double[] yValues;
         double[] yModel;
 
         if (LOAD_EXAMPLE_DATA) {
-            double[][] data = readDemoData();
+            final double[][] data = readDemoData();
             xValues = data[0];
             yValues = data[1];
             yModel = Arrays.copyOf(yValues, yValues.length);
@@ -51,11 +51,11 @@ public class WaveletDenoising extends AbstractDemoApplication {
             yValues = new double[MAX_POINTS];
             yModel = new double[MAX_POINTS];
 
-            Random rnd = new Random();
+            final Random rnd = new Random();
             for (int i = 0; i < xValues.length; i++) {
-                double x = i;
+                final double x = i;
                 double offset = 0;
-                double error = 0.2 * rnd.nextGaussian();
+                final double error = 0.2 * rnd.nextGaussian();
                 if (i > xValues.length / 2) {
                     offset = -0.05;
                 }
@@ -72,12 +72,12 @@ public class WaveletDenoising extends AbstractDemoApplication {
             }
         }
 
-        CDFWavelet wvTrafo1 = new CDFWavelet();
-        FastWaveletTransform wvTrafo3 = new FastWaveletTransform();
-        boolean trafo1 = false;
+        final CDFWavelet wvTrafo1 = new CDFWavelet();
+        final FastWaveletTransform wvTrafo3 = new FastWaveletTransform();
+        final boolean trafo1 = false;
 
-        double[] ySmooth = Arrays.copyOf(yValues, yValues.length);
-        double[] ySModel = Arrays.copyOf(yModel, yModel.length);
+        final double[] ySmooth = Arrays.copyOf(yValues, yValues.length);
+        final double[] ySModel = Arrays.copyOf(yModel, yModel.length);
 
         if (trafo1) {
             wvTrafo1.fwt97(ySmooth, ySmooth.length);
@@ -90,8 +90,8 @@ public class WaveletDenoising extends AbstractDemoApplication {
             wvTrafo3.transform(ySModel);
         }
 
-        double[] recon = Arrays.copyOf(ySmooth, yValues.length);
-        double[] reconAbs = Arrays.copyOf(ySmooth, yValues.length);
+        final double[] recon = Arrays.copyOf(ySmooth, yValues.length);
+        final double[] reconAbs = Arrays.copyOf(ySmooth, yValues.length);
         for (int i = 0; i < reconAbs.length; i++) {
             reconAbs[i] = Math.abs(recon[i]);
         }
@@ -148,9 +148,10 @@ public class WaveletDenoising extends AbstractDemoApplication {
             recon[i] = 0.0;
         }
 
-        fspectraModel = new DefaultErrorDataSet("model", xValues, ySModel);
-        fspectra = new DefaultErrorDataSet("raw data", xValues, ySmooth);
-        fspectraFit = new DefaultErrorDataSet("reconstructed", xValues, Arrays.copyOf(recon, recon.length));
+        fspectraModel = new DefaultDataSet("model", xValues, ySModel, xValues.length, true);
+        fspectra = new DefaultDataSet("raw data", xValues, ySmooth, xValues.length, true);
+        fspectraFit = new DefaultDataSet("reconstructed", xValues, Arrays.copyOf(recon, recon.length), xValues.length,
+                true);
 
         if (trafo1) {
             wvTrafo1.iwt97(recon, recon.length);
@@ -159,8 +160,8 @@ public class WaveletDenoising extends AbstractDemoApplication {
             wvTrafo3.invTransform(recon);
         }
 
-        double error1 = TMath.RMS(TMath.Difference(yValues, yModel));
-        double error2 = TMath.RMS(TMath.Difference(recon, yModel));
+        final double error1 = TMath.RMS(TMath.Difference(yValues, yModel));
+        final double error2 = TMath.RMS(TMath.Difference(recon, yModel));
         if (error1 > error2) {
             System.out.printf("improved noise floor from %f \t-> %f \t(%f %%)\n", error1, error2,
                     (error1 - error2) / error1 * 100);
@@ -169,20 +170,20 @@ public class WaveletDenoising extends AbstractDemoApplication {
                     (error1 - error2) / error1 * 100);
         }
 
-        fdata = new DefaultErrorDataSet("model ", xValues, yModel);
-        fraw = new DefaultErrorDataSet("raw data", xValues, yValues);
-        freconstructed = new DefaultErrorDataSet("reconstructed", xValues, recon);
+        fdata = new DefaultDataSet("model ", xValues, yModel, xValues.length, true);
+        fraw = new DefaultDataSet("raw data", xValues, yValues, xValues.length, true);
+        freconstructed = new DefaultDataSet("reconstructed", xValues, recon, xValues.length, true);
     }
 
     @Override
     public Node getContent() {
         initData();
 
-        DemoChart chart1 = new DemoChart();
+        final DemoChart chart1 = new DemoChart();
         chart1.getXAxis().setLabel("time");
         chart1.getDatasets().addAll(fdata, fraw, freconstructed);
 
-        DemoChart chart2 = new DemoChart();
+        final DemoChart chart2 = new DemoChart();
         chart2.getXAxis().setLabel("frequency");
         chart2.getDatasets().addAll(fspectraModel, fspectra, fspectraFit);
 
@@ -195,14 +196,14 @@ public class WaveletDenoising extends AbstractDemoApplication {
                 new InputStreamReader(WaveletScalogram.class.getResourceAsStream(fileName)))) {
 
             String line = reader.readLine();
-            int nDim = line == null ? 0 : Integer.parseInt(line);
+            final int nDim = line == null ? 0 : Integer.parseInt(line);
             double[][] ret = new double[2][nDim];
             for (int i = 0; i < nDim; i++) {
                 line = reader.readLine();
                 if (line == null) {
                     break;
                 }
-                String[] x = line.split("\t");
+                final String[] x = line.split("\t");
                 ret[0][i] = Double.parseDouble(x[0]);
                 ret[1][i] = Double.parseDouble(x[1]);
             }

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/WaveletScalogram.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/WaveletScalogram.java
@@ -67,7 +67,7 @@ public class WaveletScalogram extends AbstractDemoApplication {
 
         do {
             sleep(1000);
-            int status = wtrafo.getStatus();
+            final int status = wtrafo.getStatus();
             if (status > 10) {
                 System.out.println(status + " % of computation done");
             }
@@ -75,11 +75,11 @@ public class WaveletScalogram extends AbstractDemoApplication {
 
         sleep(1000);
 
-        DoubleFFT_1D fft = new DoubleFFT_1D(yValues.length);
-        double[] fftSpectra = Arrays.copyOf(yValues, yValues.length);
+        final DoubleFFT_1D fft = new DoubleFFT_1D(yValues.length);
+        final double[] fftSpectra = Arrays.copyOf(yValues, yValues.length);
         fft.realForward(fftSpectra);
-        double[] frequency1 = wtrafo.getScalogramFrequencyAxis(nQuantx, nQuanty, nu, fmin, fmax);
-        double[] magWavelet = new double[frequency1.length];
+        final double[] frequency1 = wtrafo.getScalogramFrequencyAxis(nQuantx, nQuanty, nu, fmin, fmax);
+        final double[] magWavelet = new double[frequency1.length];
         final int nboundary = fdataset.getXDataCount() / 20;
 
         for (int i = 0; i < fdataset.getYDataCount(); i++) {
@@ -93,22 +93,22 @@ public class WaveletScalogram extends AbstractDemoApplication {
             magWavelet[i] = val / count;
         }
 
-        double[] magFourier = SpectrumTools.computeMagnitudeSpectrum_dB(fftSpectra, true);
-        double[] frequency2 = SpectrumTools.computeFrequencyScale(fftSpectra.length / 2);
+        final double[] magFourier = SpectrumTools.computeMagnitudeSpectrum_dB(fftSpectra, true);
+        final double[] frequency2 = SpectrumTools.computeFrequencyScale(fftSpectra.length / 2);
 
         // normalise FFT and wavelet spectra for better comparison
-        double maxWavelet = TMath.Maximum(magWavelet);
+        final double maxWavelet = TMath.Maximum(magWavelet);
         for (int i = 0; i < magWavelet.length; i++) {
             magWavelet[i] -= maxWavelet;
         }
 
-        double maxFourier = TMath.Maximum(magFourier);
+        final double maxFourier = TMath.Maximum(magFourier);
         for (int i = 0; i < magFourier.length; i++) {
             magFourier[i] -= maxFourier;
         }
 
-        fwavelet = new DefaultDataSet("Wavelet magnitude", frequency1, magWavelet);
-        ffourier = new DefaultDataSet("Fourier magnitude", frequency2, magFourier);
+        fwavelet = new DefaultDataSet("Wavelet magnitude", frequency1, magWavelet, frequency1.length, true);
+        ffourier = new DefaultDataSet("Fourier magnitude", frequency2, magFourier, frequency2.length, true);
 
         return fdataset;
     }
@@ -126,11 +126,11 @@ public class WaveletScalogram extends AbstractDemoApplication {
         // synthetic data
         final double[] yModel = new double[MAX_POINTS];
 
-        Random rnd = new Random();
+        final Random rnd = new Random();
         for (int i = 0; i < yValues.length; i++) {
-            double x = i;
+            final double x = i;
             double offset = 0;
-            double error = 0.1 * rnd.nextGaussian();
+            final double error = 0.1 * rnd.nextGaussian();
 
             // linear chirp with discontinuity
             offset = (i > 500) ? -20 : 0;
@@ -140,7 +140,7 @@ public class WaveletScalogram extends AbstractDemoApplication {
             yModel[i] += (i > 50 && i < 500) ? 1.0 * Math.sin(TMath.TwoPi() * 0.25 * x) : 0;
 
             // modulation around 0.4
-            double mod = Math.cos(TMath.TwoPi() * 0.01 * x);
+            final double mod = Math.cos(TMath.TwoPi() * 0.01 * x);
             yModel[i] += (i > 300 && i < 900) ? 1.0 * Math.sin(TMath.TwoPi() * (0.4 - 5e-4 * mod) * x) : 0;
 
             // quadratic chirp starting at 0.1
@@ -154,21 +154,21 @@ public class WaveletScalogram extends AbstractDemoApplication {
     @Override
     public Node getContent() {
 
-        DemoChart chart1 = new DemoChart();
+        final DemoChart chart1 = new DemoChart();
         chart1.getXAxis().setLabel("time");
         chart1.getXAxis().setUnit("turns");
         chart1.getYAxis().setAutoRangeRounding(false);
         chart1.getYAxis().setAutoRangePadding(0.0);
         chart1.getYAxis().setLabel("frequency");
         chart1.getYAxis().setUnit("fs");
-        ContourDataSetRenderer contourChartRenderer = new ContourDataSetRenderer();
+        final ContourDataSetRenderer contourChartRenderer = new ContourDataSetRenderer();
         chart1.getRenderers().set(0, contourChartRenderer);
         contourChartRenderer.setColorGradient(ColorGradient.RAINBOW);
         // contourChartRenderer.setColorGradient(ColorGradient.JET);
         // contourChartRenderer.setColorGradient(ColorGradient.TOPO_EXT);
         contourChartRenderer.getDatasets().add(createDataSet());
 
-        DemoChart chart2 = new DemoChart();
+        final DemoChart chart2 = new DemoChart();
         chart2.getXAxis().setLabel("frequency");
         chart2.getXAxis().setUnit("fs");
         chart2.getYAxis().setLabel("magnitude");
@@ -176,7 +176,7 @@ public class WaveletScalogram extends AbstractDemoApplication {
         chart1.getXAxis().setAutoRangePadding(0.0);
         chart2.getDatasets().addAll(fwavelet, ffourier);
 
-        AxisSynchronizer sync = new AxisSynchronizer();
+        final AxisSynchronizer sync = new AxisSynchronizer();
         sync.add(chart2.getXAxis());
         sync.add(chart1.getYAxis());
 
@@ -184,20 +184,20 @@ public class WaveletScalogram extends AbstractDemoApplication {
     }
 
     private double[] readDemoData(int index) {
-        String fileName = index <= 1 ? "./rawDataCPS2.dat" : "./rawDataLHCInj.dat";
+        final String fileName = index <= 1 ? "./rawDataCPS2.dat" : "./rawDataLHCInj.dat";
         try {
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(EMDSample.class.getResourceAsStream(fileName)))) {
 
                 String line = reader.readLine();
-                int nDim = line == null ? 0 : Integer.parseInt(line);
+                final int nDim = line == null ? 0 : Integer.parseInt(line);
                 double[] ret = new double[nDim];
                 for (int i = 0; i < nDim; i++) {
                     line = reader.readLine();
                     if (line == null) {
                         break;
                     }
-                    String[] x = line.split("\t");
+                    final String[] x = line.split("\t");
                     ret[i] = Double.parseDouble(x[1]);
                 }
 


### PR DESCRIPTION
Replaces controlsfx SpreadsheetView with (open)JavaFX TableView because of controlsfx/controlsfx#1141.
Additionally contains some bugfixes and cleanup of Dataset Features and experimental FloatDataSet support.

Editing functionality is still in TableViewer, because it is difficult to factor out.
Also editing still throws some exceptions on editCommit, some task should propably be run via FXrun.

For the dataSets Travis complains about JavaDoc.