### PR TITLE
Feature chart auto zoom

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/Zoomer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/Zoomer.java
@@ -23,8 +23,10 @@ import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
@@ -75,17 +77,21 @@ public class Zoomer extends ChartPlugin {
     public static final String STYLE_CLASS_ZOOM_RECT = "chart-zoom-rect";
     private static final int ZOOM_RECT_MIN_SIZE = 5;
     private static final Duration DEFAULT_ZOOM_DURATION = Duration.millis(500);
+    private static final int DEFAULT_AUTO_ZOOM_THRESHOLD = 15; // [degrees]
     private static final int FONT_SIZE = 20;
 
     /**
      * Default pan mouse filter passing on left mouse button with {@link MouseEvent#isControlDown() control key down}.
      */
     public static final Predicate<MouseEvent> DEFAULT_MOUSE_FILTER = MouseEventsHelper::isOnlyMiddleButtonDown;
-    private Predicate<MouseEvent> mouseFilter = Panner.DEFAULT_MOUSE_FILTER;
+    private final Predicate<MouseEvent> mouseFilter = Panner.DEFAULT_MOUSE_FILTER;
     private double panShiftX;
     private double panShiftY;
     private Point2D previousMouseLocation;
-    private BooleanProperty enablePanner = new SimpleBooleanProperty(this, "enablePanner", true);
+    private final BooleanProperty enablePanner = new SimpleBooleanProperty(this, "enablePanner", true);
+    private final BooleanProperty autoZoomEnable = new SimpleBooleanProperty(this, "enableAutoZoom", false);
+    private final IntegerProperty autoZoomThreshold = new SimpleIntegerProperty(this, "autoZoomThreshold",
+            DEFAULT_AUTO_ZOOM_THRESHOLD);
     private final EventHandler<MouseEvent> panStartHandler = event -> {
         if (isPannerEnabled() && (mouseFilter == null || mouseFilter.test(event))) {
             panStarted(event);
@@ -143,10 +149,9 @@ public class Zoomer extends ChartPlugin {
     private final HBox zoomButtons = getZoomInteractorBar();
     private ZoomRangeSlider xRangeSlider;
     private boolean xRangeSliderInit;
-    private ObservableList<Axis> omitAxisZoom = FXCollections.observableArrayList();
+    private final ObservableList<Axis> omitAxisZoom = FXCollections.observableArrayList();
 
-    private final ObjectProperty<AxisMode> axisMode = new SimpleObjectProperty<AxisMode>(this, "axisMode",
-            AxisMode.XY) {
+    private final ObjectProperty<AxisMode> axisMode = new SimpleObjectProperty<>(this, "axisMode", AxisMode.XY) {
         @Override
         protected void invalidated() {
             Objects.requireNonNull(get(), "The " + getName() + " must not be null");
@@ -307,6 +312,20 @@ public class Zoomer extends ChartPlugin {
     }
 
     /**
+     * When {@code true} auto-zooming feature is being enabled,
+     * ie. more horizontal drags do x-zoom only, more vertical drags do y-zoom only, and xy-zoom otherwise
+     *
+     * @return the autoZoom property
+     */
+    public final BooleanProperty autoZoomEnabledProperty() {
+        return autoZoomEnable;
+    }
+
+    public IntegerProperty autoZoomThresholdProperty() {
+        return autoZoomThreshold;
+    }
+
+    /**
      * The mode defining axis along which the zoom can be performed. By default initialised to {@link AxisMode#XY}.
      *
      * @return the axis mode property
@@ -334,38 +353,16 @@ public class Zoomer extends ChartPlugin {
     }
 
     /**
-     * While performing zoom-in on all charts we disable auto-ranging on axes (depending on the axisMode) so if user has
-     * enabled back the auto-ranging - he wants the chart to adapt to the data. Therefore keeping the zoom stack doesn't
-     * make sense - performing zoom-out would again disable auto-ranging and put back ranges saved during the previous
-     * zoom-in operation. Also if user enables auto-ranging between two zoom-in operations, the saved zoom stack becomes
-     * irrelevant.
-     */
-    private void clearZoomStackIfAxisAutoRangingIsEnabled() {
-        Chart chart = getChart();
-        if (chart == null) {
-            return;
-        }
-
-        for (Axis axis : getChart().getAxes()) {
-            if (axis.getSide().isHorizontal()) {
-                if (getAxisMode().allowsX() && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
-                    clear(axis);
-                }
-            } else {
-                if (getAxisMode().allowsY() && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
-                    clear(axis);
-                }
-            }
-        }
-    }
-
-    /**
      * Mouse cursor to be used during drag operation.
      *
      * @return the mouse cursor property
      */
     public final ObjectProperty<Cursor> dragCursorProperty() {
         return dragCursor;
+    }
+
+    public int getAutoZoomThreshold() {
+        return autoZoomThresholdProperty().get();
     }
 
     /**
@@ -397,35 +394,6 @@ public class Zoomer extends ChartPlugin {
      */
     public final Cursor getZoomCursor() {
         return zoomCursorProperty().get();
-    }
-
-    private Map<Axis, ZoomState> getZoomDataWindows() {
-        ConcurrentHashMap<Axis, ZoomState> axisStateMap = new ConcurrentHashMap<>();
-        if (getChart() == null) {
-            return axisStateMap;
-        }
-        final double minX = zoomRectangle.getX();
-        final double minY = zoomRectangle.getY() + zoomRectangle.getHeight();
-        final double maxX = zoomRectangle.getX() + zoomRectangle.getWidth();
-        final double maxY = zoomRectangle.getY();
-
-        // pixel coordinates w.r.t. plot area
-        final Point2D minPlotCoordinate = getChart().toPlotArea(minX, minY);
-        final Point2D maxPlotCoordinate = getChart().toPlotArea(maxX, maxY);
-        for (Axis axis : getChart().getAxes()) {
-            double dataMin;
-            double dataMax;
-            if (axis.getSide().isVertical()) {
-                dataMin = axis.getValueForDisplay(minPlotCoordinate.getY());
-                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getY());
-            } else {
-                dataMin = axis.getValueForDisplay(minPlotCoordinate.getX());
-                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getX());
-            }
-            axisStateMap.put(axis, new ZoomState(dataMin, dataMax, axis.isAutoRanging(), axis.isAutoGrowRanging()));
-        }
-
-        return axisStateMap;
     }
 
     /**
@@ -507,6 +475,305 @@ public class Zoomer extends ChartPlugin {
         return zoomScrollFilter;
     }
 
+    /**
+     * Returns the value of the {@link #animatedProperty()}.
+     *
+     * @return {@code true} if zoom is animated, {@code false} otherwise
+     * @see #getZoomDuration()
+     */
+    public final boolean isAnimated() {
+        return animatedProperty().get();
+    }
+
+    /**
+     * @return {@code true} if auto-zooming feature is being enabled,
+     *         ie. more horizontal drags do x-zoom only, more vertical drags do y-zoom only, and xy-zoom otherwise
+     */
+    public final boolean isAutoZoomEnabled() {
+        return autoZoomEnabledProperty().get();
+    }
+
+    public final boolean isPannerEnabled() {
+        return pannerEnabledProperty().get();
+    }
+
+    /**
+     * Returns the value of the {@link #sliderVisibleProperty()}.
+     *
+     * @return {@code true} if horizontal range slider is shown
+     */
+    public final boolean isSliderVisible() {
+        return sliderVisibleProperty().get();
+    }
+
+    /**
+     * Returns the value of the {@link #animatedProperty()}.
+     *
+     * @return {@code true} if zoom is animated, {@code false} otherwise
+     * @see #getZoomDuration()
+     */
+    public final boolean isUpdateTickUnit() {
+        return updateTickUnitProperty().get();
+    }
+
+    /**
+     * @return list of axes that shall be ignored when performing zoom-in or outs
+     */
+    public final ObservableList<Axis> omitAxisZoomList() {
+        return omitAxisZoom;
+    }
+
+    /**
+     * When {@code true} pressing the middle mouse button and dragging pans the plot
+     *
+     * @return the pannerEnabled property
+     */
+    public final BooleanProperty pannerEnabledProperty() {
+        return enablePanner;
+    }
+
+    /**
+     * Sets the value of the {@link #animatedProperty()}.
+     *
+     * @param value if {@code true} zoom will be animated
+     * @see #setZoomDuration(Duration)
+     */
+    public final void setAnimated(final boolean value) {
+        animatedProperty().set(value);
+    }
+
+    /**
+     * Sets the value of the {@link #autoZoomEnabledProperty()}.
+     *
+     * @param state if {@code true} auto-zooming feature is being enabled,
+     *            ie. more horizontal drags do x-zoom only, more vertical drags do y-zoom only, and xy-zoom otherwise
+     */
+    public final void setAutoZoomEnabled(final boolean state) {
+        autoZoomEnabledProperty().set(state);
+    }
+
+    public void setAutoZoomThreshold(final int value) {
+        autoZoomThresholdProperty().set(value);
+    }
+
+    /**
+     * Sets the value of the {@link #axisModeProperty()}.
+     *
+     * @param mode the mode to be used
+     */
+    public final void setAxisMode(final AxisMode mode) {
+        axisModeProperty().set(mode);
+    }
+
+    /**
+     * Sets value of the {@link #dragCursorProperty()}.
+     *
+     * @param cursor the cursor to be used by the plugin
+     */
+    public final void setDragCursor(final Cursor cursor) {
+        dragCursorProperty().set(cursor);
+    }
+
+    /**
+     * Sets the value of the {@link #sliderVisibleProperty()}.
+     *
+     * @param state if {@code true} the panner (middle mouse button is enabled
+     */
+    public final void setPannerEnabled(final boolean state) {
+        pannerEnabledProperty().set(state);
+    }
+
+    /**
+     * Sets the value of the {@link #sliderVisibleProperty()}.
+     *
+     * @param state if {@code true} the horizontal range slider is shown
+     */
+    public final void setSliderVisible(final boolean state) {
+        sliderVisibleProperty().set(state);
+    }
+
+    /**
+     * Sets the value of the {@link #animatedProperty()}.
+     *
+     * @param value if {@code true} zoom will be animated
+     * @see #setZoomDuration(Duration)
+     */
+    public final void setUpdateTickUnit(final boolean value) {
+        updateTickUnitProperty().set(value);
+    }
+
+    /**
+     * Sets value of the {@link #zoomCursorProperty()}.
+     *
+     * @param cursor the cursor to be used by the plugin
+     */
+    public final void setZoomCursor(final Cursor cursor) {
+        zoomCursorProperty().set(cursor);
+    }
+
+    /**
+     * Sets the value of the {@link #zoomDurationProperty()}.
+     *
+     * @param duration duration of the zoom
+     */
+    public final void setZoomDuration(final Duration duration) {
+        zoomDurationProperty().set(duration);
+    }
+
+    /**
+     * Sets filter on {@link MouseEvent#DRAG_DETECTED DRAG_DETECTED} events that should start zoom-in operation.
+     *
+     * @param zoomInMouseFilter the filter to accept zoom-in mouse event. If {@code null} then any DRAG_DETECTED event
+     *            will start zoom-in operation. By default it's set to {@link #defaultZoomInMouseFilter}.
+     * @see #getZoomInMouseFilter()
+     */
+    public void setZoomInMouseFilter(final Predicate<MouseEvent> zoomInMouseFilter) {
+        this.zoomInMouseFilter = zoomInMouseFilter;
+    }
+
+    /**
+     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-origin operation.
+     *
+     * @param zoomOriginMouseFilter the filter to accept zoom-origin mouse event. If {@code null} then any MOUSE_CLICKED
+     *            event will start zoom-origin operation. By default it's set to {@link #defaultZoomOriginFilter}.
+     * @see #getZoomOriginMouseFilter()
+     */
+    public void setZoomOriginMouseFilter(final Predicate<MouseEvent> zoomOriginMouseFilter) {
+        this.zoomOriginMouseFilter = zoomOriginMouseFilter;
+    }
+
+    /**
+     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-out operation.
+     *
+     * @param zoomOutMouseFilter the filter to accept zoom-out mouse event. If {@code null} then any MOUSE_CLICKED event
+     *            will start zoom-out operation. By default it's set to {@link #defaultZoomOutMouseFilter}.
+     * @see #getZoomOutMouseFilter()
+     */
+    public void setZoomOutMouseFilter(final Predicate<MouseEvent> zoomOutMouseFilter) {
+        this.zoomOutMouseFilter = zoomOutMouseFilter;
+    }
+
+    /**
+     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-origin operation.
+     *
+     * @param zoomScrollFilter filter
+     */
+    public void setZoomScrollFilter(final Predicate<ScrollEvent> zoomScrollFilter) {
+        this.zoomScrollFilter = zoomScrollFilter;
+    }
+
+    /**
+     * When {@code true} an additional horizontal range slider is shown in a HiddeSidesPane at the bottom. By default
+     * it's {@code true}.
+     *
+     * @return the sliderVisible property
+     * @see #getRangeSlider()
+     */
+    public final BooleanProperty sliderVisibleProperty() {
+        return sliderVisible;
+    }
+
+    /**
+     * When {@code true} zooming will be animated. By default it's {@code false}.
+     *
+     * @return the animated property
+     * @see #zoomDurationProperty()
+     */
+    public final BooleanProperty updateTickUnitProperty() {
+        return updateTickUnit;
+    }
+
+    /**
+     * Mouse cursor to be used during zoom operation.
+     *
+     * @return the mouse cursor property
+     */
+    public final ObjectProperty<Cursor> zoomCursorProperty() {
+        return zoomCursor;
+    }
+
+    /**
+     * Duration of the animated zoom (in and out). Used only when {@link #animatedProperty()} is set to {@code true}. By
+     * default initialised to 500ms.
+     *
+     * @return the zoom duration property
+     */
+    public final ObjectProperty<Duration> zoomDurationProperty() {
+        return zoomDuration;
+    }
+
+    public boolean zoomOrigin() {
+        clearZoomStackIfAxisAutoRangingIsEnabled();
+        final Map<Axis, ZoomState> zoomWindows = zoomStacks.peekLast();
+        if (zoomWindows == null || zoomWindows.isEmpty()) {
+            return false;
+        }
+        clear();
+        performZoom(zoomWindows, false);
+        if (xRangeSlider != null) {
+            xRangeSlider.reset();
+        }
+        for (Axis axis : getChart().getAxes()) {
+            axis.forceRedraw();
+        }
+        return true;
+    }
+
+    /**
+     * While performing zoom-in on all charts we disable auto-ranging on axes (depending on the axisMode) so if user has
+     * enabled back the auto-ranging - he wants the chart to adapt to the data. Therefore keeping the zoom stack doesn't
+     * make sense - performing zoom-out would again disable auto-ranging and put back ranges saved during the previous
+     * zoom-in operation. Also if user enables auto-ranging between two zoom-in operations, the saved zoom stack becomes
+     * irrelevant.
+     */
+    private void clearZoomStackIfAxisAutoRangingIsEnabled() {
+        Chart chart = getChart();
+        if (chart == null) {
+            return;
+        }
+
+        for (Axis axis : getChart().getAxes()) {
+            if (axis.getSide().isHorizontal()) {
+                if (getAxisMode().allowsX() && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
+                    clear(axis);
+                }
+            } else {
+                if (getAxisMode().allowsY() && (axis.isAutoRanging() || axis.isAutoGrowRanging())) {
+                    clear(axis);
+                }
+            }
+        }
+    }
+
+    private Map<Axis, ZoomState> getZoomDataWindows() {
+        ConcurrentHashMap<Axis, ZoomState> axisStateMap = new ConcurrentHashMap<>();
+        if (getChart() == null) {
+            return axisStateMap;
+        }
+        final double minX = zoomRectangle.getX();
+        final double minY = zoomRectangle.getY() + zoomRectangle.getHeight();
+        final double maxX = zoomRectangle.getX() + zoomRectangle.getWidth();
+        final double maxY = zoomRectangle.getY();
+
+        // pixel coordinates w.r.t. plot area
+        final Point2D minPlotCoordinate = getChart().toPlotArea(minX, minY);
+        final Point2D maxPlotCoordinate = getChart().toPlotArea(maxX, maxY);
+        for (Axis axis : getChart().getAxes()) {
+            double dataMin;
+            double dataMax;
+            if (axis.getSide().isVertical()) {
+                dataMin = axis.getValueForDisplay(minPlotCoordinate.getY());
+                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getY());
+            } else {
+                dataMin = axis.getValueForDisplay(minPlotCoordinate.getX());
+                dataMax = axis.getValueForDisplay(maxPlotCoordinate.getX());
+            }
+            axisStateMap.put(axis, new ZoomState(dataMin, dataMax, axis.isAutoRanging(), axis.isAutoGrowRanging()));
+        }
+
+        return axisStateMap;
+    }
+
     private void installDragCursor() {
         final Region chart = getChart();
         originalCursor = chart.getCursor();
@@ -521,16 +788,6 @@ public class Zoomer extends ChartPlugin {
         if (getDragCursor() != null) {
             chart.setCursor(getZoomCursor());
         }
-    }
-
-    /**
-     * Returns the value of the {@link #animatedProperty()}.
-     *
-     * @return {@code true} if zoom is animated, {@code false} otherwise
-     * @see #getZoomDuration()
-     */
-    public final boolean isAnimated() {
-        return animatedProperty().get();
     }
 
     private boolean isMouseEventWithinCanvas(final MouseEvent mouseEvent) {
@@ -559,29 +816,6 @@ public class Zoomer extends ChartPlugin {
         return propertyState || omitAxisZoomList().contains(axis);
     }
 
-    public final boolean isPannerEnabled() {
-        return pannerEnabledProperty().get();
-    }
-
-    /**
-     * Returns the value of the {@link #sliderVisibleProperty()}.
-     *
-     * @return {@code true} if horizontal range slider is shown
-     */
-    public final boolean isSliderVisible() {
-        return sliderVisibleProperty().get();
-    }
-
-    /**
-     * Returns the value of the {@link #animatedProperty()}.
-     *
-     * @return {@code true} if zoom is animated, {@code false} otherwise
-     * @see #getZoomDuration()
-     */
-    public final boolean isUpdateTickUnit() {
-        return updateTickUnitProperty().get();
-    }
-
     /**
      * take a snapshot of present view (needed for scroll zoom interactor
      */
@@ -600,13 +834,6 @@ public class Zoomer extends ChartPlugin {
         pushCurrentZoomWindows();
         performZoom(getZoomDataWindows(), true);
         zoomRectangle.setVisible(false);
-    }
-
-    /**
-     * @return list of axes that shall be ignored when performing zoom-in or outs
-     */
-    public final ObservableList<Axis> omitAxisZoomList() {
-        return omitAxisZoom;
     }
 
     private void panChart(final Chart chart, final Point2D mouseLocation) {
@@ -670,15 +897,6 @@ public class Zoomer extends ChartPlugin {
         panShiftY = 0.0;
         previousMouseLocation = null;
         uninstallCursor();
-    }
-
-    /**
-     * When {@code true} pressing the middle mouse button and dragging pans the plot
-     *
-     * @return the pannerEnabled property
-     */
-    public final BooleanProperty pannerEnabledProperty() {
-        return enablePanner;
     }
 
     private boolean panOngoing() {
@@ -774,164 +992,8 @@ public class Zoomer extends ChartPlugin {
         registerInputEventHandler(MouseEvent.MOUSE_RELEASED, panEndHandler);
     }
 
-    /**
-     * Sets the value of the {@link #animatedProperty()}.
-     *
-     * @param value if {@code true} zoom will be animated
-     * @see #setZoomDuration(Duration)
-     */
-    public final void setAnimated(final boolean value) {
-        animatedProperty().set(value);
-    }
-
-    /**
-     * Sets the value of the {@link #axisModeProperty()}.
-     *
-     * @param mode the mode to be used
-     */
-    public final void setAxisMode(final AxisMode mode) {
-        axisModeProperty().set(mode);
-    }
-
-    /**
-     * Sets value of the {@link #dragCursorProperty()}.
-     *
-     * @param cursor the cursor to be used by the plugin
-     */
-    public final void setDragCursor(final Cursor cursor) {
-        dragCursorProperty().set(cursor);
-    }
-
-    /**
-     * Sets the value of the {@link #sliderVisibleProperty()}.
-     *
-     * @param state if {@code true} the panner (middle mouse button is enabled
-     */
-    public final void setPannerEnabled(final boolean state) {
-        pannerEnabledProperty().set(state);
-    }
-
-    /**
-     * Sets the value of the {@link #sliderVisibleProperty()}.
-     *
-     * @param state if {@code true} the horizontal range slider is shown
-     */
-    public final void setSliderVisible(final boolean state) {
-        sliderVisibleProperty().set(state);
-    }
-
-    /**
-     * Sets the value of the {@link #animatedProperty()}.
-     *
-     * @param value if {@code true} zoom will be animated
-     * @see #setZoomDuration(Duration)
-     */
-    public final void setUpdateTickUnit(final boolean value) {
-        updateTickUnitProperty().set(value);
-    }
-
-    /**
-     * Sets value of the {@link #zoomCursorProperty()}.
-     *
-     * @param cursor the cursor to be used by the plugin
-     */
-    public final void setZoomCursor(final Cursor cursor) {
-        zoomCursorProperty().set(cursor);
-    }
-
-    /**
-     * Sets the value of the {@link #zoomDurationProperty()}.
-     *
-     * @param duration duration of the zoom
-     */
-    public final void setZoomDuration(final Duration duration) {
-        zoomDurationProperty().set(duration);
-    }
-
-    /**
-     * Sets filter on {@link MouseEvent#DRAG_DETECTED DRAG_DETECTED} events that should start zoom-in operation.
-     *
-     * @param zoomInMouseFilter the filter to accept zoom-in mouse event. If {@code null} then any DRAG_DETECTED event
-     *        will start zoom-in operation. By default it's set to {@link #defaultZoomInMouseFilter}.
-     * @see #getZoomInMouseFilter()
-     */
-    public void setZoomInMouseFilter(final Predicate<MouseEvent> zoomInMouseFilter) {
-        this.zoomInMouseFilter = zoomInMouseFilter;
-    }
-
-    /**
-     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-origin operation.
-     *
-     * @param zoomOriginMouseFilter the filter to accept zoom-origin mouse event. If {@code null} then any MOUSE_CLICKED
-     *        event will start zoom-origin operation. By default it's set to {@link #defaultZoomOriginFilter}.
-     * @see #getZoomOriginMouseFilter()
-     */
-    public void setZoomOriginMouseFilter(final Predicate<MouseEvent> zoomOriginMouseFilter) {
-        this.zoomOriginMouseFilter = zoomOriginMouseFilter;
-    }
-
-    /**
-     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-out operation.
-     *
-     * @param zoomOutMouseFilter the filter to accept zoom-out mouse event. If {@code null} then any MOUSE_CLICKED event
-     *        will start zoom-out operation. By default it's set to {@link #defaultZoomOutMouseFilter}.
-     * @see #getZoomOutMouseFilter()
-     */
-    public void setZoomOutMouseFilter(final Predicate<MouseEvent> zoomOutMouseFilter) {
-        this.zoomOutMouseFilter = zoomOutMouseFilter;
-    }
-
-    /**
-     * Sets filter on {@link MouseEvent#MOUSE_CLICKED MOUSE_CLICKED} events that should trigger zoom-origin operation.
-     *
-     * @param zoomScrollFilter filter
-     */
-    public void setZoomScrollFilter(final Predicate<ScrollEvent> zoomScrollFilter) {
-        this.zoomScrollFilter = zoomScrollFilter;
-    }
-
-    /**
-     * When {@code true} an additional horizontal range slider is shown in a HiddeSidesPane at the bottom. By default
-     * it's {@code true}.
-     *
-     * @return the sliderVisible property
-     * @see #getRangeSlider()
-     */
-    public final BooleanProperty sliderVisibleProperty() {
-        return sliderVisible;
-    }
-
     private void uninstallCursor() {
         getChart().setCursor(originalCursor);
-    }
-
-    /**
-     * When {@code true} zooming will be animated. By default it's {@code false}.
-     *
-     * @return the animated property
-     * @see #zoomDurationProperty()
-     */
-    public final BooleanProperty updateTickUnitProperty() {
-        return updateTickUnit;
-    }
-
-    /**
-     * Mouse cursor to be used during zoom operation.
-     *
-     * @return the mouse cursor property
-     */
-    public final ObjectProperty<Cursor> zoomCursorProperty() {
-        return zoomCursor;
-    }
-
-    /**
-     * Duration of the animated zoom (in and out). Used only when {@link #animatedProperty()} is set to {@code true}. By
-     * default initialised to 500ms.
-     *
-     * @return the zoom duration property
-     */
-    public final ObjectProperty<Duration> zoomDurationProperty() {
-        return zoomDuration;
     }
 
     private void zoomInDragged(final MouseEvent event) {
@@ -942,6 +1004,32 @@ public class Zoomer extends ChartPlugin {
         double zoomRectY = plotAreaBounds.getMinY();
         double zoomRectWidth = plotAreaBounds.getWidth();
         double zoomRectHeight = plotAreaBounds.getHeight();
+
+        if (isAutoZoomEnabled()) {
+            final double diffX = zoomEndPoint.getX() - zoomStartPoint.getX();
+            final double diffY = zoomEndPoint.getY() - zoomStartPoint.getY();
+
+            //final double length = Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2));
+
+            final int limit = Math.abs(getAutoZoomThreshold());
+
+            // pixel distance based algorithm
+            final boolean isZoomX = Math.abs(diffY) <= limit && Math.abs(diffX) >= limit;
+            final boolean isZoomY = Math.abs(diffX) <= limit && Math.abs(diffY) >= limit;
+
+            // alternate angle-based algorithm
+            // final int angle = (int) Math.toDegrees(Math.atan2(diffY, diffX));
+            // final boolean isZoomX = Math.abs(angle) <= limit || Math.abs((angle - 180) % 180) <= limit;
+            // final boolean isZoomY = Math.abs((angle - 90) % 180) <= limit || Math.abs((angle - 270) % 180) <= limit;
+
+            if (isZoomX) {
+                this.setAxisMode(AxisMode.X);
+            } else if (isZoomY) {
+                this.setAxisMode(AxisMode.Y);
+            } else {
+                this.setAxisMode(AxisMode.XY);
+            }
+        }
 
         if (getAxisMode().allowsX()) {
             zoomRectX = Math.min(zoomStartPoint.getX(), zoomEndPoint.getX());
@@ -981,23 +1069,6 @@ public class Zoomer extends ChartPlugin {
         return zoomStartPoint != null;
     }
 
-    public boolean zoomOrigin() {
-        clearZoomStackIfAxisAutoRangingIsEnabled();
-        final Map<Axis, ZoomState> zoomWindows = zoomStacks.peekLast();
-        if (zoomWindows == null || zoomWindows.isEmpty()) {
-            return false;
-        }
-        clear();
-        performZoom(zoomWindows, false);
-        if (xRangeSlider != null) {
-            xRangeSlider.reset();
-        }
-        for (Axis axis : getChart().getAxes()) {
-            axis.forceRedraw();
-        }
-        return true;
-    }
-
     private boolean zoomOut() {
         clearZoomStackIfAxisAutoRangingIsEnabled();
         final Map<Axis, ZoomState> zoomWindows = zoomStacks.pollFirst();
@@ -1017,6 +1088,21 @@ public class Zoomer extends ChartPlugin {
     }
 
     /**
+     * @param axis the axis to be modified
+     * @param state true: axis is not taken into account when zooming
+     */
+    public static void setOmitZoom(final Axis axis, final boolean state) {
+        if (!(axis instanceof Node)) {
+            return;
+        }
+        if (state) {
+            ((Node) axis).getProperties().put(ZOOMER_OMIT_AXIS, true);
+        } else {
+            ((Node) axis).getProperties().remove(ZOOMER_OMIT_AXIS);
+        }
+    }
+
+    /**
      * limits the mouse event position to the min/max range of the canavs (N.B. event can occur to be
      * negative/larger/outside than the canvas) This is to avoid zooming outside the visible canvas range
      *
@@ -1030,21 +1116,6 @@ public class Zoomer extends ChartPlugin {
         final double limitedY = Math.max(Math.min(event.getY() - plotBounds.getMinY(), plotBounds.getMaxY()),
                 plotBounds.getMinY());
         return new Point2D(limitedX, limitedY);
-    }
-
-    /**
-     * @param axis the axis to be modified
-     * @param state true: axis is not taken into account when zooming
-     */
-    public static void setOmitZoom(final Axis axis, final boolean state) {
-        if (!(axis instanceof Node)) {
-            return;
-        }
-        if (state) {
-            ((Node) axis).getProperties().put(ZOOMER_OMIT_AXIS, true);
-        } else {
-            ((Node) axis).getProperties().remove(ZOOMER_OMIT_AXIS);
-        }
     }
 
     private static void zoomOnAxis(final Axis axis, final ScrollEvent event) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/ui/ObservableDeque.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/ui/ObservableDeque.java
@@ -1,0 +1,271 @@
+package de.gsi.chart.ui;
+
+import java.security.InvalidParameterException;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Queue;
+
+import javafx.collections.ObservableListBase;
+
+/**
+ * Implements ObservableDeque missing in default JavaFX
+ * <p>
+ * Note that manipulations of the underlying deque will not result in notification to listeners.
+ *
+ * @author rstein
+ * @param <E> queue generic parameter
+ */
+public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E> {
+    private final Deque<E> deque;
+
+    /**
+     * Creates an ObservableDeque backed by the supplied Deque.
+     * Note that manipulations of the underlying deque will not result in notification to listeners.
+     * 
+     * @param deque the specific backing implementation
+     */
+    public ObservableDeque(Deque<E> deque) {
+        if (deque == null) {
+            throw new InvalidParameterException("deque must not be null");
+        }
+        this.deque = deque;
+    }
+
+    @Override
+    public boolean offer(E e) {
+        beginChange();
+        boolean result = deque.offer(e);
+        if (result) {
+            nextAdd(deque.size() - 1, deque.size());
+        }
+        endChange();
+        return result;
+    }
+
+    @Override
+    public boolean add(E e) {
+        beginChange();
+        try {
+            deque.add(e);
+            nextAdd(deque.size() - 1, deque.size());
+            return true;
+        } finally {
+            endChange();
+        }
+    }
+
+    @Override
+    public E remove() {
+        beginChange();
+        try {
+            E e = deque.remove();
+            nextRemove(0, e);
+            return e;
+        } finally {
+            endChange();
+        }
+    }
+
+    @Override
+    public E poll() {
+        beginChange();
+        E e = deque.poll();
+        if (e != null) {
+            nextRemove(0, e);
+        }
+        endChange();
+        return e;
+    }
+
+    @Override
+    public E element() {
+        return deque.element();
+    }
+
+    @Override
+    public E peek() {
+        return deque.peek();
+    }
+
+    @Override
+    public E get(int index) {
+        Iterator<E> iterator = deque.iterator();
+        for (int i = 0; i < index; i++) {
+            iterator.next();
+        }
+        return iterator.next();
+    }
+
+    @Override
+    public int size() {
+        return deque.size();
+    }
+
+    @Override
+    public void addFirst(E e) {
+        beginChange();
+        try {
+            deque.addFirst(e);
+            nextAdd(0, 1);
+        } finally {
+            endChange();
+        }
+    }
+
+    @Override
+    public void addLast(E e) {
+        beginChange();
+        try {
+            deque.addLast(e);
+            nextAdd(deque.size() - 1, deque.size());
+        } finally {
+            endChange();
+        }
+    }
+
+    @Override
+    public boolean offerFirst(E e) {
+        if (deque.offerFirst(e)) {
+            beginChange();
+            try {
+                nextAdd(0, deque.size());
+            } finally {
+                endChange();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean offerLast(E e) {
+        if (deque.offerLast(e)) {
+            try {
+                deque.addLast(e);
+                nextAdd(deque.size() - 1, deque.size());
+            } finally {
+                endChange();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public E removeFirst() {
+        beginChange();
+        E e = deque.removeFirst();
+        if (e != null) {
+            nextRemove(0, e);
+        }
+        endChange();
+        return e;
+    }
+
+    @Override
+    public E removeLast() {
+        beginChange();
+        E e = deque.removeLast();
+        if (e != null) {
+            nextRemove(deque.size() - 1, e);
+        }
+        endChange();
+        return e;
+    }
+
+    @Override
+    public E pollFirst() {
+        beginChange();
+        E e = deque.pollFirst();
+        if (e != null) {
+            nextRemove(0, e);
+        }
+        endChange();
+        return e;
+    }
+
+    @Override
+    public E pollLast() {
+        beginChange();
+        E e = deque.pollLast();
+        if (e != null) {
+            nextRemove(deque.size(), e);
+        }
+        endChange();
+        return e;
+    }
+
+    @Override
+    public E getFirst() {
+        return deque.getFirst();
+    }
+
+    @Override
+    public E getLast() {
+        return deque.getLast();
+    }
+
+    @Override
+    public E peekFirst() {
+        return deque.peekFirst();
+    }
+
+    @Override
+    public E peekLast() {
+        return deque.peekLast();
+    }
+
+    @Override
+    public boolean removeFirstOccurrence(Object o) {
+        if (o == null) {
+            return false;
+        }
+
+        Iterator<E> iterator = deque.iterator();
+        beginChange();
+        for (int i = 0; i < deque.size(); i++) {
+            final E e = iterator.next();
+            if (o.equals(e)) {
+                nextRemove(i, e);
+                endChange();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeLastOccurrence(Object o) {
+        if (o == null) {
+            return false;
+        }
+
+        Iterator<E> iterator = deque.descendingIterator();
+        beginChange();
+        for (int i = 0; i < deque.size(); i++) {
+            final E e = iterator.next();
+            if (o.equals(e)) {
+                nextRemove(deque.size() - 1 - i, e);
+                endChange();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void push(E e) {
+        this.addFirst(e);
+    }
+
+    @Override
+    public E pop() {
+        return removeFirst();
+    }
+
+    @Override
+    public Iterator<E> descendingIterator() {
+        return deque.descendingIterator();
+    }
+
+}

--- a/chartfx-chart/src/main/java/de/gsi/chart/ui/ObservableDeque.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/ui/ObservableDeque.java
@@ -3,7 +3,6 @@ package de.gsi.chart.ui;
 import java.security.InvalidParameterException;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.Queue;
 
 import javafx.collections.ObservableListBase;
 
@@ -16,15 +15,16 @@ import javafx.collections.ObservableListBase;
  * @param <E> queue generic parameter
  */
 public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E> {
-    private final Deque<E> deque;
+    private final transient Deque<E> deque;
 
     /**
-     * Creates an ObservableDeque backed by the supplied Deque.
-     * Note that manipulations of the underlying deque will not result in notification to listeners.
-     * 
+     * Creates an ObservableDeque backed by the supplied Deque. Note that manipulations of the underlying deque will not
+     * result in notification to listeners.
+     *
      * @param deque the specific backing implementation
      */
-    public ObservableDeque(Deque<E> deque) {
+    public ObservableDeque(final Deque<E> deque) {
+        super();
         if (deque == null) {
             throw new InvalidParameterException("deque must not be null");
         }
@@ -32,9 +32,9 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean offer(E e) {
+    public boolean offer(final E e) {
         beginChange();
-        boolean result = deque.offer(e);
+        final boolean result = deque.offer(e);
         if (result) {
             nextAdd(deque.size() - 1, deque.size());
         }
@@ -43,7 +43,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean add(E e) {
+    public boolean add(final E e) {
         beginChange();
         try {
             deque.add(e);
@@ -58,7 +58,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     public E remove() {
         beginChange();
         try {
-            E e = deque.remove();
+            final E e = deque.remove();
             nextRemove(0, e);
             return e;
         } finally {
@@ -69,7 +69,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     @Override
     public E poll() {
         beginChange();
-        E e = deque.poll();
+        final E e = deque.poll();
         if (e != null) {
             nextRemove(0, e);
         }
@@ -88,8 +88,8 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public E get(int index) {
-        Iterator<E> iterator = deque.iterator();
+    public E get(final int index) {
+        final Iterator<E> iterator = deque.iterator();
         for (int i = 0; i < index; i++) {
             iterator.next();
         }
@@ -102,7 +102,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public void addFirst(E e) {
+    public void addFirst(final E e) {
         beginChange();
         try {
             deque.addFirst(e);
@@ -113,7 +113,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public void addLast(E e) {
+    public void addLast(final E e) {
         beginChange();
         try {
             deque.addLast(e);
@@ -124,7 +124,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean offerFirst(E e) {
+    public boolean offerFirst(final E e) {
         if (deque.offerFirst(e)) {
             beginChange();
             try {
@@ -138,7 +138,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean offerLast(E e) {
+    public boolean offerLast(final E e) {
         if (deque.offerLast(e)) {
             try {
                 deque.addLast(e);
@@ -154,7 +154,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     @Override
     public E removeFirst() {
         beginChange();
-        E e = deque.removeFirst();
+        final E e = deque.removeFirst();
         if (e != null) {
             nextRemove(0, e);
         }
@@ -165,7 +165,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     @Override
     public E removeLast() {
         beginChange();
-        E e = deque.removeLast();
+        final E e = deque.removeLast();
         if (e != null) {
             nextRemove(deque.size() - 1, e);
         }
@@ -176,7 +176,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     @Override
     public E pollFirst() {
         beginChange();
-        E e = deque.pollFirst();
+        final E e = deque.pollFirst();
         if (e != null) {
             nextRemove(0, e);
         }
@@ -187,7 +187,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     @Override
     public E pollLast() {
         beginChange();
-        E e = deque.pollLast();
+        final E e = deque.pollLast();
         if (e != null) {
             nextRemove(deque.size(), e);
         }
@@ -216,12 +216,12 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean removeFirstOccurrence(Object o) {
+    public boolean removeFirstOccurrence(final Object o) {
         if (o == null) {
             return false;
         }
 
-        Iterator<E> iterator = deque.iterator();
+        final Iterator<E> iterator = deque.iterator();
         beginChange();
         for (int i = 0; i < deque.size(); i++) {
             final E e = iterator.next();
@@ -235,12 +235,12 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public boolean removeLastOccurrence(Object o) {
+    public boolean removeLastOccurrence(final Object o) {
         if (o == null) {
             return false;
         }
 
-        Iterator<E> iterator = deque.descendingIterator();
+        final Iterator<E> iterator = deque.descendingIterator();
         beginChange();
         for (int i = 0; i < deque.size(); i++) {
             final E e = iterator.next();
@@ -254,7 +254,7 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     }
 
     @Override
-    public void push(E e) {
+    public void push(final E e) {
         this.addFirst(e);
     }
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -72,6 +72,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("TransposedDataSetSample", new TransposedDataSetSample()));
         buttons.getChildren().add(new MyButton("ValueIndicatorSample", new ValueIndicatorSample()));
         buttons.getChildren().add(new MyButton("WriteDataSetToFileSample", new WriteDataSetToFileSample()));
+        buttons.getChildren().add(new MyButton("ZoomerSample", new ZoomerSample()));
 
         final Scene scene = new Scene(root);
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ZoomerSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ZoomerSample.java
@@ -1,0 +1,117 @@
+package de.gsi.chart.samples;
+
+import de.gsi.chart.Chart;
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.AxisMode;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.event.AddedDataEvent;
+import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.testdata.spi.RandomDataGenerator;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.text.Font;
+import javafx.stage.Stage;
+
+/**
+ * @author rstein
+ */
+public class ZoomerSample extends Application {
+    private static final int PREF_WIDTH = 600;
+    private static final int PREF_HEIGHT = 300;
+    private static final int N_SAMPLES = 1000000; // default: 1000000
+
+    @Override
+    public void start(final Stage primaryStage) {
+
+        final FlowPane root = new FlowPane();
+        root.setAlignment(Pos.CENTER);
+
+        DataSet testDataSet = generateData();
+
+        Label label = new Label("left-click-hold-drag for zooming. middle-button for panning.\n"
+                + "Tip: drag horizontally/vertically/diagonally for testing; try to select the outlier");
+        label.setFont(Font.font(20));
+        label.setAlignment(Pos.CENTER);
+        label.setContentDisplay(ContentDisplay.CENTER);
+        label.setPrefWidth(2.0 * PREF_WIDTH);
+
+        // chart with default zoom
+        final Chart chart1 = getTestChart("default zoom", testDataSet);
+        chart1.getPlugins().add(new Zoomer());
+
+        // chart with auto xy zoom
+        final Chart chart2 = getTestChart("auto xy zoom", testDataSet);
+        final Zoomer zoomer2 = new Zoomer();
+        zoomer2.setAutoZoomEnabled(true);
+        chart2.getPlugins().add(zoomer2);
+
+        // chart with x-only zoom
+        final Chart chart3 = getTestChart("x-only zoom", testDataSet);
+        chart3.getPlugins().add(new Zoomer(AxisMode.X));
+
+        // chart with x-only zoom
+        final Chart chart4 = getTestChart("y-only zoom", testDataSet);
+        chart4.getPlugins().add(new Zoomer(AxisMode.Y));
+
+        root.getChildren().addAll(chart1, chart2, chart3, chart4, label);
+
+        primaryStage.setTitle(this.getClass().getSimpleName());
+        primaryStage.setScene(new Scene(root));
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+        primaryStage.show();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+
+    private static Chart getTestChart(final String title, final DataSet testDataSet) {
+        final Chart chart = new XYChart();
+        chart.setTitle(title);
+        chart.setLegendVisible(false);
+        chart.getDatasets().add(testDataSet);
+        chart.setPrefSize(PREF_WIDTH, PREF_HEIGHT);
+
+        return chart;
+    }
+
+    private static DataSet generateData() {
+        DoubleErrorDataSet dataSet = new DoubleErrorDataSet("test data");
+
+        dataSet.lock().writeLockGuard(() -> {
+            // auto notification is suppressed by write lock guard
+            dataSet.clearData();
+            double oldY = 0;
+
+            for (int n = 0; n < N_SAMPLES; n++) {
+                final double x = n;
+                oldY += RandomDataGenerator.random() - 0.5;
+                final double y = oldY + (n == 500000 ? 500.0 : 0) /* + ((x>1e4 && x <2e4) ? Double.NaN: 0.0) */;
+                final double ex = 0.1;
+                final double ey = 10;
+                dataSet.add(x, y, ex, ey);
+
+                if (n == 500000) { // NOPMD this point is really special ;-)
+                    dataSet.getDataLabelMap().put(n, "special outlier");
+                }
+            }
+
+            dataSet.autoNotification().set(true);
+        });
+        // need to issue a separate update notification
+        // N.B. for performance reasons we let only 'dataSet' fire an event, since we modified both
+        // dataSetNoErrors will be updated alongside dataSet.
+        dataSet.fireInvalidated(new AddedDataEvent(dataSet));
+
+        return dataSet;
+    }
+}


### PR DESCRIPTION
Added new auto zoom feature that limits zooms to X, Y, or XY depending on whether the mouse is dragged predominantly in X, Y, or  XY (ie. diagonally). See ZoomerSample for details and how to use.

Added also an ObservableDeque to allow to monitor the zooming state stack. This may be used to trigger other UI actions in response to zooms (ie. pausing acquisitions/update). 

@dedeibel and @ennerf you might be interested in this.

N.B. the auto-zoom is optional but we may consider making this the default... 

Enjoy!