### PR TITLE
removed duplicate plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
                             </goals>
                             <phase>site</phase>
                         </execution>
+			<execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <!-- <configuration> <additionalparam>-Xdoclint:none</additionalparam> <skip>true</skip> </configuration> -->
+                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -171,20 +178,6 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <!-- <configuration> <additionalparam>-Xdoclint:none</additionalparam> <skip>true</skip> </configuration> -->
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <!-- <configuration> <additionalparam>-Xdoclint:none</additionalparam> <skip>true</skip> </configuration> -->
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Currently `mvn package` fails. Tested with mvn 3.6.0 / 3.6.2 and JDK 8 / 11 / 12

![image](https://user-images.githubusercontent.com/5491587/64694217-7afd0d80-d499-11e9-9d41-e1a65db257e4.png)

This is caused by a limitation in maven that doesn't allow for the same plugin to be added more than once. This PR combines both `<plugin>` definitions into separate `<execution>` elements.

![image](https://user-images.githubusercontent.com/5491587/64694480-08406200-d49a-11e9-814a-87509c149273.png)
