### PR TITLE
EditAxis: Only add event handlers on change if chart is defined

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditAxis.java
@@ -140,7 +140,9 @@ public class EditAxis extends ChartPlugin {
 
     private void axesChangedHandler(@SuppressWarnings("unused") Observable observable) { // parameter for EventHandler api
         removeMouseEventHandlers(getChart());
-        addMouseEventHandlers(getChart());
+        if (getChart() != null) {
+            addMouseEventHandlers(getChart());
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

I had a problem when calling _chart.getAxes().clear()_ with the EditAxis plugin. A safe guard for the chart solved it for me.

```
java.lang.NullPointerException
    at de.gsi.chart.plugins.EditAxis.addMouseEventHandlers (EditAxis.java:137)
    at de.gsi.chart.plugins.EditAxis.axesChangedHandler (EditAxis.java:143)
    at com.sun.javafx.collections.ListListenerHelper$Generic.fireValueChangedEvent (ListListenerHelper.java:321)
    at com.sun.javafx.collections.ListListenerHelper.fireValueChangedEvent (ListListenerHelper.java:73)
    at javafx.collections.ObservableListBase.fireChange (ObservableListBase.java:233)
    at javafx.collections.ListChangeBuilder.commit (ListChangeBuilder.java:482)
    at javafx.collections.ListChangeBuilder.endChange (ListChangeBuilder.java:541)
    at javafx.collections.ObservableListBase.endChange (ObservableListBase.java:205)
    at javafx.collections.ModifiableObservableListBase.removeRange (ModifiableObservableListBase.java:123)
    at java.util.AbstractList.clear (AbstractList.java:243)
```