### PR TITLE
readLock deadlocks in DataSetUtils

### DIFF
--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DataSetUtils.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DataSetUtils.java
@@ -838,7 +838,7 @@ public class DataSetUtils extends DataSetUtilsHelper {
         }
 
         byteOutput.reset();
-        dataSet.lock().readLockGuard(() -> {
+        dataSet.lock().writeLockGuard(() -> {
             try {
                 byteOutput.write(("#file producer : " + DataSetUtils.class.getCanonicalName() + '\n').getBytes());
 


### PR DESCRIPTION
So, I noticed that when I try to serialize datasets using `DataSetUtils.writeDataSetToFile()` it deadlocks on `dataSet.lock().readLockGuard()` in `writeDataSetToByteArray()`. I'm guessing it's supposed to be `writeLock`, not `readLock`, similar to [this](https://github.com/GSI-CS-CO/chart-fx/commit/df31ebde356860db4e09925a9847b808eb459f74) commit, only in reverse. At least it doesn't deadlock for me anymore.