### PR TITLE
Fix Histogram2D interface

### DIFF
--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
@@ -79,28 +79,11 @@ public class Histogram2 extends AbstractHistogram implements Histogram2D, DataSe
 
     @Override
     public double get(final int dimIndex, final int binIndex) {
+        if (dimIndex == DIM_Z) {
+            return this.getBinContent(binIndex);
+        }
         return getBinCenter(dimIndex, binIndex + 1);
     }
-
-    // /*
-    // * (non-Javadoc)
-    // *
-    // * @see de.gsi.dataset.DataSet#getX(int)
-    // */
-    // @Override
-    // public double getX(int i) {
-    // return getBinCenter(DIM_X, i + 1);
-    // }
-    //
-    // /*
-    // * (non-Javadoc)
-    // *
-    // * @see de.gsi.dataset.DataSet#getY(int)
-    // */
-    // @Override
-    // public double getY(int i) {
-    // return getBinCenter(DIM_Y, i + 1);
-    // }
 
     @Override
     public int getDataCount() {


### PR DESCRIPTION
Histogram2D DataSets where not correctly rendered by the
ContourDataSetRenderer because the getter did not return valid data for
DIM_Z.