### PR TITLE
updated javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.1</version>
                     <configuration>
                         <links>
                             <link>https://openjfx.io/javadoc/12/</link>


### PR DESCRIPTION
Apparently my `mvn package` issue from #27 was caused by a bug in the javadoc-plugin: https://issues.apache.org/jira/browse/MJAVADOC-581

I'm not sure why the path `D:\Github\chart-fx` would cause any issues, but updating to the latest version fixes it.