### PR TITLE
Use first dataset name in measurement plugin when no choice is required

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
@@ -115,8 +115,12 @@ public abstract class AbstractChartMeasurement implements EventListener {
         }
 
         if (dataSet == null) {
-            valueField.setDataSetName("<unknown data set>");
-            this.dataSet = dataSet;
+            if (dataSetSelector.getNumberDataSets() == 1) {
+                valueField.setDataSetName(dataSetSelector.getFirstDataSet().getName());
+            } else {
+                valueField.setDataSetName("<unknown data set>");
+                this.dataSet = dataSet;
+            }
         } else {
             valueField.setDataSetName("<" + dataSet.getName() + ">");
             this.dataSet = dataSet;

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/DataSetSelector.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/DataSetSelector.java
@@ -41,6 +41,10 @@ public class DataSetSelector extends HBox {
     public DataSet getSelectedDataSet() {
         return dataSets.getSelectionModel().getSelectedItem();
     }
+    
+    public DataSet getFirstDataSet() {
+        return dataSets.getItems().get(0);
+    }
 
     static protected class DataSetLabel extends ListCell<DataSet> {
         @Override


### PR DESCRIPTION
If only one dataset was available, no name was used instead of using the first one.