### PR TITLE
fix: vertical tick label clash

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -34,8 +34,10 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.scene.shape.Path;
 import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
@@ -652,6 +654,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         final AxisLabelOverlapPolicy overlapPolicy = getOverlapPolicy();
         final double tickLabelGap = getTickLabelGap();
         final double tickLabelRotation = getTickLabelRotation();
+        final boolean narrowFont = overlapPolicy.equals(AxisLabelOverlapPolicy.NARROW_FONT);
         int counter = 0;
 
         // save css-styled label parameters
@@ -670,13 +673,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // tickMarks)
         if (!tickMarks.isEmpty()) {
             final TickMark firstTick = tickMarks.get(0);
-            if (overlapPolicy.equals(AxisLabelOverlapPolicy.NARROW_FONT)) {
-                Font firstTickFont = firstTick.getFont();
-                Font narrowFont = Font.font(firstTickFont.getFamily(), FontWeight.THIN, firstTickFont.getSize());
-                gc.setFont(narrowFont);
-            } else {
-                gc.setFont(firstTick.getFont());
-            }
+
             gc.setFill(firstTick.getFill());
             // gc.setStroke(tickMark.getStroke());
             // gc.setLineWidth(tickMark.getStrokeWidth());
@@ -697,7 +694,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
                 final double x = axisWidth - tickLength - tickLabelGap;
                 final double y = position;
-                drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
             }
             break;
 
@@ -714,7 +711,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
                 final double x = tickLength + tickLabelGap;
                 final double y = position;
-                drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
             }
 
             break;
@@ -742,25 +739,25 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 double y = axisHeight - tickLength - tickLabelGap;
                 switch (overlapPolicy) {
                 case DO_NOTHING:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case NARROW_FONT:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SHIFT_ALT:
                     if (isLabelOverlapping()) {
                         y -= ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
                     }
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case FORCED_SHIFT_ALT:
                     y -= ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SKIP_ALT:
                 default:
                     if (((counter % 2) == 0) || !isLabelOverlapping()) {
-                        drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                        drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     }
                     break;
                 }
@@ -791,25 +788,25 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 double y = tickLength + tickLabelGap;
                 switch (overlapPolicy) {
                 case DO_NOTHING:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case NARROW_FONT:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SHIFT_ALT:
                     if (isLabelOverlapping()) {
                         y += ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
                     }
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case FORCED_SHIFT_ALT:
                     y += ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SKIP_ALT:
                 default:
                     if (((counter % 2) == 0) || !isLabelOverlapping()) {
-                        drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                        drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     }
                     break;
                 }
@@ -829,7 +826,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
                 final double x = (axisCentre * axisWidth) + tickLength + tickLabelGap;
                 final double y = position;
-                drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
             }
 
             break;
@@ -856,25 +853,25 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 double y = (axisCentre * axisHeight) + tickLength + tickLabelGap;
                 switch (overlapPolicy) {
                 case DO_NOTHING:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case NARROW_FONT:
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SHIFT_ALT:
                     if (isLabelOverlapping()) {
                         y += ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
                     }
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case FORCED_SHIFT_ALT:
                     y += ((counter % 2) * tickLabelGap) + ((counter % 2) * tickMark.getFont().getSize());
-                    drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                    drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     break;
                 case SKIP_ALT:
                 default:
                     if (((counter % 2) == 0) || !isLabelOverlapping()) {
-                        drawTickMarkLabel(gc, x, y, tickLabelRotation, tickMark);
+                        drawTickMarkLabel(gc, x, y, tickLabelRotation, narrowFont, tickMark);
                     }
                     break;
                 }
@@ -1271,9 +1268,8 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 labelOverlap = true;
             }
 
-            final boolean isShiftOverlapPolicy = (getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT)
-                    || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT);
-            if ((numLabelsToSkip > 0) && !isShiftOverlapPolicy) {
+            final boolean isSkipOverlapPolicy = (getOverlapPolicy() == AxisLabelOverlapPolicy.SKIP_ALT);
+            if ((numLabelsToSkip > 0) && isSkipOverlapPolicy) {
                 int tickIndex = 0;
                 for (final TickMark m : majorTickMarks) {
                     if (m.isVisible()) {
@@ -1436,10 +1432,18 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     }
 
     protected static void drawTickMarkLabel(final GraphicsContext gc, final double x, final double y,
-            final double rotation, final TickMark tickMark) {
+            final double rotation, final boolean narrowFont, final TickMark tickMark) {
         gc.save();
-        gc.setFont(tickMark.getFont());
-        gc.setFill(tickMark.getFill());
+        if (narrowFont) {
+            Font tickFont = tickMark.getFont();
+            Font narrow = Font.font("Arial", FontWeight.EXTRA_LIGHT, FontPosture.REGULAR, tickFont.getSize());
+            gc.setFont(narrow);
+            gc.setFill(Color.DARKRED);
+        } else {
+            gc.setFont(tickMark.getFont());
+            gc.setFill(tickMark.getFill());
+        }
+        
         gc.translate(x, y);
         if (rotation != 0.0) {
             gc.rotate(tickMark.getRotate());

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -35,6 +35,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Path;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import javafx.util.Duration;
@@ -668,7 +670,13 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // tickMarks)
         if (!tickMarks.isEmpty()) {
             final TickMark firstTick = tickMarks.get(0);
-            gc.setFont(firstTick.getFont());
+            if (overlapPolicy.equals(AxisLabelOverlapPolicy.NARROW_FONT)) {
+                Font firstTickFont = firstTick.getFont();
+                Font narrowFont = Font.font(firstTickFont.getFamily(), FontWeight.THIN, firstTickFont.getSize());
+                gc.setFont(narrowFont);
+            } else {
+                gc.setFont(firstTick.getFont());
+            }
             gc.setFill(firstTick.getFill());
             // gc.setStroke(tickMark.getStroke());
             // gc.setLineWidth(tickMark.getStrokeWidth());
@@ -677,6 +685,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
         switch (getSide()) {
         case LEFT:
+            // TODO: enable/deploy overlap policies
             gc.setTextAlign(TextAlignment.RIGHT);
             gc.setTextBaseline(VPos.CENTER);
             for (final TickMark tickMark : tickMarks) {
@@ -693,6 +702,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             break;
 
         case RIGHT:
+            // TODO: enable/deploy overlap policies
             gc.setTextAlign(TextAlignment.LEFT);
             gc.setTextBaseline(VPos.CENTER);
             for (final TickMark tickMark : tickMarks) {
@@ -1248,7 +1258,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             for (final TickMark m : majorTickMarks) {
                 m.setPosition(getDisplayPosition(m.getValue()));
                 if (m.isVisible()) {
-                    final double tickSize = side.isHorizontal() ? m.getWidth() : m.getHeight();
+                    final double tickSize = side.isHorizontal() ? m.getWidth() : m.getHeight() + 2 * getTickLabelGap();
                     totalLabelsSize += tickSize;
                     maxLabelSize = Math.round(Math.max(maxLabelSize, tickSize));
                 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/DefaultNumericAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/DefaultNumericAxis.java
@@ -37,7 +37,6 @@ import javafx.scene.chart.NumberAxis;
 public class DefaultNumericAxis extends AbstractAxis implements Axis {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNumericAxis.class);
     public static final double DEFAULT_LOG_MIN_VALUE = 1e-6;
-    private static final int MAX_TICK_COUNT = 20;
     private static final int DEFAULT_RANGE_LENGTH = 2;
     private double offset;
     private final Cache cache = new Cache();
@@ -280,7 +279,7 @@ public class DefaultNumericAxis extends AbstractAxis implements Axis {
     public double computePreferredTickUnit(final double axisLength) {
         final double labelSize = getTickLabelFont().getSize() * 2;
         final int numOfFittingLabels = (int) Math.floor(axisLength / labelSize);
-        final int numOfTickMarks = Math.max(Math.min(numOfFittingLabels, DefaultNumericAxis.MAX_TICK_COUNT), 2);
+        final int numOfTickMarks = Math.max(Math.min(numOfFittingLabels, getMaxMaxjorTickLabelCount()), 2);
         double rawTickUnit = (getMax() - getMin()) / numOfTickMarks;
         if (rawTickUnit == 0 || Double.isNaN(rawTickUnit)) {
             rawTickUnit = 1e-3;// TODO: remove this hack (eventually) ;-)
@@ -315,7 +314,7 @@ public class DefaultNumericAxis extends AbstractAxis implements Axis {
     private AxisRange computeRangeImpl(final double min, final double max, final double axisLength,
             final double labelSize) {
         final int numOfFittingLabels = (int) Math.floor(axisLength / labelSize);
-        final int numOfTickMarks = Math.max(Math.min(numOfFittingLabels, DefaultNumericAxis.MAX_TICK_COUNT), 2);
+        final int numOfTickMarks = Math.max(Math.min(numOfFittingLabels, getMaxMaxjorTickLabelCount()), 2);
 
         double rawTickUnit = (max - min) / numOfTickMarks;
         if (rawTickUnit == 0 || Double.isNaN(rawTickUnit)) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/DefaultNumericAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/DefaultNumericAxis.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.gsi.chart.axes.Axis;
 import de.gsi.chart.axes.AxisTransform;
 import de.gsi.chart.axes.LogAxisType;
 import de.gsi.chart.axes.TickUnitSupplier;
@@ -33,7 +34,7 @@ import javafx.scene.chart.NumberAxis;
  * 
  * @author rstein
  */
-public class DefaultNumericAxis extends AbstractAxis {
+public class DefaultNumericAxis extends AbstractAxis implements Axis {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNumericAxis.class);
     public static final double DEFAULT_LOG_MIN_VALUE = 1e-6;
     private static final int MAX_TICK_COUNT = 20;

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/TickMark.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/TickMark.java
@@ -1,6 +1,9 @@
 package de.gsi.chart.axes.spi;
 
+import de.gsi.chart.ui.geometry.Side;
+import javafx.geometry.VPos;
 import javafx.scene.text.Text;
+import javafx.scene.text.TextAlignment;
 
 /**
  * TickMark represents the label text, its associated tick mark value and position along the axis for each tick.
@@ -8,21 +11,43 @@ import javafx.scene.text.Text;
  * @author rstein
  */
 public class TickMark extends Text {
-    private Double tickValue; // tick mark in data units
+    private final Side side; // tick mark side (LEFT, TOP; RIGHT; BOTTOM)
+    private double tickValue; // tick mark in data units
     private double tickPosition; // tick position along axis in display units
+    private double tickRotation; // tick mark rotation (here: centre axis)
 
     /**
      * Creates and initialises an instance of TickMark.
-     * 
+     *
+     * @param side where tick mark is supposed to be drawn (N.B. controls text alignment together with rotation)
      * @param tickValue numeric value of tick
      * @param tickPosition position of tick in canvas pixel coordinates
      * @param tickMarkLabel string label associated with tick
      */
-    public TickMark(final double tickValue, final double tickPosition, final String tickMarkLabel) {
+    public TickMark(final Side side, final double tickValue, final double tickPosition, final double tickRotation,
+            final String tickMarkLabel) {
         super();
+        this.side = side;
         this.tickValue = tickValue;
         this.tickPosition = tickPosition;
+        this.tickRotation = tickRotation;
         setText(tickMarkLabel);
+        setRotate(tickRotation);
+        recomputeAlignment(); // NOPMD may be overwritten in user-code
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TickMark)) {
+            return false;
+        }
+        final TickMark other = (TickMark) obj;
+
+        return (tickPosition == other.tickPosition) && (tickRotation == other.tickRotation)
+                && (tickValue == other.tickValue);
     }
 
     /**
@@ -37,14 +62,29 @@ public class TickMark extends Text {
     /**
      * @return value tick position along the axis in display units
      */
-    public Double getPosition() {
+    public double getPosition() {
         return tickPosition;
+    }
+
+    /**
+     * @return value tick rotation
+     */
+    public double getRotation() {
+        return tickRotation;
+    }
+
+    /**
+     * @return side of axis where tick mark is supposed to be drawn (N.B. controls text alignment together with
+     *         rotation)
+     */
+    public Side getSide() {
+        return side;
     }
 
     /**
      * @return tick mark value in data units
      */
-    public Double getValue() {
+    public double getValue() {
         return tickValue;
     }
 
@@ -57,11 +97,92 @@ public class TickMark extends Text {
         return getBoundsInParent().getWidth();
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+
+        temp = Double.doubleToLongBits(tickPosition);
+        result = (prime * result) + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(tickRotation);
+        result = (prime * result) + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(tickValue);
+        result = (prime * result) + (int) (temp ^ (temp >>> 32));
+        final String text = getText();
+        result = (prime * result) + ((text == null) ? 0 : text.hashCode());
+
+        return result;
+    }
+
+    public void recomputeAlignment() {
+        // normalise rotation to [-360, +360]
+        final int rotation = ((int) getRotation() % 360);
+        switch (side) {
+        case TOP:
+            setTextAlignment(TextAlignment.CENTER);
+            setTextOrigin(VPos.BOTTOM);
+            //special alignment treatment if axes labels are to be rotated
+            if ((rotation != 0) && ((rotation % 90) == 0)) {
+                setTextAlignment(TextAlignment.LEFT);
+                setTextOrigin(VPos.CENTER);
+            } else if ((rotation % 90) != 0) {
+                // pivoting point to left-bottom label corner
+                setTextAlignment(TextAlignment.LEFT);
+                setTextOrigin(VPos.BOTTOM);
+            }
+            break;
+        case BOTTOM:
+        case CENTER_HOR:
+            setTextAlignment(TextAlignment.CENTER);
+            setTextOrigin(VPos.TOP);
+            // special alignment treatment if axes labels are to be rotated
+            if ((rotation != 0) && ((rotation % 90) == 0)) {
+                setTextAlignment(TextAlignment.LEFT);
+                setTextOrigin(VPos.CENTER);
+            } else if ((rotation % 90) != 0) {
+                // pivoting point to left-top label corner
+                setTextAlignment(TextAlignment.LEFT);
+                setTextOrigin(VPos.TOP);
+            }
+            break;
+        case LEFT:
+            setTextAlignment(TextAlignment.RIGHT);
+            setTextOrigin(VPos.CENTER);
+            // special alignment treatment if axes labels are to be rotated
+            if ((rotation != 0) && ((rotation % 90) == 0)) {
+                setTextAlignment(TextAlignment.CENTER);
+                setTextOrigin(VPos.BOTTOM);
+            }
+            break;
+        case RIGHT:
+        case CENTER_VER:
+            setTextAlignment(TextAlignment.LEFT);
+            setTextOrigin(VPos.CENTER);
+            // special alignment treatment if axes labels are to be rotated
+            if ((rotation != 0) && ((rotation % 90) == 0)) {
+                setTextAlignment(TextAlignment.CENTER);
+                setTextOrigin(VPos.TOP);
+            }
+            break;
+        default:
+        }
+    }
+
     /**
      * @param value tick position along the axis in display units
      */
     public void setPosition(final double value) {
         tickPosition = value;
+    }
+
+    /**
+     * @param value tick rotation
+     */
+    public void setRotation(final double value) {
+        tickRotation = value;
+        setRotate(tickRotation);
+        recomputeAlignment();
     }
 
     /**

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.AxisLabelOverlapPolicy;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.EditAxis;
 import de.gsi.chart.plugins.Zoomer;
 import de.gsi.chart.ui.geometry.Side;
 import de.gsi.dataset.spi.DoubleDataSet;
@@ -16,7 +17,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 /**
- * Simple example of how to rotate axis label and different label collision schemes
+ * Simple example of how to rotate axis label and different label collision-avoidance schemes
  *
  * @author rstein
  */
@@ -27,30 +28,56 @@ public class RotatedAxisLabelSample extends Application {
     @Override
     public void start(final Stage primaryStage) {
         final DefaultNumericAxis xAxis0 = new DefaultNumericAxis("default x-axis");
+        xAxis0.setSide(Side.TOP);
         final DefaultNumericAxis yAxis0 = new DefaultNumericAxis("default y-axis");
-        yAxis0.setTickLabelRotation(-90);
+        yAxis0.setSide(Side.RIGHT);
 
         final XYChart chart = new XYChart(xAxis0, yAxis0);
         chart.getPlugins().add(new Zoomer()); // standard plugin, useful for most cases
         final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1");
         chart.getDatasets().addAll(dataSet1);
 
+        // set additional axes
         for (AxisLabelOverlapPolicy policy : AxisLabelOverlapPolicy.values()) {
-            // set additional axes
-            final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis ("+policy+")");
+
+            final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis (" + policy + ")");
+            xAxis1.setSide(Side.BOTTOM);
             xAxis1.setOverlapPolicy(policy);
 
-            final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis ("+policy+")");
+            final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis (-90°, " + policy + ")");
+            yAxis1.setSide(Side.LEFT);
+            yAxis1.setTickLabelRotation(-90);
             yAxis1.setOverlapPolicy(policy);
 
             chart.getAxes().addAll(xAxis1, yAxis1);
         }
 
+        final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis (45°)");
+        xAxis1.setSide(Side.BOTTOM);
+        xAxis1.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
+        xAxis1.setTickLabelRotation(45);
+        xAxis1.setMaxMajorTickLabelCount(40);
+
+        final DefaultNumericAxis xAxis2 = getSynchedAxis(xAxis0, "x-axis (90°)");
+        xAxis2.setSide(Side.BOTTOM);
+        xAxis2.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
+        xAxis2.setTickLabelRotation(90);
+        xAxis2.setMaxMajorTickLabelCount(40);
+
+        chart.getAxes().addAll(xAxis1, xAxis2);
+
+        final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis (-45°)");
+        yAxis1.setSide(Side.LEFT);
+        yAxis1.setOverlapPolicy(AxisLabelOverlapPolicy.DO_NOTHING);
+        yAxis1.setTickLabelRotation(-45);
+
+        chart.getAxes().addAll(yAxis1);
+
         for (int n = 0; n < N_SAMPLES; n++) {
             dataSet1.add(12.34 * n, 1.33e3 * Math.cos(Math.toRadians(10.0 * n)));
         }
 
-        final Scene scene = new Scene(new StackPane(chart), 800, 600);
+        final Scene scene = new Scene(new StackPane(chart), 800, 800);
         primaryStage.setTitle(getClass().getSimpleName());
         primaryStage.setScene(scene);
         primaryStage.show();
@@ -60,10 +87,8 @@ public class RotatedAxisLabelSample extends Application {
 
     private static DefaultNumericAxis getSynchedAxis(DefaultNumericAxis orig, String newAxisName) {
         final DefaultNumericAxis axis = new DefaultNumericAxis(newAxisName);
-        axis.setSide(Side.LEFT);
         axis.minProperty().bind(orig.minProperty());
         axis.maxProperty().bind(orig.maxProperty());
-        axis.sideProperty().bind(orig.sideProperty());
         axis.setTickLabelRotation(orig.getTickLabelRotation());
 
         return axis;

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
@@ -1,0 +1,78 @@
+package de.gsi.chart.samples;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.AxisLabelOverlapPolicy;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.chart.ui.geometry.Side;
+import de.gsi.dataset.spi.DoubleDataSet;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * Simple example of how to rotate axis label and different label collision schemes
+ *
+ * @author rstein
+ */
+public class RotatedAxisLabelSample extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RotatedAxisLabelSample.class);
+    private static final int N_SAMPLES = 100; // default number of data points
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final DefaultNumericAxis xAxis0 = new DefaultNumericAxis("default x-axis");
+        final DefaultNumericAxis yAxis0 = new DefaultNumericAxis("default y-axis");
+        yAxis0.setTickLabelRotation(-90);
+
+        final XYChart chart = new XYChart(xAxis0, yAxis0);
+        chart.getPlugins().add(new Zoomer()); // standard plugin, useful for most cases
+        final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1");
+        chart.getDatasets().addAll(dataSet1);
+
+        for (AxisLabelOverlapPolicy policy : AxisLabelOverlapPolicy.values()) {
+            // set additional axes
+            final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis ("+policy+")");
+            xAxis1.setOverlapPolicy(policy);
+
+            final DefaultNumericAxis yAxis1 = getSynchedAxis(yAxis0, "y-axis ("+policy+")");
+            yAxis1.setOverlapPolicy(policy);
+
+            chart.getAxes().addAll(xAxis1, yAxis1);
+        }
+
+        for (int n = 0; n < N_SAMPLES; n++) {
+            dataSet1.add(12.34 * n, 1.33e3 * Math.cos(Math.toRadians(10.0 * n)));
+        }
+
+        final Scene scene = new Scene(new StackPane(chart), 800, 600);
+        primaryStage.setTitle(getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+        LOGGER.atInfo().addArgument(getClass().getSimpleName()).log("sample {} started");
+    }
+
+    private static DefaultNumericAxis getSynchedAxis(DefaultNumericAxis orig, String newAxisName) {
+        final DefaultNumericAxis axis = new DefaultNumericAxis(newAxisName);
+        axis.setSide(Side.LEFT);
+        axis.minProperty().bind(orig.minProperty());
+        axis.maxProperty().bind(orig.maxProperty());
+        axis.sideProperty().bind(orig.sideProperty());
+        axis.setTickLabelRotation(orig.getTickLabelRotation());
+
+        return axis;
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}


### PR DESCRIPTION
fixes TickLabel clashing when rotated by -90 see #49 

* added sample to illustrate tick label collision avoidance schemes
* shifted rotation and label alignment handling to TickMark
* 'drawTickLabels(..)' completed missing collision handling for LEFT and RIGHT and regrouped cases in
* changed default minimum label distance to 20% (was 100% earlier)
* added counter offset for SHIFT_ALT(_FORCED) cases to minimise "label jumping" effect when new labels are added or removed at the axis ranges
* added new (stylable) max major tick count property
