### PR TITLE
Allow selecting DataSet for Parameter Measurement

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -166,6 +166,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             case RIGHT:
             default:
                 AbstractAxis.this.getAxisLabel().setTextAlignment(TextAlignment.CENTER);
+                break;
             }
         });
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Path;
 import javafx.scene.text.Text;
+import javafx.scene.text.TextAlignment;
 import javafx.util.Duration;
 import javafx.util.StringConverter;
 
@@ -151,6 +152,22 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
         widthProperty().addListener(axisSizeChangeListener);
         heightProperty().addListener(axisSizeChangeListener);
+
+        // set default axis title/label alignment
+        sideProperty().addListener((ch, o, n) -> {
+            switch (n) {
+            case CENTER_HOR:
+            case CENTER_VER:
+                AbstractAxis.this.getAxisLabel().setTextAlignment(TextAlignment.RIGHT);
+                break;
+            case TOP:
+            case BOTTOM:
+            case LEFT:
+            case RIGHT:
+            default:
+                AbstractAxis.this.getAxisLabel().setTextAlignment(TextAlignment.CENTER);
+            }
+        });
 
         VBox.setVgrow(this, Priority.ALWAYS);
         HBox.setHgrow(this, Priority.ALWAYS);
@@ -731,7 +748,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         case CENTER_VER: {
             gc.setTextBaseline(VPos.TOP);
             axisName.setRotate(-90);
-            final double x = (axisCentre * axisWidth) - tickLength - tickLabelGap - tickLabelSize - axisLabelGap
+            final double x = (axisCentre * axisWidth) - tickLength - (2 * tickLabelGap) - tickLabelSize - axisLabelGap
                     - shiftedLabels;
             final double y = ((1.0 - labelPosition) * axisHeight) - labelGap;
             drawAxisLabel(gc, x, y, axisName);

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/SimpleMeasurements.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/SimpleMeasurements.java
@@ -18,6 +18,7 @@ import de.gsi.chart.axes.AxisLabelFormatter;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
 import de.gsi.chart.axes.spi.MetricPrefix;
 import de.gsi.chart.plugins.measurements.utils.SimpleDataSetEstimators;
+import de.gsi.chart.utils.FXUtils;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.event.UpdateEvent;
 import javafx.scene.Node;
@@ -196,13 +197,13 @@ public class SimpleMeasurements extends ValueIndicator {
             valueField.setUnit(unit);
         }
 
-        valueField.setValue(val, valueLabel);
+        FXUtils.runFX(() -> valueField.setValue(val, valueLabel));
 
         final String altAxisLabel = altAxis.getName();
         switch (measType) {
         case TRANSMISSION_ABS:
         case TRANSMISSION_REL:
-            valueField.setUnit("%");
+            FXUtils.runFX(() -> valueField.setUnit("%"));
             break;
         case INTEGRAL:
         default:
@@ -243,7 +244,9 @@ public class SimpleMeasurements extends ValueIndicator {
     }
 
     public enum MeasurementCategory {
-        INDICATOR("Indicators"), VERTICAL("Vertical Measurements"), HORIZONTAL("Horizontal Measurements"),
+        INDICATOR("Indicators"),
+        VERTICAL("Vertical Measurements"),
+        HORIZONTAL("Horizontal Measurements"),
         ACC("Accelerator Misc.");
 
         private String name;
@@ -260,22 +263,32 @@ public class SimpleMeasurements extends ValueIndicator {
 
     public enum MeasurementType {
         // indicators
-        VALUE_HOR(false, INDICATOR, "hor. value"), VALUE_VER(true, INDICATOR, "ver. value"),
-        DISTANCE_HOR(false, INDICATOR, "hor. distance"), DISTANCE_VER(true, INDICATOR, "ver. distance"),
+        VALUE_HOR(false, INDICATOR, "hor. value"),
+        VALUE_VER(true, INDICATOR, "ver. value"),
+        DISTANCE_HOR(false, INDICATOR, "hor. distance"),
+        DISTANCE_VER(true, INDICATOR, "ver. distance"),
 
         // vertical-type measurements
-        MINIMUM(true, VERTICAL, "Minimum"), MAXIMUM(true, VERTICAL, "Maximum"), RANGE(true, VERTICAL, "Range"),
-        MEAN(true, VERTICAL, "Mean"), RMS(true, VERTICAL, "R.M.S."), MEDIAN(true, VERTICAL, "Median"),
-        INTEGRAL(true, VERTICAL, "Integral"), TRANSMISSION_ABS(true, ACC, "Abs. Transmission"),
+        MINIMUM(true, VERTICAL, "Minimum"),
+        MAXIMUM(true, VERTICAL, "Maximum"),
+        RANGE(true, VERTICAL, "Range"),
+        MEAN(true, VERTICAL, "Mean"),
+        RMS(true, VERTICAL, "R.M.S."),
+        MEDIAN(true, VERTICAL, "Median"),
+        INTEGRAL(true, VERTICAL, "Integral"),
+        TRANSMISSION_ABS(true, ACC, "Abs. Transmission"),
         TRANSMISSION_REL(true, ACC, "Rel. Transmission"),
 
         // horizontal-type measurements
         EDGE_DETECT(false, HORIZONTAL, "Edge-Detect"),
         RISETIME_10_90(false, HORIZONTAL, "10%-90% Rise-/Fall-Time\n (simple)"),
-        RISETIME_20_80(false, HORIZONTAL, "20%-80% Rise-/Fall-Time\n (simple)"), FWHM(false, HORIZONTAL, "FWHM"),
-        FWHM_INTERPOLATED(false, HORIZONTAL, "FWHM (interp.)"), LOCATION_MAXIMUM(false, HORIZONTAL, "Loc. Maximum"),
+        RISETIME_20_80(false, HORIZONTAL, "20%-80% Rise-/Fall-Time\n (simple)"),
+        FWHM(false, HORIZONTAL, "FWHM"),
+        FWHM_INTERPOLATED(false, HORIZONTAL, "FWHM (interp.)"),
+        LOCATION_MAXIMUM(false, HORIZONTAL, "Loc. Maximum"),
         LOCATION_MAXIMUM_GAUSS(false, HORIZONTAL, "Loc. Maximum\n(Gauss-interp.)"),
-        DUTY_CYCLE(false, HORIZONTAL, "Duty Cycle\n(10% hysteresis)"), PERIOD(true, HORIZONTAL, "Period"),
+        DUTY_CYCLE(false, HORIZONTAL, "Duty Cycle\n(10% hysteresis)"),
+        PERIOD(true, HORIZONTAL, "Period"),
         FREQUENCY(false, HORIZONTAL, "Frequency");
 
         private String name;

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/DataSetSelector.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/DataSetSelector.java
@@ -2,6 +2,7 @@ package de.gsi.chart.plugins.measurements.utils;
 
 import de.gsi.chart.XYChart;
 import de.gsi.dataset.DataSet;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
@@ -21,7 +22,9 @@ public class DataSetSelector extends HBox {
         super();
         final Label label = new Label("Selected Dataset:");
 
-        allDataSets = chart.getAllDatasets();
+        // wrap observable Array List, to prevent resetting the selection model whenever getAllDatasets() is called
+        // somewhere in the code.
+        allDataSets = FXCollections.observableArrayList(chart.getAllDatasets());
         dataSets = new ListView<>(allDataSets);
         dataSets.setOrientation(Orientation.VERTICAL);
         dataSets.setPrefSize(-1, DataSetSelector.DEFAULT_SELECTOR_HEIGHT);


### PR DESCRIPTION
The DataSet selection used the list returned by chart.getAllDataSets().
This function always returns the same ObservableArrayList, but on each call,
the list is cleared and refilled. This happens all the time, because eg the axes
use it to rescale to the data in each render loop. When the list is cleared, the
selection model is reset.

This PR fixes this issue by initializing a private observableList with the one
returned by getAllDataSets(). Now the listView only updates when the dialog is
closed and reopened, but this is imho not too bad.

Should also fix the issue described in #67