### PR TITLE
Fix dataset getter

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
@@ -14,6 +14,7 @@ import de.gsi.chart.axes.Axis;
 import de.gsi.chart.renderer.Renderer;
 import de.gsi.chart.utils.FXUtils;
 import de.gsi.dataset.DataSet;
+import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.EditableDataSet;
 import javafx.beans.property.BooleanProperty;
@@ -224,7 +225,7 @@ public class EditDataSet extends TableViewer {
             final double newValX = xAxis.getValueForDisplay(x - x0);
             final double newValY = yAxis.getValueForDisplay(y - y0);
             final EditableDataSet ds = (EditableDataSet) (dataPoint.getDataSet());
-            final double oldValX = ds.getX(index);
+            final double oldValX = ds.get(DataSet.DIM_X, index);
             if (oldValX <= newValX) {
                 ds.add(index, newValX, newValY);
             } else {
@@ -286,13 +287,13 @@ public class EditDataSet extends TableViewer {
         final double yMaxScreen = Math.max(selectStartPoint.getY(), selectEndPoint.getY());
 
         for (final DataSet ds : dataSets) {
-            if (!(ds instanceof EditableDataSet)) {
+            if (!(ds instanceof EditableDataSet || !(ds instanceof DataSet2D))) {
                 continue;
             }
             final EditableDataSet dataSet = (EditableDataSet) ds;
 
-            final int indexMin = Math.max(0, dataSet.getXIndex(xAxis.getValueForDisplay(xMinScreen)));
-            final int indexMax = Math.min(dataSet.getXIndex(xAxis.getValueForDisplay(xMaxScreen)) + 1,
+            final int indexMin = Math.max(0, ((DataSet2D) dataSet).getXIndex(xAxis.getValueForDisplay(xMinScreen)));
+            final int indexMax = Math.min(((DataSet2D) dataSet).getXIndex(xAxis.getValueForDisplay(xMaxScreen)) + 1,
                     dataSet.getDataCount());
 
             // N.B. (0,0) screen coordinate is in the top left corner vs. normal
@@ -303,7 +304,7 @@ public class EditDataSet extends TableViewer {
             final ConcurrentHashMap<Integer, SelectedDataPoint> dataSetHashMap = markedPoints.computeIfAbsent(dataSet,
                     k -> new ConcurrentHashMap<>());
             for (int i = indexMin; i < indexMax; i++) {
-                final double y = dataSet.getY(i);
+                final double y = dataSet.get(DataSet.DIM_Y, i);
                 if ((y >= yMin) && (y <= yMax)) {
                     if (isShiftDown()) {
                         // add if not existing/remove if existing
@@ -941,8 +942,8 @@ public class EditDataSet extends TableViewer {
             this.xAxis = xAxis;
             this.yAxis = yAxis;
             this.dataSet = dataSet;
-            this.xValue = dataSet.getX(index);
-            this.yValue = dataSet.getY(index);
+            this.xValue = dataSet.get(DataSet.DIM_X, index);
+            this.yValue = dataSet.get(DataSet.DIM_Y, index);
             this.setCenterX(getX()); // NOPMD by rstein on 13/06/19 14:14
             this.setCenterY(getY()); // NOPMD by rstein on 13/06/19 14:14
             this.setRadius(DEFAULT_MARKER_RADIUS);
@@ -1028,8 +1029,8 @@ public class EditDataSet extends TableViewer {
 
         public int getIndex() {
             for (int i = 0; i < dataSet.getDataCount(); i++) {
-                final double x0 = dataSet.getX(i);
-                final double y0 = dataSet.getY(i);
+                final double x0 = dataSet.get(DataSet.DIM_X, i);
+                final double y0 = dataSet.get(DataSet.DIM_Y, i);
                 if (x0 == xValue && y0 == yValue) {
                     return i;
                 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
@@ -503,11 +503,11 @@ public class TableViewer extends ChartPlugin {
                 final EditableDataSet editableDataSet = (EditableDataSet) ds;
                 final EditConstraints editConstraints = editableDataSet.getEditConstraints();
 
-                if (type == ColumnType.X && editConstraints != null && !editConstraints.isEditable(DataSet.DIM_X)) {
+                if (type == ColumnType.X && editConstraints != null && !editConstraints.isEditable(DIM_X)) {
                     // editing of x coordinate is excluded
                     return;
                 }
-                if (type == ColumnType.Y && editConstraints != null && !editConstraints.isEditable(DataSet.DIM_Y)) {
+                if (type == ColumnType.Y && editConstraints != null && !editConstraints.isEditable(DIM_Y)) {
                     // editing of y coordinate is excluded
                     return;
                 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
@@ -520,8 +520,8 @@ public class TableViewer extends ChartPlugin {
 
                 this.setOnEditCommit(e -> {
                     final int row = e.getRowValue().getRow();
-                    final double oldX = editableDataSet.getX(row);
-                    final double oldY = editableDataSet.getY(row);
+                    final double oldX = editableDataSet.get(DIM_X, row);
+                    final double oldY = editableDataSet.get(DIM_Y, row);
 
                     if (editConstraints != null && !editConstraints.canChange(row)) {
                         // may not edit value, revert to old value (ie. via

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
@@ -503,11 +503,11 @@ public class TableViewer extends ChartPlugin {
                 final EditableDataSet editableDataSet = (EditableDataSet) ds;
                 final EditConstraints editConstraints = editableDataSet.getEditConstraints();
 
-                if (type == ColumnType.X && editConstraints != null && !editConstraints.isXEditable()) {
+                if (type == ColumnType.X && editConstraints != null && !editConstraints.isEditable(DataSet.DIM_X)) {
                     // editing of x coordinate is excluded
                     return;
                 }
-                if (type == ColumnType.Y && editConstraints != null && !editConstraints.isYEditable()) {
+                if (type == ColumnType.Y && editConstraints != null && !editConstraints.isEditable(DataSet.DIM_Y)) {
                     // editing of y coordinate is excluded
                     return;
                 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/CachedDataPoints.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/CachedDataPoints.java
@@ -164,8 +164,8 @@ class CachedDataPoints {
         // experimental transform euclidean to polar coordinates
         dataSet.lock().readLockGuardOptimistic(() -> {
             for (int index = min; index < max; index++) {
-                final double x = dataSet.getX(index);
-                final double y = dataSet.getY(index);
+                final double x = dataSet.get(DIM_X, index);
+                final double y = dataSet.get(DIM_Y, index);
                 // check if error should be surrounded by Math.abs(..)
                 // to ensure that they are always positive
                 final double phi = x * DEG_TO_RAD;
@@ -429,8 +429,8 @@ class CachedDataPoints {
     private void computeYonlyPolar(final Axis yAxis, final DataSet2D dataSet, final int min, final int max) {
         dataSet.lock().readLockGuardOptimistic(() -> {
             for (int index = min; index < max; index++) {
-                final double x = dataSet.getX(index);
-                final double y = dataSet.getY(index);
+                final double x = dataSet.get(DIM_X, index);
+                final double y = dataSet.get(DIM_Y, index);
                 // check if error should be surrounded by Math.abs(..)
                 // to ensure that they are always positive
                 final double phi = x * DEG_TO_RAD;

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -273,7 +273,7 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
 
         @Override
         public double getX(final int i) {
-            return dataSet.getX(i);
+            return dataSet.get(DIM_X, i);
         }
 
         @Override

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
@@ -113,8 +113,8 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
                         if (i < 0) {
                             i = 0;
                         }
-                        double x0 = xAxis.getDisplayPosition(dataset.getX(i));
-                        double y0 = yAxis.getDisplayPosition(dataset.getY(i));
+                        double x0 = xAxis.getDisplayPosition(dataset.get(DataSet.DIM_X, i));
+                        double y0 = yAxis.getDisplayPosition(dataset.get(DataSet.DIM_Y, i));
                         i++;
                         for (; i < Math.min(dataset.getXIndex(xmax) + 1, dataset.getDataCount()); i++) {
                             final double x1 = xAxis.getDisplayPosition(dataset.getX(i));
@@ -128,18 +128,18 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
                         if (i < 0) {
                             i = 0;
                         }
-                        double x0 = xAxis.getDisplayPosition(dataset.getX(i));
-                        double y0 = yAxis.getDisplayPosition(dataset.getY(i));
+                        double x0 = xAxis.getDisplayPosition(dataset.get(DataSet.DIM_X, i));
+                        double y0 = yAxis.getDisplayPosition(dataset.get(DataSet.DIM_Y, i));
                         i++;
-                        double x1 = xAxis.getDisplayPosition(dataset.getX(i));
-                        double y1 = yAxis.getDisplayPosition(dataset.getY(i));
+                        double x1 = xAxis.getDisplayPosition(dataset.get(DataSet.DIM_X, i));
+                        double y1 = yAxis.getDisplayPosition(dataset.get(DataSet.DIM_Y, i));
                         double delta = Math.abs(y1 - y0);
                         i++;
                         int j = d - 2;
                         for (; i < Math.min(dataset.getXIndex(xmax) + 1, dataset.getDataCount()); i++) {
                             if (j > 0) {
-                                final double x2 = xAxis.getDisplayPosition(dataset.getX(i));
-                                final double y2 = yAxis.getDisplayPosition(dataset.getY(i));
+                                final double x2 = xAxis.getDisplayPosition(dataset.get(DataSet.DIM_X, i));
+                                final double y2 = yAxis.getDisplayPosition(dataset.get(DataSet.DIM_Y, i));
                                 if (Math.abs(y2 - y0) > delta) {
                                     x1 = x2;
                                     y1 = y2;
@@ -150,8 +150,8 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
                                 gc.strokeLine(x0, y0, x1, y1);
                                 x0 = x1;
                                 y0 = y1;
-                                x1 = xAxis.getDisplayPosition(dataset.getX(i));
-                                y1 = yAxis.getDisplayPosition(dataset.getY(i));
+                                x1 = xAxis.getDisplayPosition(dataset.get(DataSet.DIM_X, i));
+                                y1 = yAxis.getDisplayPosition(dataset.get(DataSet.DIM_Y, i));
                                 delta = Math.abs(y1 - y0);
                                 j = d - 1;
                             }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet2D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet2D.java
@@ -132,6 +132,6 @@ public interface DataSet2D extends DataSet {
      * @return the x value array
      */
     default double[] getYValues() {
-        return getValues(DIM_X);
+        return getValues(DIM_Y);
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet2D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet2D.java
@@ -9,11 +9,6 @@ package de.gsi.dataset;
  */
 public interface DataSet2D extends DataSet {
 
-    @Override
-    default double get(final int dimIndex, final int index) {
-        return dimIndex == DIM_X ? getX(index) : getY(index);
-    }
-
     /**
      * Get the number of data points in the data set.
      *

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/EditConstraints.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/EditConstraints.java
@@ -36,22 +36,17 @@ public interface EditConstraints {
      * doesn't have the same X coordinate as existing point.
      * 
      * @param index index of the point being modified or -1 if it is a new point
-     * @param newX X coordinate of the considered point
-     * @param newY Y coordinate of the considered point
+     * @param newValue coordinate list of the considered point
      * @return <code>true</code> if the point is acceptable by the data set, <code>false</code> otherwise
      */
-    default boolean isAcceptable(int index, double newX, double newY) {
+    default boolean isAcceptable(int index, double ...newValue) {
         return true;
     }
 
     /**
+     * @param dimIndex the dimension index (ie. '0' equals 'X', '1' equals 'Y')
      * @return true: if the horizontal values can be modified
      */
-    boolean isXEditable();
-
-    /**
-     * @return true: if the vertical values can be modified
-     */
-    boolean isYEditable();
+    boolean isEditable(final int dimIndex);
 
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
@@ -4,7 +4,7 @@ package de.gsi.dataset;
  * @author rstein
  *
  */
-public interface EditableDataSet extends DataSet2D {
+public interface EditableDataSet {
 
     /**
      * add point to the data set

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
@@ -4,7 +4,7 @@ package de.gsi.dataset;
  * @author rstein
  *
  */
-public interface EditableDataSet {
+public interface EditableDataSet extends DataSet {
 
     /**
      * add point to the data set

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/EditableDataSet.java
@@ -10,11 +10,10 @@ public interface EditableDataSet {
      * add point to the data set
      *
      * @param index data point index at which the new data point should be added
-     * @param x horizontal coordinate of the new data point
-     * @param y vertical coordinate of the new data point
+     * @param newValue new data point coordinate
      * @return itself (fluent design)
      */
-    EditableDataSet add(final int index, final double x, final double y);
+    EditableDataSet add(final int index, final double ...newValue);
 
     /**
      * 
@@ -34,11 +33,10 @@ public interface EditableDataSet {
      * modify point in the the data set
      *
      * @param index data point index at which the new data point should be added
-     * @param x horizontal coordinate of the new data point
-     * @param y vertical coordinate of the new data point
+     * @param newValue new data point coordinate
      * @return itself (fluent design)
      */
-    EditableDataSet set(final int index, final double x, final double y);
+    EditableDataSet set(final int index, final double ...newValue);
 
     /**
      * 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
@@ -2,6 +2,7 @@ package de.gsi.dataset.spi;
 
 import java.util.ArrayDeque;
 
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.event.AddedDataEvent;
 
@@ -116,11 +117,11 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
     }
 
     @Override
-    public double getX(int i) {
+    public final double get(final int dimIndex, final int index) {
         if (dataset == null) {
-            return 0;
+            return Double.NaN;
         }
-        return dataset.getX(i);
+        return dimIndex == DataSet.DIM_X ? dataset.getX(index) : dataset.getY(index);
     }
 
     @Override
@@ -129,14 +130,6 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
             return 0;
         }
         return dataset.getXIndex(x);
-    }
-
-    @Override
-    public double getY(int i) {
-        if (dataset == null) {
-            return 0;
-        }
-        return dataset.getY(i);
     }
 
     @Override
@@ -174,6 +167,7 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
     }
 
     private class InternalDataSet extends DoubleDataSet {
+        private static final long serialVersionUID = 1L;
 
         public InternalDataSet(DataSet2D ds) {
             super(ds.getName(), ds.getXValues(), ds.getYValues(), ds.getDataCount(), true);
@@ -217,7 +211,5 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
                 yValues.elements()[i] -= d.getY(i);
             }
         }
-
     }
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
@@ -170,7 +170,7 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
         private static final long serialVersionUID = 1L;
 
         public InternalDataSet(DataSet2D ds) {
-            super(ds.getName(), ds.getXValues(), ds.getYValues(), ds.getDataCount(), true);
+            super(ds.getName(), ds.getValues(DataSet.DIM_X), ds.getValues(DataSet.DIM_Y), ds.getDataCount(), true);
             // xValues = new double[ds.getDataCount()];
             // yValues = new double[ds.getDataCount()];
             // for (int i=0;i<yValues.length;i++)

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
@@ -1,6 +1,7 @@
 package de.gsi.dataset.spi;
 
 import de.gsi.dataset.AxisDescription;
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.DataSetError;
 import de.gsi.dataset.event.AddedDataEvent;
@@ -176,6 +177,11 @@ public class CircularDoubleErrorDataSet extends AbstractErrorDataSet<CircularDou
     @Override
     public String getStyle(final int index) {
         return dataStyles.get(index);
+    }
+
+    @Override
+    public final double get(final int dimIndex, final int index) {
+        return dimIndex == DataSet.DIM_X ? xValues.get(index) : yValues.get(index);
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
@@ -184,16 +184,6 @@ public class CircularDoubleErrorDataSet extends AbstractErrorDataSet<CircularDou
         return dimIndex == DataSet.DIM_X ? xValues.get(index) : yValues.get(index);
     }
 
-    @Override
-    public double getX(final int index) {
-        return xValues.get(index);
-    }
-
-    @Override
-    public double getY(final int index) {
-        return yValues.get(index);
-    }
-
     /**
      * resets all data
      * 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
@@ -263,16 +263,6 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
         return dimIndex == DataSet.DIM_X ? xValues.elements() : yValues.elements();
     }
 
-    @Override
-    public double[] getXValues() {
-        return xValues.elements();
-    }
-
-    @Override
-    public double[] getYValues() {
-        return yValues.elements();
-    }
-
     /**
      * @param amount storage capacity increase
      * @return itself (fluent design)

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
@@ -18,7 +18,7 @@ import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
  * @author rstein
  */
 @SuppressWarnings("PMD.TooManyMethods") // part of the flexible class nature
-public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements EditableDataSet {
+public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements EditableDataSet, DataSet2D {
     private static final long serialVersionUID = -493232313124620828L;
     protected DoubleArrayList xValues; // way faster than java default lists
     protected DoubleArrayList yValues; // way faster than java default lists
@@ -253,18 +253,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
     }
 
     @Override
-    public double getX(final int index) {
-        return xValues.elements()[index];
-    }
-
-    @Override
     public double[] getXValues() {
         return xValues.elements();
-    }
-
-    @Override
-    public double getY(final int index) {
-        return yValues.elements()[index];
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
@@ -154,11 +154,22 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
      * add point to the data set
      *
      * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
+    @Override
+    public DoubleDataSet add(final int index, final double... newValue) {
+        return add(index, newValue[0], newValue[1], null);
+    }
+
+    /**
+     * add point to the data set
+     *
+     * @param index data point index at which the new data point should be added
      * @param x horizontal coordinate of the new data point
      * @param y vertical coordinate of the new data point
      * @return itself (fluent design)
      */
-    @Override
     public DoubleDataSet add(final int index, final double x, final double y) {
         return add(index, x, y, null);
     }
@@ -424,12 +435,23 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
     /**
      * replaces point coordinate of existing data point
      *
+     * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
+    @Override
+    public DoubleDataSet set(final int index, final double... newValue) {
+        return set(index, newValue[0], newValue[1]);
+    }
+
+    /**
+     * replaces point coordinate of existing data point
+     *
      * @param index the index of the data point
      * @param x new horizontal coordinate
      * @param y new vertical coordinate N.B. errors are implicitly assumed to be zero
      * @return itself (fluent design)
      */
-    @Override
     public DoubleDataSet set(final int index, final double x, final double y) {
         lock().writeLockGuard(() -> {
             final int dataCount = Math.max(index + 1, this.getDataCount());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
@@ -125,8 +125,9 @@ public class DoubleDataSet3D extends AbstractDataSet3D<DoubleDataSet3D> {
             return yValues[index];
         case DIM_Z:
             return zValues[index / xValues.length][index % xValues.length];
+        default:
+            return Double.NaN;
         }
-        return Double.NaN;
     }
 
     @Override
@@ -143,8 +144,9 @@ public class DoubleDataSet3D extends AbstractDataSet3D<DoubleDataSet3D> {
             return Arrays.copyOf(yValues, yValues.length);
         case DIM_Z:
             return super.getValues(dimIndex);
+        default:
+            return new double[0];
         }
-        return new double[0];
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
@@ -124,7 +124,7 @@ public class DoubleDataSet3D extends AbstractDataSet3D<DoubleDataSet3D> {
         case DIM_Y:
             return yValues[index];
         case DIM_Z:
-            return zValues[index/xValues.length][index%xValues.length];
+            return zValues[index / xValues.length][index % xValues.length];
         }
         return Double.NaN;
     }
@@ -135,18 +135,16 @@ public class DoubleDataSet3D extends AbstractDataSet3D<DoubleDataSet3D> {
     }
 
     @Override
-    public double[] getXValues() {
-        return Arrays.copyOf(xValues, xValues.length);
-    }
-
-    @Override
-    public double getY(final int i) {
-        return yValues[i];
-    }
-
-    @Override
-    public double[] getYValues() {
-        return Arrays.copyOf(yValues, yValues.length);
+    public double[] getValues(final int dimIndex) {
+        switch (dimIndex) {
+        case DIM_X:
+            return Arrays.copyOf(xValues, xValues.length);
+        case DIM_Y:
+            return Arrays.copyOf(yValues, yValues.length);
+        case DIM_Z:
+            return super.getValues(dimIndex);
+        }
+        return new double[0];
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet3D.java
@@ -117,6 +117,19 @@ public class DoubleDataSet3D extends AbstractDataSet3D<DoubleDataSet3D> {
     }
 
     @Override
+    public final double get(final int dimIndex, final int index) {
+        switch (dimIndex) {
+        case DIM_X:
+            return xValues[index];
+        case DIM_Y:
+            return yValues[index];
+        case DIM_Z:
+            return zValues[index/xValues.length][index%xValues.length];
+        }
+        return Double.NaN;
+    }
+
+    @Override
     public double getX(final int i) {
         return xValues[i];
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
@@ -20,7 +20,7 @@ import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
  */
 @SuppressWarnings("PMD.TooManyMethods") // part of the flexible class nature
 public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
-        implements DataSetError, EditableDataSet {
+        implements DataSetError, EditableDataSet, DataSet2D {
     private static final long serialVersionUID = 8931518518245752926L;
     protected DoubleArrayList xValues; // way faster than java default lists
     protected DoubleArrayList yValues; // way faster than java default lists

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
@@ -195,11 +195,22 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
      * add point to the data set
      *
      * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
+    @Override
+    public DoubleErrorDataSet add(final int index, final double... newValue) {
+        return add(index, newValue[0], newValue[1]);
+    }
+
+    /**
+     * add point to the data set
+     *
+     * @param index data point index at which the new data point should be added
      * @param x horizontal coordinate of the new data point
      * @param y vertical coordinate of the new data point
      * @return itself (fluent design)
      */
-    @Override
     public DoubleErrorDataSet add(int index, double x, double y) {
         return add(index, x, y, 0.0, 0.0, null);
     }
@@ -542,13 +553,24 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
 
     /**
      * replaces point coordinate of existing data point
+     *
+     * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
+    @Override
+    public DoubleErrorDataSet set(final int index, final double... newValue) {
+        return set(index, newValue[0], newValue[1]);
+    }
+
+    /**
+     * replaces point coordinate of existing data point
      * 
      * @param index the index of the data point
      * @param x new horizontal coordinate
      * @param y new vertical coordinate N.B. errors are implicitly assumed to be zero
      * @return itself (fluent design)
      */
-    @Override
     public DoubleErrorDataSet set(int index, double x, double y) {
         return set(index, x, y, 0.0, 0.0);
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.gsi.dataset.AxisDescription;
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.DataSetError;
 import de.gsi.dataset.event.AddedDataEvent;
@@ -207,13 +208,8 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
     }
 
     @Override
-    public double getX(final int index) {
-        return data.get(index).getX();
-    }
-
-    @Override
-    public double getY(final int index) {
-        return data.get(index).getY();
+    public final double get(final int dimIndex, final int index) {
+        return dimIndex == DataSet.DIM_X ? data.get(index).getX() : data.get(index).getY();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
@@ -18,7 +18,7 @@ import it.unimi.dsi.fastutil.floats.FloatArrayList;
  * @see DoubleErrorDataSet for an equivalent implementation with asymmetric errors in Y
  * @author rstein
  */
-public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements EditableDataSet {
+public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements EditableDataSet, DataSet2D {
     private static final long serialVersionUID = 7625465583757088697L;
     protected FloatArrayList xValues; // faster compared to java default
     protected FloatArrayList yValues; // faster compared to java default
@@ -250,8 +250,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
     }
 
     @Override
-    public double getX(final int index) {
-        return xValues.elements()[index];
+    public double get(final int dimIndex, final int index) {
+        return dimIndex == DIM_X ? xValues.elements()[index] : yValues.elements()[index];
     }
 
     public float[] getXFloatValues() {
@@ -261,11 +261,6 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
     @Override
     public double[] getXValues() {
         return toDoubles(xValues.elements());
-    }
-
-    @Override
-    public double getY(final int index) {
-        return yValues.elements()[index];
     }
 
     public float[] getYFloatValues() {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
@@ -158,11 +158,22 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
      * add point to the data set
      *
      * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
+    @Override
+    public FloatDataSet add(final int index, final double... newValue) {
+        return add(index, (float) newValue[0], (float) newValue[1], null);
+    }
+
+    /**
+     * add point to the data set
+     *
+     * @param index data point index at which the new data point should be added
      * @param x horizontal coordinate of the new data point
      * @param y vertical coordinate of the new data point
      * @return itself (fluent design)
      */
-    @Override
     public FloatDataSet add(final int index, final double x, final double y) {
         return add(index, (float) x, (float) y, null);
     }
@@ -237,6 +248,11 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
         return fireInvalidated(new RemovedDataEvent(this, "clearData()"));
     }
 
+    @Override
+    public double get(final int dimIndex, final int index) {
+        return dimIndex == DIM_X ? xValues.elements()[index] : yValues.elements()[index];
+    }
+
     /**
      * @return storage capacity of dataset
      */
@@ -247,11 +263,6 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
     @Override
     public int getDataCount() {
         return Math.min(xValues.size(), yValues.size());
-    }
-
-    @Override
-    public double get(final int dimIndex, final int index) {
-        return dimIndex == DIM_X ? xValues.elements()[index] : yValues.elements()[index];
     }
 
     public float[] getXFloatValues() {
@@ -422,7 +433,18 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
         return fireInvalidated(new UpdatedDataEvent(this));
     }
 
+    /**
+     * replaces point coordinate of existing data point
+     *
+     * @param index data point index at which the new data point should be added
+     * @param newValue new data point coordinate
+     * @return itself (fluent design)
+     */
     @Override
+    public FloatDataSet set(final int index, final double... newValue) {
+        return set(index, newValue[0], newValue[1]);
+    }
+
     public FloatDataSet set(final int index, final double x, final double y) {
         lock().writeLockGuard(() -> {
             final int dataCount = Math.max(index + 1, this.getDataCount());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.event.AddedDataEvent;
 import de.gsi.dataset.event.UpdatedDataEvent;
@@ -22,7 +23,7 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     // protected double xmax;
     // protected double ymin;
     // protected double ymax;
-    protected final ArrayList<DataSet2D> list = new ArrayList<>();
+    protected final ArrayList<DataSet> list = new ArrayList<>();
 
     /**
      * @param name data set name
@@ -34,7 +35,7 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     /**
      * @param set new data set to be added to list
      */
-    public void add(final DataSet2D set) {
+    public void add(final DataSet set) {
         lock().writeLockGuard(() -> {
             list.add(set);
             /* Trace data is expected to be sorted in ascending order */
@@ -88,13 +89,13 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     /**
      * @return sub-datasets
      */
-    public Collection<DataSet2D> getDatasets() {
+    public Collection<DataSet> getDatasets() {
         return list;
     }
 
     @Override
     public String getStyle(int i) {
-        for (final DataSet2D dataset : list) {
+        for (final DataSet dataset : list) {
             if (i < dataset.getDataCount()) {
                 return dataset.getStyle(i);
             }
@@ -104,14 +105,15 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     }
 
     @Override
-    public double getX(int i) {
-        for (final DataSet2D dataset : list) {
+    public double get(final int dimIndex, final int index) {
+        int i = index;
+        for (final DataSet dataset : list) {
             if (i < dataset.getDataCount()) {
-                return dataset.getX(i);
+                return dataset.get(dimIndex, i);
             }
             i -= dataset.getDataCount();
         }
-        return 0;
+        return Double.NaN;
     }
 
     @Override
@@ -121,9 +123,9 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
                 return 0;
             }
             int index = 0;
-            for (final DataSet2D dataset : list) {
+            for (final DataSet dataset : list) {
                 if (x >= dataset.getAxisDescription(0).getMin() && x <= dataset.getAxisDescription(0).getMax()) {
-                    return index + dataset.getXIndex(x);
+                    return index + dataset.getIndex(DIM_X, x);
                 }
                 index += dataset.getDataCount();
             }
@@ -136,9 +138,9 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
         return lock().readLockGuard(() -> {
             final double[] tmp = new double[dataCount];
             int index = 0;
-            for (final DataSet2D dataset : list) {
+            for (final DataSet dataset : list) {
                 for (int i = 0; i < dataset.getDataCount(); i++) {
-                    tmp[index++] = dataset.getX(i);
+                    tmp[index++] = dataset.get(DIM_X, i);
                 }
             }
             return tmp;
@@ -146,24 +148,13 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     }
 
     @Override
-    public double getY(int i) {
-        for (final DataSet2D dataset : list) {
-            if (i < dataset.getDataCount()) {
-                return dataset.getY(i);
-            }
-            i -= dataset.getDataCount();
-        }
-        return 0;
-    }
-
-    @Override
     public double[] getYValues() {
         return lock().readLockGuard(() -> {
             final double[] tmp = new double[dataCount];
             int index = 0;
-            for (final DataSet2D dataset : list) {
+            for (final DataSet dataset : list) {
                 for (int i = 0; i < dataset.getDataCount(); i++) {
-                    tmp[index++] = dataset.getY(i);
+                    tmp[index++] = dataset.get(DIM_Y, i);
                 }
             }
             return tmp;

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
@@ -69,6 +69,11 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
         return fireInvalidated(new RemovedDataEvent(this, "clear"));
     }
 
+    @Override
+    public double get(final int dimIndex, final int index) {
+        return dimIndex == DIM_X ? data.get(index).getX() : data.get(index).getY();
+    }
+
     /**
      * @return list containing data point values
      */
@@ -79,6 +84,12 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
     @Override
     public int getDataCount() {
         return data.size();
+    }
+
+    @Override
+    public int getDataCount(int dimIndex) {
+        // TODO Auto-generated method stub
+        return dataLabels.size();
     }
 
     /**
@@ -122,16 +133,6 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
     @Override
     public String getStyle(final int index) {
         return dataStyles.get(index);
-    }
-
-    @Override
-    public double getX(final int index) {
-        return data.get(index).getX();
-    }
-
-    @Override
-    public double getY(final int index) {
-        return data.get(index).getY();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
@@ -212,6 +212,11 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
         });
     }
 
+    @Override
+    public double get(final int dimIndex, final int i) {
+        return dimIndex == DIM_X ? data.get(i).getX() : data.get(i).getY();
+    }
+
     /**
      * @return data container
      */
@@ -275,22 +280,6 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
     @Override
     public String getStyle(final int index) {
         return data.get(index).getStyle();
-    }
-
-    /**
-     * @return the x coordinate
-     */
-    @Override
-    public double getX(final int i) {
-        return data.get(i).getX();
-    }
-
-    /**
-     * @return the y coordinate
-     */
-    @Override
-    public double getY(final int i) {
-        return data.get(i).getY();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
@@ -187,6 +187,11 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
         return fireInvalidated(new RemovedDataEvent(this, "clearData()"));
     }
 
+    @Override
+    public double get(final int dimIndex, final int index) {
+        return dimIndex == DIM_X ? data.get(index).getX() : data.get(index).getY();
+    }
+
     /**
      * @return list containing data point definition
      */
@@ -226,16 +231,6 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
     @Override
     public String getStyle(final int index) {
         return dataStyles.get(index);
-    }
-
-    @Override
-    public double getX(final int index) {
-        return data.get(index).getX();
-    }
-
-    @Override
-    public double getY(final int index) {
-        return data.get(index).getY();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
@@ -317,20 +317,9 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
         return lock().readLockGuard(() -> dataStyles.get(index));
     }
 
-    /**
-     * @return the x coordinate
-     */
     @Override
-    public double getX(final int i) {
-        return data.get(i).getX();
-    }
-
-    /**
-     * @return the y coordinate
-     */
-    @Override
-    public double getY(final int i) {
-        return data.get(i).getY();
+    public double get(final int dimIndex, final int i) {
+        return dimIndex == DIM_X ? data.get(i).getX() : data.get(i).getY();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
@@ -9,7 +9,6 @@
 package de.gsi.dataset.spi;
 
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.event.AddedDataEvent;
 import de.gsi.dataset.event.UpdatedDataEvent;
 
@@ -62,9 +61,9 @@ public class RollingDataSet extends FragmentedDataSet {
     // }
 
     @Override
-    public void add(final DataSet2D set) {
+    public void add(final DataSet set) {
         while (list.size() >= depth) {
-            final DataSet2D ds = list.remove(0);
+            final DataSet ds = list.remove(0);
             dataCount -= ds.getDataCount();
         }
         for (final DataSet ds : list) {
@@ -101,7 +100,7 @@ public class RollingDataSet extends FragmentedDataSet {
 
     private class InternalDataSet extends DoubleDataSet {
 
-        public InternalDataSet(DataSet2D ds) {
+        public InternalDataSet(DataSet ds) {
             super(ds);
             recomputeLimits(0);
             recomputeLimits(1);

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
@@ -234,7 +234,7 @@ public class DataSetEqualityTests {
 
     private class OneDimDataSet extends AbstractDataSet<OneDimDataSet> implements DataSet {
         private static final long serialVersionUID = 1L;
-        final double[] data = new double[] { 2.4, 5.2, 8.5, 9.2 };
+        final private double[] data = new double[] { 2.4, 5.2, 8.5, 9.2 };
 
         public OneDimDataSet() {
             super("test", 1);

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +54,12 @@ public class DataSetEqualityTests {
         assertEquals(new LimitedIndexedTreeDataSet("default", 10), new LimitedIndexedTreeDataSet("default", 11));
         assertEquals(new RollingDataSet("default"), new RollingDataSet("default"));
         assertEquals(new WrappedDataSet("default"), new WrappedDataSet("default"));
+        assertEquals(
+                new DoubleDataSet3D("test", new double[] { 1, 2, 3 }, new double[] { 6, 7, 8 },
+                        new double[][] { new double[] { 1, 2, 3 }, new double[] { 6, 5, 4 },
+                                new double[] { 9, 8, 7 } }),
+                new DoubleDataSet3D("test", new double[] { 1, 2, 3 }, new double[] { 6, 7, 8 }, new double[][] {
+                        new double[] { 1, 2, 3 }, new double[] { 6, 5, 4 }, new double[] { 9, 8, 7 } }));
 
     }
 
@@ -219,18 +227,14 @@ public class DataSetEqualityTests {
         }
 
         @Override
-        public boolean isXEditable() {
+        public boolean isEditable(final int dimIndex) {
             return false;
         }
-
-        @Override
-        public boolean isYEditable() {
-            return false;
-        }
-
     }
 
-    private class OneDimDataSet extends AbstractDataSet implements DataSet {
+    private class OneDimDataSet extends AbstractDataSet<OneDimDataSet> implements DataSet {
+        private static final long serialVersionUID = 1L;
+        final double[] data = new double[] { 2.4, 5.2, 8.5, 9.2 };
 
         public OneDimDataSet() {
             super("test", 1);
@@ -238,22 +242,32 @@ public class DataSetEqualityTests {
 
         @Override
         public double get(int dimIndex, int index) {
-            return 0;
+            if (dimIndex != 0) {
+                throw new IndexOutOfBoundsException("Dimension index out of bound");
+            }
+            return data[index];
         }
 
         @Override
         public int getDataCount(int dimIndex) {
-            return 0;
+            if (dimIndex != 0) {
+                throw new IndexOutOfBoundsException("Dimension index out of bound");
+            }
+            return data.length;
         }
 
         @Override
         public int getIndex(int dimIndex, double value) {
-            return 0;
+            if (dimIndex != 0) {
+                throw new IndexOutOfBoundsException("Dimension index out of bound");
+            }
+            return Math.abs(Arrays.binarySearch(data, value));
         }
 
         @Override
         public double getValue(int dimIndex, double x) {
-            return 0;
+            return (x - Math.floor(x)) * get(dimIndex, (int) Math.floor(x))
+                    + (Math.ceil(x) - x) * get(dimIndex, (int) Math.ceil(x));
         }
     }
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ContourChartSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ContourChartSample.java
@@ -10,7 +10,6 @@ import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
 import de.gsi.chart.plugins.ColormapSelector.ColormapComboBox;
 import de.gsi.chart.plugins.EditAxis;
-import de.gsi.chart.plugins.Panner;
 import de.gsi.chart.plugins.Zoomer;
 import de.gsi.chart.renderer.ContourType;
 import de.gsi.chart.renderer.spi.ContourDataSetRenderer;
@@ -347,7 +346,19 @@ public class ContourChartSample extends Application {
             xValues[xIndex] = x;
             yValues[yIndex] = y;
             zValues[xIndex][yIndex] = z;
+        }
 
+        @Override
+        public double get(int dimIndex, int index) {
+            switch (dimIndex) {
+            case DIM_X:
+                return xValues[index].doubleValue();
+            case DIM_Y:
+                return yValues[index].doubleValue();
+            case DIM_Z:
+                return zValues[index / xValues.length][index % xValues.length];
+            }
+            throw new IndexOutOfBoundsException("Dimension Index out of bounds 3, was " + dimIndex);
         }
     }
 }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
@@ -9,6 +9,7 @@ import de.gsi.chart.plugins.UpdateAxisLabels;
 import de.gsi.chart.plugins.Zoomer;
 import de.gsi.chart.renderer.Renderer;
 import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.spi.DoubleDataSet;
 import javafx.application.Application;
@@ -89,15 +90,9 @@ public class EditDataSetSample extends Application {
             }
 
             @Override
-            public boolean isXEditable() {
+            public boolean isEditable(final int dimIndex) {
                 // only allow editing in Y
-                return false;
-            }
-
-            @Override
-            public boolean isYEditable() {
-                // only allow editing in Y
-                return true;
+                return dimIndex == DataSet.DIM_X ? false : true;
             }
         });
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
@@ -50,11 +50,9 @@ public class EditDataSetSample extends Application {
         // Add data Sets to different Renderers to allow automatic axis names and units
         Renderer renderer1 = new ErrorDataSetRenderer();
         Renderer renderer2 = new ErrorDataSetRenderer();
-//        renderer1.getDatasets().add(dataSet1);
-        renderer2.getDatasets().add(dataSet2);
-        chart.getRenderers().addAll(renderer1, renderer2);
-
         renderer1.getDatasets().add(dataSet1);
+        chart.getRenderers().addAll(renderer1, renderer2);
+        renderer2.getDatasets().add(dataSet2);
 
         final double[] xValues = new double[N_SAMPLES];
         final double[] yValues1 = new double[N_SAMPLES];

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/NotANumberSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/NotANumberSample.java
@@ -19,7 +19,7 @@ import javafx.stage.Stage;
 /**
  * Test/demo that explicitly allows to draw NaN values in DataSets as well as custom dash-based line-styling
  * <p>
- * Note: this works fine for >JDK11/JFX11 but consistently crashes the JDK8/JavaFX framework outside this library
+ * Note: this works fine for &gt;JDK11/JFX11 but consistently crashes the JDK8/JavaFX framework outside this library
  * whenever e.g performing a zoom, panning or other similar operation (ie. one of the reasons for the NaN workaround in
  * earlier chart-fx versions).
  * 

--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleDataSet.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleDataSet.java
@@ -23,7 +23,7 @@ import de.gsi.dataset.utils.AssertUtils;
  * @deprecated this is kept for reference/performance comparisons only
  */
 @SuppressWarnings("PMD")
-public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements EditableDataSet {
+public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements EditableDataSet, DataSet2D {
     private static final long serialVersionUID = 467969092912080826L;
     protected double[] xValues;
     protected double[] yValues;
@@ -171,13 +171,12 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
      * add point to the data set
      *
      * @param index data point index at which the new data point should be added
-     * @param x horizontal coordinate of the new data point
-     * @param y vertical coordinate of the new data point
+     * @param newValues coordinate of the new data point
      * @return itself (fluent design)
      */
     @Override
-    public DoubleDataSet add(final int index, final double x, final double y) {
-        return add(index, x, y, null);
+    public DoubleDataSet add(final int index, final double... newValues) {
+        return add(index, newValues[0], newValues[1], null);
     }
 
     /**
@@ -259,23 +258,18 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
     }
 
     @Override
+    public double get(final int dimImdex, final int index) {
+        return dimImdex == DIM_X ? xValues[index] : yValues[index];
+    }
+
+    @Override
     public int getDataCount() {
         return Math.min(dataMaxIndex, xValues.length);
     }
 
     @Override
-    public double getX(final int index) {
-        return xValues[index];
-    }
-
-    @Override
     public double[] getXValues() {
         return xValues;
-    }
-
-    @Override
-    public double getY(final int index) {
-        return yValues[index];
     }
 
     @Override
@@ -429,10 +423,10 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
     }
 
     @Override
-    public DoubleDataSet set(final int index, final double x, final double y) {
+    public DoubleDataSet set(final int index, final double... newValue) {
         lock().writeLockGuard(() -> {
-            xValues[index] = x;
-            yValues[index] = y;
+            xValues[index] = newValue[0];
+            yValues[index] = newValue[1];
             dataMaxIndex = Math.max(index, dataMaxIndex);
 
             getAxisDescriptions().forEach(AxisDescription::clear);

--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleErrorDataSet.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleErrorDataSet.java
@@ -24,7 +24,7 @@ import de.gsi.dataset.utils.AssertUtils;
  */
 @SuppressWarnings("PMD")
 public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
-        implements DataSetError, EditableDataSet {
+        implements DataSetError, EditableDataSet, DataSet2D {
     protected double[] xValues;
     protected double[] yValues;
     protected double[] yErrorsPos;
@@ -223,7 +223,7 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
     }
 
     @Override
-    public EditableDataSet add(int index, double x, double y) {
+    public EditableDataSet add(int index, double... newValue) {
         return null;
     }
 
@@ -246,6 +246,11 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             getAxisDescription(1).clear();
         });
         return fireInvalidated(new RemovedDataEvent(this, "clearData()"));
+    }
+
+    @Override
+    public double get(final int dimIndex, final int index) {
+        return dimIndex == DIM_X ? xValues[index] : yValues[index];
     }
 
     @Override
@@ -274,18 +279,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
     }
 
     @Override
-    public double getX(final int index) {
-        return xValues[index];
-    }
-
-    @Override
     public double[] getXValues() {
         return xValues;
-    }
-
-    @Override
-    public double getY(final int index) {
-        return yValues[index];
     }
 
     @Override
@@ -454,13 +449,12 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
      * replaces point coordinate of existing data point
      * 
      * @param index the index of the data point
-     * @param x new horizontal coordinate
-     * @param y new vertical coordinate N.B. errors are implicitly assumed to be zero
+     * @param newValue new point coordinates
      * @return itself (fluent design)
      */
     @Override
-    public DoubleErrorDataSet set(int index, double x, double y) {
-        return set(index, x, y, 0.0, 0.0);
+    public DoubleErrorDataSet set(int index, double... newValue) {
+        return set(index, newValue[0], newValue[1], 0.0, 0.0);
     }
 
     /**


### PR DESCRIPTION
Because of inconsistent usage of the get(dimIndex, index) vs the getX/Y(index) interfaces, there where some bugs, e.g. DataSet.equals would run out of bounds for 3D DataSets.

This Pull request fixes this by only using the 2 argument version, leaving the single argument version only for external users and for convenience.