### PR TITLE
Prevent recomputeLimits being called on every DataSet set operation

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -19,6 +19,7 @@ import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet2D;
 import de.gsi.dataset.DataSet3D;
 import de.gsi.dataset.DataSetError;
+import de.gsi.dataset.event.AxisRangeChangeEvent;
 import de.gsi.dataset.event.EventListener;
 import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
@@ -184,8 +185,8 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         private double yShift;
         private final transient List<EventListener> updateListener = new ArrayList<>();
         private final transient List<AxisDescription> axesDescriptions = new ArrayList<>(Arrays.asList( //
-                new DefaultAxisDescription(Demux3dTo2dDataSet.this, "x-Axis", "a.u."), //
-                new DefaultAxisDescription(Demux3dTo2dDataSet.this, "y-Axis", "a.u.")));
+                new DefaultAxisDescription("x-Axis", "a.u."), //
+                new DefaultAxisDescription("y-Axis", "a.u.")));
 
         public Demux3dTo2dDataSet(final DataSet3D sourceDataSet, final int selectedYIndex) {
             super();
@@ -295,7 +296,8 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
 
         @Override
         public DataSet recomputeLimits(int dimension) {
-            this.setYMax(dataSet.getAxisDescription(2));
+            this.setYMax(dataSet.getAxisDescription(DIM_Z));
+            notifyRangeChange();
             return this;
         }
 
@@ -309,6 +311,16 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
 
             Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).set(zAxis.getName(), zAxis.getUnit(), zAxis.getMin(),
                     zRangeMax * (1 + mountainRaingeExtra));
+        }
+        
+        private final void notifyRangeChange() {
+            if (dataSet == null || !dataSet.autoNotification().get()) {
+                return;
+            }
+            final String name = Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).getName();
+            final String unit = Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).getUnit();
+            dataSet.invokeListener(
+                    new AxisRangeChangeEvent(dataSet, "updated axis range for '" + name + "' '[" + unit + "]'", -1));
         }
 
         @Override

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -9,6 +9,12 @@ import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.canvas.GraphicsContext;
+
 import de.gsi.chart.Chart;
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.Axis;
@@ -26,11 +32,6 @@ import de.gsi.dataset.locks.DefaultDataSetLock;
 import de.gsi.dataset.spi.DefaultAxisDescription;
 import de.gsi.dataset.utils.AssertUtils;
 import de.gsi.dataset.utils.ProcessingProfiler;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.scene.canvas.GraphicsContext;
 
 /**
  * @author rstein
@@ -156,7 +157,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
                     }
                 });
             }
-
         }
 
         ProcessingProfiler.getTimeDiff(start);
@@ -312,7 +312,7 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
             Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).set(zAxis.getName(), zAxis.getUnit(), zAxis.getMin(),
                     zRangeMax * (1 + mountainRaingeExtra));
         }
-        
+
         private final void notifyRangeChange() {
             if (dataSet == null || !dataSet.autoNotification().get()) {
                 return;
@@ -351,6 +351,5 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
                 throw new IndexOutOfBoundsException("dimIndex=" + dimIndex + " out of range");
             }
         }
-
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -566,14 +566,12 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
      */
     @Override
     public D recomputeLimits(final int dimIndex) {
-        lock().writeLockGuard(() -> {
-            // Clear previous ranges
-            getAxisDescription(dimIndex).clear();
-            final int dataCount = getDataCount(dimIndex);
-            for (int i = 0; i < dataCount; i++) {
-                getAxisDescription(dimIndex).add(get(dimIndex, i));
-            }
-        });
+        // Clear previous ranges
+        getAxisDescription(dimIndex).clear();
+        final int dataCount = getDataCount(dimIndex);
+        for (int i = 0; i < dataCount; i++) {
+            getAxisDescription(dimIndex).add(get(dimIndex, i));
+        }
         return getThis();
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
@@ -46,36 +46,34 @@ public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends 
      */
     @Override
     public D recomputeLimits(final int dimension) {
-        lock().writeLockGuard(() -> {
-            // Clear previous ranges
-            getAxisDescription(dimension).clear();
+        // Clear previous ranges
+        getAxisDescription(dimension).clear();
 
-            if (dimension == 0) {
-                // x-range
-                final int dataCount = getDataCount(DataSet.DIM_X);
-                AxisDescription axisRange = getAxisDescription(dimension);
-                for (int i = 0; i < dataCount; i++) {
-                    axisRange.add(getX(i));
-                }
-            } else if (dimension == 1) {
-                // x-range
-                final int dataCount = getDataCount(DataSet.DIM_Y);
-                AxisDescription axisRange = getAxisDescription(dimension);
-                for (int i = 0; i < dataCount; i++) {
-                    axisRange.add(getY(i));
-                }
-            } else {
-                // z-range
-                final int xDataCount = getDataCount(DataSet.DIM_X);
-                final int yDataCount = getDataCount(DataSet.DIM_Y);
-                AxisDescription axisRange = getAxisDescription(dimension);
-                for (int i = 0; i < xDataCount; i++) {
-                    for (int j = 0; j < yDataCount; j++) {
-                        axisRange.add(getZ(i, j));
-                    }
+        if (dimension == 0) {
+            // x-range
+            final int dataCount = getDataCount(DataSet.DIM_X);
+            AxisDescription axisRange = getAxisDescription(dimension);
+            for (int i = 0; i < dataCount; i++) {
+                axisRange.add(getX(i));
+            }
+        } else if (dimension == 1) {
+            // x-range
+            final int dataCount = getDataCount(DataSet.DIM_Y);
+            AxisDescription axisRange = getAxisDescription(dimension);
+            for (int i = 0; i < dataCount; i++) {
+                axisRange.add(getY(i));
+            }
+        } else {
+            // z-range
+            final int xDataCount = getDataCount(DataSet.DIM_X);
+            final int yDataCount = getDataCount(DataSet.DIM_Y);
+            AxisDescription axisRange = getAxisDescription(dimension);
+            for (int i = 0; i < xDataCount; i++) {
+                for (int j = 0; j < yDataCount; j++) {
+                    axisRange.add(getZ(i, j));
                 }
             }
-        });
+        }
         return getThis();
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
@@ -76,5 +76,4 @@ public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends 
         }
         return getThis();
     }
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
@@ -69,34 +69,32 @@ public abstract class AbstractErrorDataSet<D extends AbstractErrorDataSet<D>> ex
      */
     @Override
     public D recomputeLimits(final int dimIndex) {
-        lock().writeLockGuard(() -> {
-            // Clear previous ranges
-            getAxisDescription(dimIndex).clear();
-            final int dataCount = getDataCount(dimIndex);
-            switch (getErrorType(dimIndex)) {
-            case NO_ERROR:
-                super.recomputeLimits(dimIndex);
-                break;
-            case ASYMMETRIC:
-                for (int i = 0; i < dataCount; i++) {
-                    final double value = get(dimIndex, i);
-                    final double errorNeg = getErrorNegative(dimIndex, i);
-                    final double errorPos = getErrorPositive(dimIndex, i);
-                    getAxisDescription(dimIndex).add(value - errorNeg);
-                    getAxisDescription(dimIndex).add(value + errorPos);
-                }
-                break;
-            case SYMMETRIC:
-            default:
-                for (int i = 0; i < dataCount; i++) {
-                    final double value = get(dimIndex, i);
-                    final double error = getErrorPositive(dimIndex, i);
-                    getAxisDescription(dimIndex).add(value - error);
-                    getAxisDescription(dimIndex).add(value + error);
-                }
-                break;
+        // Clear previous ranges
+        getAxisDescription(dimIndex).clear();
+        final int dataCount = getDataCount(dimIndex);
+        switch (getErrorType(dimIndex)) {
+        case NO_ERROR:
+            super.recomputeLimits(dimIndex);
+            break;
+        case ASYMMETRIC:
+            for (int i = 0; i < dataCount; i++) {
+                final double value = get(dimIndex, i);
+                final double errorNeg = getErrorNegative(dimIndex, i);
+                final double errorPos = getErrorPositive(dimIndex, i);
+                getAxisDescription(dimIndex).add(value - errorNeg);
+                getAxisDescription(dimIndex).add(value + errorPos);
             }
-        });
+            break;
+        case SYMMETRIC:
+        default:
+            for (int i = 0; i < dataCount; i++) {
+                final double value = get(dimIndex, i);
+                final double error = getErrorPositive(dimIndex, i);
+                getAxisDescription(dimIndex).add(value - error);
+                getAxisDescription(dimIndex).add(value + error);
+            }
+            break;
+        }
         return getThis();
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractHistogram.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractHistogram.java
@@ -36,9 +36,9 @@ public abstract class AbstractHistogram extends AbstractDataSet<AbstractHistogra
         Arrays.sort(xBinsSorted);
         for (int i = 0; i < nBins; i++) {
             axisBins[0][i + 1] = xBinsSorted[i];
-            getAxisDescription(0).add(xBinsSorted[i]);
+            getAxisDescription(DIM_X).add(xBinsSorted[i]);
         }
-        getAxisDescription(1).clear();
+        getAxisDescription(DIM_Y).clear();
         equidistant = false;
     }
 
@@ -56,8 +56,8 @@ public abstract class AbstractHistogram extends AbstractDataSet<AbstractHistogra
         nAxisBins[0] = nBins + 2; // N.B. one bin for underflow, one bin for overflow
         nAxisBins[1] = nBins + 2;
         data = new double[nAxisBins[0]];
-        getAxisDescription(0).set(minX, maxX);
-        getAxisDescription(1).clear();
+        getAxisDescription(DIM_X).set(minX, maxX);
+        getAxisDescription(DIM_Y).clear();
         equidistant = true;
     }
 
@@ -80,8 +80,8 @@ public abstract class AbstractHistogram extends AbstractDataSet<AbstractHistogra
         nAxisBins[1] = nBinsY + 2;
         nAxisBins[2] = nBinsX * nBinsY + 2;
         data = new double[nAxisBins[2]];
-        getAxisDescription(0).set(minX, maxX);
-        getAxisDescription(1).set(minY, maxY);
+        getAxisDescription(DIM_X).set(minX, maxX);
+        getAxisDescription(DIM_Y).set(minY, maxY);
         getAxisDescription(2).clear();
         equidistant = true;
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AveragingDataSet.java
@@ -59,8 +59,8 @@ public class AveragingDataSet extends AbstractDataSet<AveragingDataSet> implemen
             deque.add(new InternalDataSet(ds));
             dataset.opScale(1.0 / deque.size());
         }
-        dataset.recomputeLimits(0);
-        dataset.recomputeLimits(1);
+        dataset.recomputeLimits(DIM_X);
+        dataset.recomputeLimits(DIM_Y);
         fireInvalidated(new AddedDataEvent(this));
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
@@ -91,8 +91,8 @@ public class CircularDoubleErrorDataSet extends AbstractErrorDataSet<CircularDou
             dataTag.put(tag);
             dataStyles.put(style);
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
 
         return fireInvalidated(new AddedDataEvent(this));
@@ -128,8 +128,11 @@ public class CircularDoubleErrorDataSet extends AbstractErrorDataSet<CircularDou
             dataTag.put(new String[yErrPos.length], yErrPos.length);
             dataStyles.put(new String[yErrPos.length], yErrPos.length);
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            getAxisDescription(DIM_X).add(xVals);
+            for (int i = 0; i < yVals.length; i++) {
+                getAxisDescription(DIM_Y).add(yVals[i]+ yErrPos[i]);
+                getAxisDescription(DIM_Y).add(yVals[i]- yErrNeg[i]);
+            }
         });
 
         return fireInvalidated(new AddedDataEvent(this));

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/CircularDoubleErrorDataSet.java
@@ -130,8 +130,8 @@ public class CircularDoubleErrorDataSet extends AbstractErrorDataSet<CircularDou
 
             getAxisDescription(DIM_X).add(xVals);
             for (int i = 0; i < yVals.length; i++) {
-                getAxisDescription(DIM_Y).add(yVals[i]+ yErrPos[i]);
-                getAxisDescription(DIM_Y).add(yVals[i]- yErrNeg[i]);
+                getAxisDescription(DIM_Y).add(yVals[i] + yErrPos[i]);
+                getAxisDescription(DIM_Y).add(yVals[i] - yErrNeg[i]);
             }
         });
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataRange.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataRange.java
@@ -267,9 +267,11 @@ public class DataRange {
     public String toString() {
         final StringBuilder sb = new StringBuilder(50);
         sb.append(this.getClass().getSimpleName()) //
-                .append(" [min=").append(isMinDefined() ? getMin() : "NotDefined") //
-                .append(", max=").append(isMaxDefined() ? getMax() : "NotDefined").append(']');
+                .append(" [min=")
+                .append(isMinDefined() ? getMin() : "NotDefined") //
+                .append(", max=")
+                .append(isMaxDefined() ? getMax() : "NotDefined")
+                .append(']');
         return sb.toString();
     }
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataRange.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DataRange.java
@@ -155,11 +155,9 @@ public class DataRange {
      * @return max - min or 0.0 if the range is not defined.
      */
     public double getLength() {
-        if (isDefined()) {
-            return max - min;
-        }
-
-        return 0.0;
+        double len = getMax() - getMin();
+        // subclasses of DataRange might override getMax/Min to recompute the range.
+        return isDefined() ? len : 0.0;
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
@@ -179,6 +179,58 @@ public class DefaultAxisDescription extends DataRange implements AxisDescription
     }
 
     @Override
+    public final double getMax() {
+        if (this.isMaxDefined()) {
+            return super.getMax();
+        }
+        // axis range min value is invalid -- attempt to recompute
+        // the recomputeLimits is usually recomputed when validating the axis,
+        // this function is called in case e.g. a point has been modified and range invalidated
+
+        if (dataSet != null) {
+            boolean notify = false;
+            for (int dim = 0; dim < dataSet.getDimension(); dim++) {
+                if (dataSet.getAxisDescription(dim).isDefined()) {
+                    continue;
+                }
+                dataSet.recomputeLimits(dim);
+                notify = true;
+            }
+            if (notify) {
+                notifyRangeChange();
+            }
+        }
+
+        return super.getMax();
+    }
+
+    @Override
+    public final double getMin() {
+        if (this.isMinDefined()) {
+            return super.getMin();
+        }
+        // axis range min value is invalid -- attempt to recompute
+        // the recomputeLimits is usually recomputed when validating the axis,
+        // this function is called in case e.g. a point has been modified and range invalidated
+
+        if (dataSet != null) {
+            boolean notify = false;
+            for (int dim = 0; dim < dataSet.getDimension(); dim++) {
+                if (dataSet.getAxisDescription(dim).isDefined()) {
+                    continue;
+                }
+                dataSet.recomputeLimits(dim);
+                notify = true;
+            }
+            if (notify) {
+                notifyRangeChange();
+            }
+        }
+
+        return super.getMin();
+    }
+
+    @Override
     public final String getName() {
         return name;
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
@@ -190,6 +190,9 @@ public class DefaultAxisDescription extends DataRange implements AxisDescription
         if (dataSet != null) {
             boolean notify = false;
             for (int dim = 0; dim < dataSet.getDimension(); dim++) {
+                if (dim >= dataSet.getAxisDescriptions().size()) {
+                    break;
+                }
                 if (dataSet.getAxisDescription(dim).isDefined()) {
                     continue;
                 }
@@ -216,6 +219,9 @@ public class DefaultAxisDescription extends DataRange implements AxisDescription
         if (dataSet != null) {
             boolean notify = false;
             for (int dim = 0; dim < dataSet.getDimension(); dim++) {
+                if (dim >= dataSet.getAxisDescriptions().size()) {
+                    break;
+                }
                 if (dataSet.getAxisDescription(dim).isDefined()) {
                     continue;
                 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DimReductionDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DimReductionDataSet.java
@@ -85,16 +85,22 @@ public class DimReductionDataSet extends DoubleDataSet implements EventListener 
     }
 
     public void setMaxIndex(final int dimIndex, double val) {
+        // disable notifications for the source dataSet, to prevent an infinite loop
+        source.removeListener(this);
         lock().writeLockGuard(() -> {
             indexMax = source.getIndex(dimIndex, val);
         });
+        source.addListener(this);
         this.handle(new UpdateEvent(this, "changed indexMax"));
     }
 
     public void setMinIndex(final int dimIndex, double val) {
+        // disable notifications for the source dataSet, to prevent an infinite loop
+        source.removeListener(this);
         lock().writeLockGuard(() -> {
             indexMin = source.getIndex(dimIndex, val);
         });
+        source.addListener(this);
         this.handle(new UpdateEvent(this, "changed indexMax"));
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
@@ -296,9 +296,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             getDataLabelMap().remove(fromIndex, clampedToIndex);
             getDataStyleMap().remove(fromIndex, clampedToIndex);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -424,8 +423,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
                 this.yValues = DoubleArrayList.wrap(yValues, nSamplesToAdd);
             }
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -460,9 +459,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             getDataLabelMap().remove(index);
             getDataStyleMap().remove(index);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this, "set - single"));
     }
@@ -475,9 +473,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             getDataLabelMap().remove(index, index + x.length);
             getDataStyleMap().remove(index, index + x.length);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this, "set - via arrays"));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleDataSet.java
@@ -107,8 +107,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
                 addDataLabel(xValues.size() - 1, label);
             }
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new UpdatedDataEvent(this, "add"));
     }
@@ -132,8 +132,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             xValues.setElements(addAt, xValuesNew);
             yValues.setElements(addAt, yValuesNew);
 
-            getAxisDescription(0).add(xValuesNew);
-            getAxisDescription(1).add(yValuesNew);
+            getAxisDescription(DIM_X).add(xValuesNew);
+            getAxisDescription(DIM_Y).add(yValuesNew);
         });
 
         return fireInvalidated(new AddedDataEvent(this));
@@ -180,8 +180,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             yValues.add(indexAt, y);
             getDataLabelMap().addValueAndShiftKeys(indexAt, xValues.size(), label);
             getDataStyleMap().shiftKeys(indexAt, xValues.size());
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -204,8 +204,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             final int indexAt = Math.max(0, Math.min(index, getDataCount() + 1));
             xValues.addElements(indexAt, x, 0, min);
             yValues.addElements(indexAt, y, 0, min);
-            getAxisDescription(0).add(x, min);
-            getAxisDescription(0).add(y, min);
+            getAxisDescription(DIM_X).add(x, min);
+            getAxisDescription(DIM_Y).add(y, min);
             getDataLabelMap().shiftKeys(indexAt, xValues.size());
             getDataStyleMap().shiftKeys(indexAt, xValues.size());
         });

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
@@ -135,9 +135,9 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
                 addDataLabel(xValues.size() - 1, label);
             }
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y - yErrorNeg);
-            getAxisDescription(1).add(y + yErrorPos);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y - yErrorNeg);
+            getAxisDescription(DIM_Y).add(y + yErrorPos);
         });
         return fireInvalidated(new UpdatedDataEvent(this, "add"));
     }
@@ -239,9 +239,9 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             yErrorsPos.add(indexAt, yErrorPos);
             getDataLabelMap().addValueAndShiftKeys(indexAt, xValues.size(), label);
             getDataStyleMap().shiftKeys(indexAt, xValues.size());
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y - yErrorNeg);
-            getAxisDescription(1).add(y + yErrorPos);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y - yErrorNeg);
+            getAxisDescription(DIM_Y).add(y + yErrorPos);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleErrorDataSet.java
@@ -273,9 +273,9 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             yErrorsNeg.addElements(indexAt, yErrorNeg, 0, min);
             yErrorsPos.addElements(indexAt, yErrorPos, 0, min);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // recompute ranges
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
 
             getDataLabelMap().shiftKeys(indexAt, xValues.size());
             getDataStyleMap().shiftKeys(indexAt, xValues.size());
@@ -406,9 +406,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             getDataLabelMap().remove(fromIndex, clampedToIndex);
             getDataLabelMap().remove(fromIndex, clampedToIndex);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -570,8 +569,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
                 this.yErrorsPos = DoubleArrayList.wrap(yErrorsPos, nSamplesToAdd);
             }
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -628,9 +627,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             getDataLabelMap().remove(index);
             getDataStyleMap().remove(index);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
 
         return fireInvalidated(new UpdatedDataEvent(this, "set - single"));
@@ -647,9 +645,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             getDataLabelMap().remove(index, index + x.length);
             getDataStyleMap().remove(index, index + x.length);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this, "set - via arrays"));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
@@ -97,8 +97,8 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
             // remove old fields
             expire(x);
 
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         fireInvalidated(new AddedDataEvent(this));
 
@@ -150,10 +150,10 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
                         // data.remove(blob);
                         toRemoveList.add(blob);
                     } else {
-                        getAxisDescription(0).add(x + blob.getErrorX());
-                        getAxisDescription(0).add(x - blob.getErrorX());
-                        getAxisDescription(1).add(y + blob.getErrorY());
-                        getAxisDescription(1).add(y - blob.getErrorY());
+                        getAxisDescription(DIM_X).add(x + blob.getErrorX());
+                        getAxisDescription(DIM_X).add(x - blob.getErrorX());
+                        getAxisDescription(DIM_Y).add(y + blob.getErrorY());
+                        getAxisDescription(DIM_Y).add(y - blob.getErrorY());
                     }
                 } else {
                     // data.remove(blob);
@@ -162,8 +162,8 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
             }
 
             data.removeAll(toRemoveList);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
             // computeLimits(); // N.B. already computed above
             return toRemoveList.size();
         });

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FifoDoubleErrorDataSet.java
@@ -97,8 +97,8 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
             // remove old fields
             expire(x);
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         fireInvalidated(new AddedDataEvent(this));
 
@@ -162,9 +162,8 @@ public class FifoDoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorData
             }
 
             data.removeAll(toRemoveList);
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
-            // computeLimits(); // N.B. already computed above
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
             return toRemoveList.size();
         });
         if (dataPointsToRemove != 0) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
@@ -445,8 +445,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
                 this.yValues = FloatArrayList.wrap(yValues, nSamplesToAdd);
             }
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -487,9 +487,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
             getDataLabelMap().remove(index, index + x.length);
             getDataStyleMap().remove(index, index + x.length);
 
-            // invalidate and recompute ranges
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FloatDataSet.java
@@ -108,8 +108,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
                 addDataLabel(xValues.size() - 1, label);
             }
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -134,10 +134,10 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
             yValues.addElements(yValues.size(), yValuesNew);
 
             for (int i = 0; i < xValuesNew.length; i++) {
-                getAxisDescription(0).add(xValuesNew[i]);
+                getAxisDescription(DIM_X).add(xValuesNew[i]);
             }
             for (int i = 0; i < yValuesNew.length; i++) {
-                getAxisDescription(1).add(yValuesNew[i]);
+                getAxisDescription(DIM_Y).add(yValuesNew[i]);
             }
         });
         return fireInvalidated(new AddedDataEvent(this));
@@ -184,8 +184,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
             yValues.add(indexAt, y);
             getDataLabelMap().addValueAndShiftKeys(indexAt, xValues.size(), label);
             getDataStyleMap().shiftKeys(indexAt, xValues.size());
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -209,8 +209,8 @@ public class FloatDataSet extends AbstractDataSet<FloatDataSet> implements Edita
             xValues.addElements(indexAt, x, 0, min);
             yValues.addElements(indexAt, y, 0, min);
             for (int i = 0; i < min; i++) {
-                getAxisDescription(0).add(x[i]);
-                getAxisDescription(1).add(y[i]);
+                getAxisDescription(DIM_X).add(x[i]);
+                getAxisDescription(DIM_Y).add(y[i]);
             }
 
             getDataLabelMap().shiftKeys(indexAt, xValues.size());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
@@ -42,9 +42,11 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
             Collections.sort(list,
                     (o1, o2) -> Double.compare(o1.getAxisDescription(DIM_X).getMin(), o2.getAxisDescription(DIM_X).getMin()));
             dataCount += set.getDataCount();
+            getAxisDescription(DIM_X).add(set.getAxisDescription(DIM_X).getMax());
+            getAxisDescription(DIM_X).add(set.getAxisDescription(DIM_X).getMin());
+            getAxisDescription(DIM_Y).add(set.getAxisDescription(DIM_Y).getMax());
+            getAxisDescription(DIM_Y).add(set.getAxisDescription(DIM_Y).getMin());
         });
-        recomputeLimits(DIM_X);
-        recomputeLimits(DIM_Y);
         fireInvalidated(new AddedDataEvent(this, "added data set"));
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/FragmentedDataSet.java
@@ -40,11 +40,11 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
             list.add(set);
             /* Trace data is expected to be sorted in ascending order */
             Collections.sort(list,
-                    (o1, o2) -> Double.compare(o1.getAxisDescription(0).getMin(), o2.getAxisDescription(0).getMin()));
+                    (o1, o2) -> Double.compare(o1.getAxisDescription(DIM_X).getMin(), o2.getAxisDescription(DIM_X).getMin()));
             dataCount += set.getDataCount();
         });
-        recomputeLimits(0);
-        recomputeLimits(1);
+        recomputeLimits(DIM_X);
+        recomputeLimits(DIM_Y);
         fireInvalidated(new AddedDataEvent(this, "added data set"));
     }
 
@@ -119,12 +119,12 @@ public class FragmentedDataSet extends AbstractDataSet<FragmentedDataSet> implem
     @Override
     public int getXIndex(double x) {
         return lock().readLockGuard(() -> {
-            if (x < getAxisDescription(0).getMin()) {
+            if (x < getAxisDescription(DIM_X).getMin()) {
                 return 0;
             }
             int index = 0;
             for (final DataSet dataset : list) {
-                if (x >= dataset.getAxisDescription(0).getMin() && x <= dataset.getAxisDescription(0).getMax()) {
+                if (x >= dataset.getAxisDescription(DIM_X).getMin() && x <= dataset.getAxisDescription(DIM_X).getMax()) {
                     return index + dataset.getIndex(DIM_X, x);
                 }
                 index += dataset.getDataCount();

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
@@ -66,8 +66,8 @@ public class Histogram extends AbstractHistogram implements Histogram1D {
         super(name, nBins, minX, maxX);
         isHorizontal = horizontal;
         if (!isHorizontal) {
-            getAxisDescription(0).clear();
-            getAxisDescription(1).set(minX, maxX);
+            getAxisDescription(DIM_X).clear();
+            getAxisDescription(DIM_Y).set(minX, maxX);
         }
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
@@ -235,5 +235,4 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
     //
     // return unlock();
     // }
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LabelledMarkerDataSet.java
@@ -46,7 +46,7 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
         AssertUtils.notNull("marker", marker);
         lock().writeLockGuard(() -> {
             data.add(new DoublePoint(marker.getX(), marker.getY()));
-            getAxisDescription(0).add(marker.getX());
+            getAxisDescription(DIM_X).add(marker.getX());
             // yRange.add(marker.getY());
             dataLabels.add(marker.getLabel());
             dataStyles.add(marker.getStyle());
@@ -168,7 +168,7 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
         AssertUtils.indexInBounds(index, getDataCount());
         lock().writeLockGuard(() -> {
             data.get(index).set(marker.getX(), marker.getY());
-            getAxisDescription(0).add(marker.getX());
+            getAxisDescription(DIM_X).add(marker.getX());
             // yRange.add(marker.getY());
             dataLabels.set(index, marker.getLabel());
             dataStyles.set(index, marker.getStyle());
@@ -205,7 +205,7 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
                 final double x = marker.getX();
                 final double y = marker.getY();
                 data.add(new DoublePoint(x, y));
-                getAxisDescription(0).add(x);
+                getAxisDescription(DIM_X).add(x);
                 // yRange.add(y);
                 dataLabels.add(marker.getLabel());
                 dataStyles.add(marker.getStyle());
@@ -229,8 +229,8 @@ public class LabelledMarkerDataSet extends AbstractDataSet<LabelledMarkerDataSet
     // final int dataCount = getDataCount();
     //
     // for (int i = 0; i < dataCount; i++) {
-    // getAxisDescription(0).add(getX(i));
-    // // getAxisDescription(1).add(getY(i));
+    // getAxisDescription(DIM_X).add(getX(i));
+    // // getAxisDescription(DIM_Y).add(getY(i));
     // }
     //
     // return unlock();

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
@@ -204,8 +204,8 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
                 for (; data.size() > maxQueueSize || now - first.getX() > maxLength; first = data.first()) {
                     data.remove(first);
                 }
-                recomputeLimits(DIM_X);
-                recomputeLimits(DIM_Y);
+                // invalidate ranges
+                getAxisDescriptions().forEach(AxisDescription::clear);
             } catch (final NoSuchElementException cannotDoAnythingHere) {
                 // cannot do anything here
             }
@@ -326,10 +326,8 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            getAxisDescription(DIM_X).setMax(Double.NaN);
-            getAxisDescription(DIM_Y).setMax(Double.NaN);
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/LimitedIndexedTreeDataSet.java
@@ -78,10 +78,10 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
             final String... labelStyle) {
         lock().writeLockGuard(() -> {
             data.add(new DataAtom(x, y, ex, ey, labelStyle));
-            getAxisDescription(0).add(x - ex);
-            getAxisDescription(0).add(x + ex);
-            getAxisDescription(1).add(y - ey);
-            getAxisDescription(1).add(y + ey);
+            getAxisDescription(DIM_X).add(x - ex);
+            getAxisDescription(DIM_X).add(x + ex);
+            getAxisDescription(DIM_Y).add(y - ey);
+            getAxisDescription(DIM_Y).add(y + ey);
             expire();
         });
         return fireInvalidated(new AddedDataEvent(this));
@@ -126,10 +126,10 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
                 final double ey = yErrors[i];
                 data.add(new DataAtom(x, y, ex, ey, labelStyle)); // NOPMD need to initialise object in loop by design
 
-                getAxisDescription(0).add(x - ex);
-                getAxisDescription(0).add(x + ex);
-                getAxisDescription(1).add(y - ey);
-                getAxisDescription(1).add(y + ey);
+                getAxisDescription(DIM_X).add(x - ex);
+                getAxisDescription(DIM_X).add(x + ex);
+                getAxisDescription(DIM_Y).add(y - ey);
+                getAxisDescription(DIM_Y).add(y + ey);
             }
             expire();
         });
@@ -204,8 +204,8 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
                 for (; data.size() > maxQueueSize || now - first.getX() > maxLength; first = data.first()) {
                     data.remove(first);
                 }
-                recomputeLimits(0);
-                recomputeLimits(1);
+                recomputeLimits(DIM_X);
+                recomputeLimits(DIM_Y);
             } catch (final NoSuchElementException cannotDoAnythingHere) {
                 // cannot do anything here
             }
@@ -301,8 +301,8 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
             }
             data.removeAll(toRemove);
 
-            getAxisDescription(0).setMax(Double.NaN);
-            getAxisDescription(1).setMax(Double.NaN);
+            getAxisDescription(DIM_X).setMax(Double.NaN);
+            getAxisDescription(DIM_Y).setMax(Double.NaN);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -326,10 +326,10 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            getAxisDescription(0).setMax(Double.NaN);
-            getAxisDescription(1).setMax(Double.NaN);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            getAxisDescription(DIM_X).setMax(Double.NaN);
+            getAxisDescription(DIM_Y).setMax(Double.NaN);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -414,10 +414,10 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
                 final double y = yValues[i];
                 final double dx = xErrors[i];
                 final double dy = yValues[i];
-                getAxisDescription(0).add(x - dx);
-                getAxisDescription(0).add(x + dx);
-                getAxisDescription(1).add(y - dy);
-                getAxisDescription(1).add(y + dy);
+                getAxisDescription(DIM_X).add(x - dx);
+                getAxisDescription(DIM_X).add(x + dx);
+                getAxisDescription(DIM_Y).add(y - dy);
+                getAxisDescription(DIM_Y).add(y + dy);
                 data.add(new DataAtom(x, y, dx, dy)); // NOPMD need to initialise object in loop by design
             }
             expire();
@@ -484,10 +484,10 @@ public class LimitedIndexedTreeDataSet extends AbstractErrorDataSet<LimitedIndex
         lock().writeLockGuard(() -> {
             data.get(index).set(x, y, dy, dy);
 
-            getAxisDescription(0).add(x - dx);
-            getAxisDescription(0).add(x + dx);
-            getAxisDescription(1).add(y - dy);
-            getAxisDescription(1).add(y + dy);
+            getAxisDescription(DIM_X).add(x - dx);
+            getAxisDescription(DIM_X).add(x + dx);
+            getAxisDescription(DIM_Y).add(y - dy);
+            getAxisDescription(DIM_Y).add(y + dy);
             expire();
         });
         return fireInvalidated(new UpdatedDataEvent(this));

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
@@ -273,8 +273,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -338,8 +338,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
             data.clear();
             data.addAll(values);
 
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListDataSet.java
@@ -111,8 +111,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
         lock().writeLockGuard(() -> {
             data.add(new DoublePoint(x, y));
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -134,12 +134,12 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
 
         lock().writeLockGuard(() -> {
             data.clear();
-            getAxisDescription(0).setMax(Double.NaN);
-            getAxisDescription(1).setMax(Double.NaN);
+            getAxisDescription(DIM_X).setMax(Double.NaN);
+            getAxisDescription(DIM_Y).setMax(Double.NaN);
             for (int i = 0; i < xValues.length; i++) {
                 data.add(new DoublePoint(xValues[i], yValues[i]));
-                getAxisDescription(0).add(xValues[i]);
-                getAxisDescription(1).add(yValues[i]);
+                getAxisDescription(DIM_X).add(xValues[i]);
+                getAxisDescription(DIM_Y).add(yValues[i]);
             }
         });
         return fireInvalidated(new AddedDataEvent(this));
@@ -249,8 +249,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
 
             data.subList(fromIndex, toIndex).clear();
 
-            getAxisDescription(0).setMax(Double.NaN);
-            getAxisDescription(1).setMax(Double.NaN);
+            getAxisDescription(DIM_X).setMax(Double.NaN);
+            getAxisDescription(DIM_Y).setMax(Double.NaN);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -273,8 +273,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -320,8 +320,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
             AssertUtils.indexInBounds(index, getDataCount());
             data.get(index).set(x, y);
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -338,8 +338,8 @@ public class ListDataSet extends AbstractDataSet<ListDataSet> implements DataSet
             data.clear();
             data.addAll(values);
 
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
@@ -167,10 +167,10 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
         lock().writeLockGuard(() -> {
             data.add(new DoublePointError(x, y, ex, ey));
 
-            getAxisDescription(0).add(x - ex);
-            getAxisDescription(0).add(x + ex);
-            getAxisDescription(1).add(y - ey);
-            getAxisDescription(1).add(y + ey);
+            getAxisDescription(DIM_X).add(x - ex);
+            getAxisDescription(DIM_X).add(x + ex);
+            getAxisDescription(DIM_Y).add(y - ey);
+            getAxisDescription(DIM_Y).add(y + ey);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -214,10 +214,10 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
                 final double ey = yErrors[i];
                 data.add(new DoublePointError(x, y, ex, ey));
 
-                getAxisDescription(0).add(x - ex);
-                getAxisDescription(0).add(x + ex);
-                getAxisDescription(1).add(y - ey);
-                getAxisDescription(1).add(y + ey);
+                getAxisDescription(DIM_X).add(x - ex);
+                getAxisDescription(DIM_X).add(x + ex);
+                getAxisDescription(DIM_Y).add(y - ey);
+                getAxisDescription(DIM_Y).add(y + ey);
             }
         });
         return fireInvalidated(new AddedDataEvent(this));
@@ -337,8 +337,8 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
 
             data.subList(fromIndex, toIndex).clear();
 
-            getAxisDescription(0).add(Double.NaN);
-            getAxisDescription(1).add(Double.NaN);
+            getAxisDescription(DIM_X).add(Double.NaN);
+            getAxisDescription(DIM_Y).add(Double.NaN);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -362,10 +362,10 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            getAxisDescription(0).add(Double.NaN);
-            getAxisDescription(1).add(Double.NaN);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            getAxisDescription(DIM_X).add(Double.NaN);
+            getAxisDescription(DIM_Y).add(Double.NaN);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }
@@ -441,10 +441,10 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
                 final double y = yValues[i];
                 final double dx = xErrors[i];
                 final double dy = yValues[i];
-                getAxisDescription(0).add(x - dx);
-                getAxisDescription(0).add(x + dx);
-                getAxisDescription(1).add(y - dy);
-                getAxisDescription(1).add(y + dy);
+                getAxisDescription(DIM_X).add(x - dx);
+                getAxisDescription(DIM_X).add(x + dx);
+                getAxisDescription(DIM_Y).add(y - dy);
+                getAxisDescription(DIM_Y).add(y + dy);
                 data.add(new DoublePointError(x, y, dx, dy));
             }
         });
@@ -509,10 +509,10 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
         lock().writeLockGuard(() -> {
             data.get(index).set(x, y, dy, dy);
 
-            getAxisDescription(0).add(x - dx);
-            getAxisDescription(0).add(x + dx);
-            getAxisDescription(1).add(y - dy);
-            getAxisDescription(1).add(y + dy);
+            getAxisDescription(DIM_X).add(x - dx);
+            getAxisDescription(DIM_X).add(x + dx);
+            getAxisDescription(DIM_Y).add(y - dy);
+            getAxisDescription(DIM_Y).add(y + dy);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/ListErrorDataSet.java
@@ -362,10 +362,8 @@ public class ListErrorDataSet extends AbstractErrorDataSet<ListErrorDataSet> imp
             }
             data.removeAll(tupleTobeRemovedReferences);
 
-            getAxisDescription(DIM_X).add(Double.NaN);
-            getAxisDescription(DIM_Y).add(Double.NaN);
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new RemovedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/MultiDimDoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/MultiDimDoubleDataSet.java
@@ -204,7 +204,7 @@ public class MultiDimDoubleDataSet extends AbstractDataSet<MultiDimDoubleDataSet
             final int indexAt = Math.max(0, Math.min(index, getDataCount() + 1));
             for (int i = 0; i < this.values.length; i++) {
                 this.values[i].addElements(indexAt, newValues[i], 0, nPointsFinal);
-                getAxisDescription(0).add(newValues[i], nPointsFinal);
+                getAxisDescription(DIM_X).add(newValues[i], nPointsFinal);
             }
             getDataLabelMap().shiftKeys(indexAt, this.values[0].size());
             getDataStyleMap().shiftKeys(indexAt, this.values[0].size());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/MultiDimDoubleDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/MultiDimDoubleDataSet.java
@@ -404,9 +404,8 @@ public class MultiDimDoubleDataSet extends AbstractDataSet<MultiDimDoubleDataSet
                 }
             }
 
-            for (int i = 0; i < this.values.length; i++) {
-                recomputeLimits(i);
-            }
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
@@ -8,6 +8,7 @@
  */
 package de.gsi.dataset.spi;
 
+import de.gsi.dataset.AxisDescription;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.event.AddedDataEvent;
 import de.gsi.dataset.event.UpdatedDataEvent;
@@ -72,8 +73,8 @@ public class RollingDataSet extends FragmentedDataSet {
         list.add(new InternalDataSet(set));
         dataCount += set.getDataCount();
         lastLength = set.getAxisDescription(DIM_X).getMax();
-        recomputeLimits(DIM_X);
-        recomputeLimits(DIM_Y);
+        // invalidate ranges
+        getAxisDescriptions().forEach(AxisDescription::clear);
         fireInvalidated(new AddedDataEvent(this));
     }
 
@@ -104,8 +105,8 @@ public class RollingDataSet extends FragmentedDataSet {
 
         public InternalDataSet(DataSet ds) {
             super(ds);
-            recomputeLimits(DIM_X);
-            recomputeLimits(DIM_Y);
+            // invalidate ranges
+            getAxisDescriptions().forEach(AxisDescription::clear);
         }
 
         public void shift(double value) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
@@ -100,7 +100,6 @@ public class RollingDataSet extends FragmentedDataSet {
     }
 
     private class InternalDataSet extends DoubleDataSet {
-
         private static final long serialVersionUID = 1L;
 
         public InternalDataSet(DataSet ds) {
@@ -117,7 +116,5 @@ public class RollingDataSet extends FragmentedDataSet {
             });
             fireInvalidated(new UpdatedDataEvent(this));
         }
-
     }
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/RollingDataSet.java
@@ -71,9 +71,9 @@ public class RollingDataSet extends FragmentedDataSet {
         }
         list.add(new InternalDataSet(set));
         dataCount += set.getDataCount();
-        lastLength = set.getAxisDescription(0).getMax();
-        recomputeLimits(0);
-        recomputeLimits(1);
+        lastLength = set.getAxisDescription(DIM_X).getMax();
+        recomputeLimits(DIM_X);
+        recomputeLimits(DIM_Y);
         fireInvalidated(new AddedDataEvent(this));
     }
 
@@ -104,8 +104,8 @@ public class RollingDataSet extends FragmentedDataSet {
 
         public InternalDataSet(DataSet ds) {
             super(ds);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         }
 
         public void shift(double value) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/WrappedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/WrappedDataSet.java
@@ -34,8 +34,8 @@ public class WrappedDataSet extends AbstractDataSet<WrappedDataSet> implements D
     }
 
     private void datasetInvalidated() {
-        recomputeLimits(DIM_X);
-        recomputeLimits(DIM_Y);
+        // invalidate ranges
+        getAxisDescriptions().forEach(AxisDescription::clear);
         fireInvalidated(new UpdatedDataEvent(this));
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/WrappedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/WrappedDataSet.java
@@ -34,8 +34,8 @@ public class WrappedDataSet extends AbstractDataSet<WrappedDataSet> implements D
     }
 
     private void datasetInvalidated() {
-        recomputeLimits(0);
-        recomputeLimits(1);
+        recomputeLimits(DIM_X);
+        recomputeLimits(DIM_Y);
         fireInvalidated(new UpdatedDataEvent(this));
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/AbstractTestFunction.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/AbstractTestFunction.java
@@ -92,8 +92,8 @@ public abstract class AbstractTestFunction<D extends AbstractTestFunction<D>> ex
     public D update() {
         lock().writeLockGuard(() -> {
             data = generateY(data.length);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DataSetUtils.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DataSetUtils.java
@@ -261,16 +261,16 @@ public class DataSetUtils extends DataSetUtilsHelper {
                 value = dataSet == null ? "noDataset" : dataSet.getName();
                 break;
             case "xMin":
-                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(0).getMin());
+                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(DIM_X).getMin());
                 break;
             case "xMax":
-                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(0).getMax());
+                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(DIM_X).getMax());
                 break;
             case "yMin":
-                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(1).getMin());
+                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(DIM_Y).getMin());
                 break;
             case "yMax":
-                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(1).getMax());
+                value = dataSet == null ? "noDataset" : Double.toString(dataSet.getAxisDescription(DIM_Y).getMax());
                 break;
             default:
                 if (!(dataSet instanceof DataSetMetaData)) {

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DimReductionDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DimReductionDataSetTests.java
@@ -234,6 +234,12 @@ public class DimReductionDataSetTests {
         assertArrayEquals(testData.getZValues()[0], sliceDataSetX.getValues(DIM_Y), "first row match");
         assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
 
+        sliceDataSetX.setMinIndex(DIM_X, 2.0);
+        assertEquals(2, nEvent, "DataSet3D event propagated");
+
+        assertArrayEquals(testData.getZValues()[1], sliceDataSetX.getValues(DIM_Y), "first row match");
+        assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
+
         LOGGER.atDebug().log("testSliceOptions - done");
     }
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DataSetUtilsTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DataSetUtilsTest.java
@@ -3,6 +3,7 @@ package de.gsi.dataset.utils;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static de.gsi.dataset.DataSet.DIM_X;
 import static de.gsi.dataset.DataSet.DIM_Y;
 
@@ -35,7 +36,8 @@ public class DataSetUtilsTest {
     private static final double EPSILON = 1e-6;
 
     @ParameterizedTest()
-    @CsvSource({ //
+    @CsvSource({
+            //
             "test.csv,               test.csv               ", // plain filename
             "test_{dataSetName}.csv, test_TestSerialize.csv ", // data Set name
             "test_{xMin}-{xMax}.csv, test_1.0-5.0.csv ", // x min/max
@@ -44,7 +46,8 @@ public class DataSetUtilsTest {
             "val_{testval;float;%.2f}.csv, val_5.25.csv ", // metadata field with formated cast to double
     })
     @DisplayName("Test Filename Generation")
-    public void getFileNameTest(String pattern, String fileName) {
+    public void
+    getFileNameTest(String pattern, String fileName) {
         DataSet dataSet = getTestDataSet();
         assertEquals(fileName, DataSetUtils.getFileName(dataSet, pattern));
     }
@@ -141,11 +144,11 @@ public class DataSetUtilsTest {
         double[] xvalues = new double[] { 1.0, 2.0, 3.0, 4.0, 5.0 };
         double[] yvalues = new double[] { 1.3, 3.7, 4.2, 2.3, 1.8 };
         DataSet result = new DataSetBuilder() //
-                .setName("TestSerialize") //
-                .setXValues(xvalues) //
-                .setYValues(yvalues) //
-                .setMetaInfoMap(Map.of("test", "asdf", "testval", "5.24532")) //
-                .build();
+                                 .setName("TestSerialize") //
+                                 .setXValues(xvalues) //
+                                 .setYValues(yvalues) //
+                                 .setMetaInfoMap(Map.of("test", "asdf", "testval", "5.24532")) //
+                                 .build();
         result.getAxisDescription(DIM_X).set("index", "", 1.0, 5.0);
         result.getAxisDescription(DIM_Y).set("Voltage", "V", 1.3, 4.2);
         return result;
@@ -155,5 +158,4 @@ public class DataSetUtilsTest {
     public static void resetLocalization() {
         Locale.setDefault(Locale.US);
     }
-
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DataSetUtilsTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DataSetUtilsTest.java
@@ -3,6 +3,8 @@ package de.gsi.dataset.utils;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -59,8 +61,8 @@ public class DataSetUtilsTest {
         int n = 6;
         double[][] zvalues = new double[][] { { 1.3, 3.7, 4.2 }, { 2.3, 1.8, 5.0 } };
         DataSet3D dataSet = new DoubleDataSet3D("Test 3D Dataset", xvalues, yvalues, zvalues);
-        dataSet.getAxisDescription(0).set("U", "V", 1.0, 3.0);
-        dataSet.getAxisDescription(1).set("I", "A", 0.001, 4.2);
+        dataSet.getAxisDescription(DIM_X).set("U", "V", 1.0, 3.0);
+        dataSet.getAxisDescription(DIM_Y).set("I", "A", 0.001, 4.2);
         dataSet.getAxisDescription(2).set("P", "W", 1.3, 4.2);
         // assert that dataSet was created correctly
         assertArrayEquals(xvalues, dataSet.getXValues(), EPSILON);
@@ -131,7 +133,7 @@ public class DataSetUtilsTest {
                 notified.incrementAndGet();
             }
         });
-        dataSetRead.getAxisDescription(1).set("Test");
+        dataSetRead.getAxisDescription(DIM_Y).set("Test");
         assertEquals(1, notified.get());
     }
 
@@ -144,8 +146,8 @@ public class DataSetUtilsTest {
                 .setYValues(yvalues) //
                 .setMetaInfoMap(Map.of("test", "asdf", "testval", "5.24532")) //
                 .build();
-        result.getAxisDescription(0).set("index", "", 1.0, 5.0);
-        result.getAxisDescription(1).set("Voltage", "V", 1.3, 4.2);
+        result.getAxisDescription(DIM_X).set("index", "", 1.0, 5.0);
+        result.getAxisDescription(DIM_Y).set("Voltage", "V", 1.3, 4.2);
         return result;
     }
 

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/serializer/IoSerialiserTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/serializer/IoSerialiserTests.java
@@ -2,6 +2,7 @@ package de.gsi.dataset.utils.serializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import static de.gsi.dataset.DataSet.DIM_X;
 
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,6 @@ public class IoSerialiserTests {
 
     @Test
     public void simpleStreamerTest() {
-
         // check reading/writing
         final MyGenericClass inputObject = new MyGenericClass();
         MyGenericClass outputObject1 = new MyGenericClass();
@@ -140,8 +140,6 @@ public class IoSerialiserTests {
         assertEquals(inputObject, outputObject);
         LOGGER.atDebug().log("finished test#3 - initialised DataSet w/ single data point");
 
-        LOGGER.atInfo().addArgument(this.getClass().getSimpleName())
-                .log("{} - testIdentityDoubleDataSet() - completed successfully");
+        LOGGER.atInfo().addArgument(this.getClass().getSimpleName()).log("{} - testIdentityDoubleDataSet() - completed successfully");
     }
-
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/serializer/IoSerialiserTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/serializer/IoSerialiserTests.java
@@ -2,6 +2,7 @@ package de.gsi.dataset.utils.serializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static de.gsi.dataset.DataSet.DIM_X;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -109,7 +110,7 @@ public class IoSerialiserTests {
         LOGGER.atDebug().log("finished test#1 - uninitialised DataSet");
 
         inputObject.add(0.0, 1.0);
-        inputObject.getAxisDescription(0).set("time", "s");
+        inputObject.getAxisDescription(DIM_X).set("time", "s");
         try {
             buffer.reset();
             serialiser.serialiseObject(inputObject);

--- a/chartfx-math/src/main/java/de/gsi/math/spectra/ShortTimeFourierTransform.java
+++ b/chartfx-math/src/main/java/de/gsi/math/spectra/ShortTimeFourierTransform.java
@@ -103,33 +103,33 @@ public class ShortTimeFourierTransform {
                 dbScale, truncateDCNy);
 
         // initialize result dataset
-        DataSet result;
+        DoubleDataSet3D result;
         if (output == null) {
             result = new DoubleDataSet3D("STFT(" + input.getName() + ")", timeAxis, frequencyAxis, amplitudeData);
         } else if (output instanceof DoubleDataSet3D) {
-            result = output;
-            final DoubleDataSet3D output3D = (DoubleDataSet3D) output;
-            // only update data arrays if at least one array was newly allocated
-            if (oldTimeAxis != timeAxis || oldFrequencyAxis != frequencyAxis || oldAmplitudeData != amplitudeData) {
-                output3D.set(timeAxis, frequencyAxis, amplitudeData);
-            }
+            result = (DoubleDataSet3D) output;
         } else {
             // TODO: find generic way to modify data in place
             result = new DoubleDataSet3D("STFT(" + input.getName() + ")", timeAxis, frequencyAxis, amplitudeData);
         }
-        if (result instanceof DataSetMetaData) {
-            ((DataSetMetaData) result).getMetaInfo().put("ComplexSTFT-nFFT", Integer.toString(nFFT));
-            ((DataSetMetaData) result).getMetaInfo().put("ComplexSTFT-step", Integer.toString(step));
-        }
+        result.lock().writeLockGuard(() -> {
+            // only update data arrays if at least one array was newly allocated
+            if (oldTimeAxis != timeAxis || oldFrequencyAxis != frequencyAxis || oldAmplitudeData != amplitudeData) {
+                result.set(timeAxis, frequencyAxis, amplitudeData);
+            }
 
-        // Set Axis Labels and Units
-        final String timeUnit = input.getAxisDescription(DIM_X).getUnit();
-        result.getAxisDescription(DIM_X).set("Time", timeUnit, timeAxis[0], timeAxis[timeAxis.length - 1]);
-        final String freqUnit = timeUnit.equals("s") ? "Hz" : "1/" + timeUnit;
-        result.getAxisDescription(DIM_Y).set("Frequency", freqUnit, frequencyAxis[0],
-                frequencyAxis[frequencyAxis.length - 1]);
-        result.getAxisDescription(DIM_Z).set("Magnitude", input.getAxisDescription(DIM_Y).getUnit());
-        result.recomputeLimits(DIM_Z);
+            result.getMetaInfo().put("ComplexSTFT-nFFT", Integer.toString(nFFT));
+            result.getMetaInfo().put("ComplexSTFT-step", Integer.toString(step));
+
+            // Set Axis Labels and Units
+            final String timeUnit = input.getAxisDescription(DIM_X).getUnit();
+            result.getAxisDescription(DIM_X).set("Time", timeUnit, timeAxis[0], timeAxis[timeAxis.length - 1]);
+            final String freqUnit = timeUnit.equals("s") ? "Hz" : "1/" + timeUnit;
+            result.getAxisDescription(DIM_Y).set("Frequency", freqUnit, frequencyAxis[0],
+                    frequencyAxis[frequencyAxis.length - 1]);
+            result.getAxisDescription(DIM_Z).set("Magnitude", input.getAxisDescription(DIM_Y).getUnit());
+            result.recomputeLimits(DIM_Z);
+        });
 
         return result;
     }
@@ -311,33 +311,33 @@ public class ShortTimeFourierTransform {
                 truncateDCNy);
 
         // initialize result dataset
-        DataSet result;
+        DoubleDataSet3D result;
         if (output == null) {
             result = new DoubleDataSet3D("STFT(" + input.getName() + ")", timeAxis, frequencyAxis, amplitudeData);
         } else if (output instanceof DoubleDataSet3D) {
-            result = output;
-            final DoubleDataSet3D output3D = (DoubleDataSet3D) output;
-            // only update data arrays if at least one array was newly allocated
-            if (oldTimeAxis != timeAxis || oldFrequencyAxis != frequencyAxis || oldAmplitudeData != amplitudeData) {
-                output3D.set(timeAxis, frequencyAxis, amplitudeData);
-            }
+            result = (DoubleDataSet3D) output;
         } else {
             // TODO: find generic way to modify data in place
             result = new DoubleDataSet3D("STFT(" + input.getName() + ")", timeAxis, frequencyAxis, amplitudeData);
         }
-        if (result instanceof DataSetMetaData) {
-            ((DataSetMetaData) result).getMetaInfo().put("RealSTFT-nFFT", Integer.toString(nFFT));
-            ((DataSetMetaData) result).getMetaInfo().put("RealSTFT-step", Integer.toString(step));
-        }
+        result.lock().writeLockGuard(() -> {
+            // only update data arrays if at least one array was newly allocated
+            if (oldTimeAxis != timeAxis || oldFrequencyAxis != frequencyAxis || oldAmplitudeData != amplitudeData) {
+                result.set(timeAxis, frequencyAxis, amplitudeData);
+            }
 
-        // Set Axis Labels and Units
-        final String timeUnit = input.getAxisDescription(DIM_X).getUnit();
-        result.getAxisDescription(DIM_X).set("Time", timeUnit, timeAxis[0], timeAxis[timeAxis.length - 1]);
-        final String freqUnit = timeUnit.equals("s") ? "Hz" : "1/" + timeUnit;
-        result.getAxisDescription(DIM_Y).set("Frequency", freqUnit, frequencyAxis[0],
-                frequencyAxis[frequencyAxis.length - 1]);
-        result.getAxisDescription(DIM_Z).set("Magnitude", input.getAxisDescription(DIM_Y).getUnit());
-        result.recomputeLimits(DIM_Z);
+            result.getMetaInfo().put("RealSTFT-nFFT", Integer.toString(nFFT));
+            result.getMetaInfo().put("RealSTFT-step", Integer.toString(step));
+
+            // Set Axis Labels and Units
+            final String timeUnit = input.getAxisDescription(DIM_X).getUnit();
+            result.getAxisDescription(DIM_X).set("Time", timeUnit, timeAxis[0], timeAxis[timeAxis.length - 1]);
+            final String freqUnit = timeUnit.equals("s") ? "Hz" : "1/" + timeUnit;
+            result.getAxisDescription(DIM_Y).set("Frequency", freqUnit, frequencyAxis[0],
+                    frequencyAxis[frequencyAxis.length - 1]);
+            result.getAxisDescription(DIM_Z).set("Magnitude", input.getAxisDescription(DIM_Y).getUnit());
+            result.recomputeLimits(DIM_Z);
+        });
 
         return result;
     }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ChartIndicatorSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ChartIndicatorSample.java
@@ -1,5 +1,8 @@
 package de.gsi.chart.samples;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
 import java.time.ZoneOffset;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -195,12 +198,12 @@ public class ChartIndicatorSample extends Application {
         zoom.setSliderVisible(false);
         chart.getPlugins().add(zoom);
 
-        final double minX = rollingBufferDipoleCurrent.getAxisDescription(0).getMin();
-        final double maxX = rollingBufferDipoleCurrent.getAxisDescription(0).getMax();
-        final double minY1 = rollingBufferBeamIntensity.getAxisDescription(1).getMin();
-        final double maxY1 = rollingBufferBeamIntensity.getAxisDescription(1).getMax();
-        final double minY2 = rollingBufferDipoleCurrent.getAxisDescription(1).getMin();
-        final double maxY2 = rollingBufferDipoleCurrent.getAxisDescription(1).getMax();
+        final double minX = rollingBufferDipoleCurrent.getAxisDescription(DIM_X).getMin();
+        final double maxX = rollingBufferDipoleCurrent.getAxisDescription(DIM_X).getMax();
+        final double minY1 = rollingBufferBeamIntensity.getAxisDescription(DIM_Y).getMin();
+        final double maxY1 = rollingBufferBeamIntensity.getAxisDescription(DIM_Y).getMax();
+        final double minY2 = rollingBufferDipoleCurrent.getAxisDescription(DIM_Y).getMin();
+        final double maxY2 = rollingBufferDipoleCurrent.getAxisDescription(DIM_Y).getMax();
         final double rangeX = maxX - minX;
         final double rangeY1 = maxY1 - minY1;
         final double rangeY2 = maxY2 - minY2;

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
@@ -1,5 +1,8 @@
 package de.gsi.chart.samples;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
 import de.gsi.chart.plugins.DataPointTooltip;
@@ -39,11 +42,11 @@ public class EditDataSetSample extends Application {
         root.getChildren().add(chart);
 
         final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1 (full change)");
-        dataSet1.getAxisDescription(0).set("time", "s");
-        dataSet1.getAxisDescription(1).set("Voltage", "V");
+        dataSet1.getAxisDescription(DIM_X).set("time", "s");
+        dataSet1.getAxisDescription(DIM_Y).set("Voltage", "V");
         final DoubleDataSet dataSet2 = new DoubleDataSet("data set #2 (modify y-only)");
-        dataSet2.getAxisDescription(0).set("time", "s");
-        dataSet2.getAxisDescription(1).set("Current", "A");
+        dataSet2.getAxisDescription(DIM_X).set("time", "s");
+        dataSet2.getAxisDescription(DIM_Y).set("Current", "A");
         // chart.getDatasets().add(dataSet1); // for single data set
         // chart.getDatasets().addAll(dataSet1, dataSet2); // two data sets
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
@@ -3,6 +3,12 @@ package de.gsi.chart.samples;
 import static de.gsi.dataset.DataSet.DIM_X;
 import static de.gsi.dataset.DataSet.DIM_Y;
 
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
 import de.gsi.chart.plugins.DataPointTooltip;
@@ -15,11 +21,6 @@ import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.spi.DoubleDataSet;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.scene.Scene;
-import javafx.scene.layout.StackPane;
-import javafx.stage.Stage;
 
 /**
  * Simple example of how to edit data sets

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
@@ -52,10 +52,8 @@ public class HistoryDataSetRendererSample extends Application {
                 final double phase = 2 * Math.PI * updateIteration / 40.0;
                 final double a1 = 1 + 0.5 * Math.sin(phase);
                 final double a2 = 1 + 0.5 * Math.cos(phase);
-                final double y1 = a1 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 1.0 / 3.0,
-                        HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
-                final double y2 = a2 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 2.0 / 3.0,
-                        HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
+                final double y1 = a1 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 1.0 / 3.0, HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
+                final double y2 = a2 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 2.0 / 3.0, HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
                 final double ey1 = 0.01 * y1;
 
                 // lin scale

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
@@ -46,32 +46,32 @@ public class HistoryDataSetRendererSample extends Application {
 
         long startTime = ProcessingProfiler.getTimeStamp();
 
-        dataSet.autoNotification().set(false);
-        dataSetNoError.autoNotification().set(false);
-        for (int n = 0; n < HistoryDataSetRendererSample.N_SAMPLES; n++) {
-            final double x = n;
-            final double phase = 2 * Math.PI * updateIteration / 40.0;
-            final double a1 = 1 + 0.5 * Math.sin(phase);
-            final double a2 = 1 + 0.5 * Math.cos(phase);
-            final double y1 = a1 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 1.0 / 3.0, HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
-            final double y2 = a2 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 2.0 / 3.0, HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
-            final double ey1 = 0.01 * y1;
+        dataSetNoError.lock().writeLockGuard(() -> dataSet.lock().writeLockGuard(() -> {
+            for (int n = 0; n < HistoryDataSetRendererSample.N_SAMPLES; n++) {
+                final double x = n;
+                final double phase = 2 * Math.PI * updateIteration / 40.0;
+                final double a1 = 1 + 0.5 * Math.sin(phase);
+                final double a2 = 1 + 0.5 * Math.cos(phase);
+                final double y1 = a1 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 1.0 / 3.0,
+                        HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
+                final double y2 = a2 * GaussFunction.gauss(x, HistoryDataSetRendererSample.N_SAMPLES * 2.0 / 3.0,
+                        HistoryDataSetRendererSample.N_SAMPLES / 20.0) * 1000;
+                final double ey1 = 0.01 * y1;
 
-            // lin scale
-            dataSet.set(n, x, y1, ey1, ey1);
-            dataSetNoError.set(n, x, y2);
+                // lin scale
+                dataSet.set(n, x, y1, ey1, ey1);
+                dataSetNoError.set(n, x, y2);
 
-            // log scale
-            // dataSet.set(n, x, Math.exp(1e-4*x), 1e-3, 1e-3);
-            // dataSetNoError.set(n, x, Math.exp(2e-4*x));
-        }
-        dataSetNoError.setStyle("dsIndex=1;");
-        // dataSet.setStyle("strokeColor=red;");
-        // dataSet.setStyle("dsIndex=2;");
+                // log scale
+                // dataSet.set(n, x, Math.exp(1e-4*x), 1e-3, 1e-3);
+                // dataSetNoError.set(n, x, Math.exp(2e-4*x));
+            }
+            dataSetNoError.setStyle("dsIndex=1;");
+            // dataSet.setStyle("strokeColor=red;");
+            // dataSet.setStyle("dsIndex=2;");
 
-        updateIteration++;
-        dataSetNoError.autoNotification().set(true);
-        dataSet.autoNotification().set(true);
+            updateIteration++;
+        }));
 
         Platform.runLater(() -> {
             dataSet.fireInvalidated(null);
@@ -140,7 +140,7 @@ public class HistoryDataSetRendererSample extends Application {
         final HistoryDataSetRenderer historyRenderer2 = new HistoryDataSetRenderer(10);
         historyRenderer2.getAxes().add(yAxis2);
         chart.getRenderers().add(historyRenderer2);
-        historyRenderer2.setIntensityFading(0.8);
+        historyRenderer2.setIntensityFading(0.8); // default: 0.65
 
         chart.getPlugins().add(new Zoomer());
         chart.getPlugins().add(new EditAxis());

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/TransposedDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/TransposedDataSetSample.java
@@ -1,5 +1,8 @@
 package de.gsi.chart.samples;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -71,8 +74,8 @@ public class TransposedDataSetSample extends Application {
         //                new double[] { 0, 1, 2, 3 },
         //                new double[][] { { 0.1, 0, 0, 0.2 }, { 0.3, 0.4, 0.5, 0.6 }, { 0.7, 0, 0, 1 }, { 1, 1, 1, 1 } });
         final DataSet3D dataSet2 = createTestData();
-        dataSet2.getAxisDescription(0).set("x-axis", "x-unit");
-        dataSet2.getAxisDescription(1).set("y-axis", "y-unit");
+        dataSet2.getAxisDescription(DIM_X).set("x-axis", "x-unit");
+        dataSet2.getAxisDescription(DIM_Y).set("y-axis", "y-unit");
         final TransposedDataSet transposedDataSet2 = TransposedDataSet.transpose(dataSet2, false);
         contourRenderer.getDatasets().add(transposedDataSet2);
 
@@ -192,8 +195,8 @@ public class TransposedDataSetSample extends Application {
                    + (pert * Math.sin(i * omega * 0.777) * Math.cos(i * omega));
         }
         final DataSet dataSet = new DataSetBuilder().setName("non-sorted 2D DataSet").setXValues(x).setYValues(y).build();
-        dataSet.getAxisDescription(0).set("x-axis", "x-unit");
-        dataSet.getAxisDescription(1).set("y-axis", "y-unit");
+        dataSet.getAxisDescription(DIM_X).set("x-axis", "x-unit");
+        dataSet.getAxisDescription(DIM_Y).set("y-axis", "y-unit");
 
         return dataSet;
     }

--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleDataSet.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleDataSet.java
@@ -161,8 +161,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             System.arraycopy(yValuesNew, 0, yValues, getDataCount(), xValuesNew.length);
 
             dataMaxIndex = Math.max(0, dataMaxIndex + xValuesNew.length);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -232,8 +232,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
             }
             dataMaxIndex++;
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -399,8 +399,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
                 this.xValues = xValues;
                 this.yValues = yValues;
                 dataMaxIndex = xValues.length;
-                recomputeLimits(0);
-                recomputeLimits(1);
+                recomputeLimits(DIM_X);
+                recomputeLimits(DIM_Y);
                 return;
             }
 
@@ -415,8 +415,8 @@ public class DoubleDataSet extends AbstractDataSet<DoubleDataSet> implements Edi
                 this.yValues = Arrays.copyOf(yValues, xValues.length);
             }
             dataMaxIndex = xValues.length;
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
 
         return fireInvalidated(new UpdatedDataEvent(this));

--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleErrorDataSet.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/legacy/DoubleErrorDataSet.java
@@ -93,8 +93,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             this.yErrorsPos = yErrorsPos;
             this.yErrorsNeg = yErrorsNeg;
         }
-        recomputeLimits(0);
-        recomputeLimits(1);
+        recomputeLimits(DIM_X);
+        recomputeLimits(DIM_Y);
     }
 
     /**
@@ -160,9 +160,9 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             yErrorsNeg[dataMaxIndex] = yErrorNeg;
             dataMaxIndex++;
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y - yErrorNeg);
-            getAxisDescription(1).add(y + yErrorPos);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y - yErrorNeg);
+            getAxisDescription(DIM_Y).add(y + yErrorPos);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -216,8 +216,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             System.arraycopy(yErrorsPos, 0, this.yErrorsPos, getDataCount(), newLength - getDataCount());
 
             dataMaxIndex = Math.max(0, dataMaxIndex + xValues.length);
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new AddedDataEvent(this));
     }
@@ -242,8 +242,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
             getDataLabelMap().clear();
             getDataStyleMap().clear();
 
-            getAxisDescription(0).clear();
-            getAxisDescription(1).clear();
+            getAxisDescription(DIM_X).clear();
+            getAxisDescription(DIM_Y).clear();
         });
         return fireInvalidated(new RemovedDataEvent(this, "clearData()"));
     }
@@ -419,8 +419,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
                 this.yValues = yValues;
                 this.yErrorsNeg = yErrorsNeg;
                 this.yErrorsPos = yErrorsPos;
-                recomputeLimits(0);
-                recomputeLimits(1);
+                recomputeLimits(DIM_X);
+                recomputeLimits(DIM_Y);
                 return;
             }
 
@@ -439,8 +439,8 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
                 this.yErrorsPos = Arrays.copyOf(yErrorsPos, xValues.length);
             }
 
-            recomputeLimits(0);
-            recomputeLimits(1);
+            recomputeLimits(DIM_X);
+            recomputeLimits(DIM_Y);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }
@@ -479,9 +479,9 @@ public class DoubleErrorDataSet extends AbstractErrorDataSet<DoubleErrorDataSet>
                 this.add(x, y, yErrorNeg, yErrorPos);
             }
 
-            getAxisDescription(0).add(x);
-            getAxisDescription(1).add(y - yErrorNeg);
-            getAxisDescription(1).add(y + yErrorPos);
+            getAxisDescription(DIM_X).add(x);
+            getAxisDescription(DIM_Y).add(y - yErrorNeg);
+            getAxisDescription(DIM_Y).add(y + yErrorPos);
         });
         return fireInvalidated(new UpdatedDataEvent(this));
     }

--- a/chartfx-samples/src/main/java/de/gsi/silly/samples/SnowFlakeSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/silly/samples/SnowFlakeSample.java
@@ -1,5 +1,8 @@
 package de.gsi.silly.samples;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -178,8 +181,8 @@ public class SnowFlakeSample extends Application {
             yStomp[i] /= scale;
         }
         final DataSet stomp = new DataSetBuilder().setName("tree").setXValues(xStomp).setYValues(yStomp).build();
-        stomp.getAxisDescription(0).set("X", "Mas");
-        stomp.getAxisDescription(1).set("Y", "Mas");
+        stomp.getAxisDescription(DIM_X).set("X", "Mas");
+        stomp.getAxisDescription(DIM_Y).set("Y", "Mas");
         stomp.setStyle("strokeColor=#B5651D; fillColor=#B5651D");
 
         final double[] xTree = { 2.0, 2.0, 8.0, 8.0, 12.0, 12.0, 16.0, 16.0, 21.0, /* the tip */
@@ -191,8 +194,8 @@ public class SnowFlakeSample extends Application {
             yTree[i] /= scale;
         }
         final DataSet tree = new DataSetBuilder().setName("tree").setXValues(xTree).setYValues(yTree).build();
-        tree.getAxisDescription(0).set("X", "Mas");
-        tree.getAxisDescription(1).set("Y", "Max");
+        tree.getAxisDescription(DIM_X).set("X", "Mas");
+        tree.getAxisDescription(DIM_Y).set("Y", "Max");
         tree.setStyle("strokeColor=darkGreen; fillColor=green");
 
         list.add(stomp);
@@ -208,8 +211,8 @@ public class SnowFlakeSample extends Application {
     public static DataSet treeOrnaments(final DataSet tree, final double spacing) {
         DoubleDataSet dataSet = new DoubleDataSet("ornaments");
         dataSet.setStyle("markerType=circle;");
-        tree.recomputeLimits(0);
-        tree.recomputeLimits(1);
+        tree.recomputeLimits(DIM_X);
+        tree.recomputeLimits(DIM_Y);
         final double xMin = tree.getAxisDescriptions().get(DataSet.DIM_X).getMin();
         final double xMax = tree.getAxisDescriptions().get(DataSet.DIM_X).getMax();
         final double yMin = tree.getAxisDescriptions().get(DataSet.DIM_Y).getMin();

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes><![CDATA[
+    file name: JLargeArrays-1.5.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/pl\.edu\.icm/JLargeArrays@.*$</packageUrl>
+    <cpe>cpe:/a:gitlab:gitlab</cpe>
+  </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -152,9 +152,10 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.2.4</version>
+                    <version>5.3.1</version>
                     <configuration>
                         <failBuildOnCVSS>8</failBuildOnCVSS>
+                        <suppressionFiles>dependency-check-suppressions.xml</suppressionFiles>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Many DataSet implementations used to recompute their limits after every modification. For most operation this needs to iterate over the complete DataSet, which gets prohibitively expensive for the case where e.g. 10k points are updated with separate set() calls.

This pull request changes all occurrences of recomputeLimits() in the DataSet setters to either invalidate the Range or where possible to DataRange.add( newDataPoints ).

This works very well, because the limits are recomputed by the Chart for every rendering cycle anyway. Additionally, the getMin/Max/Length routines of DefaultAxisDescription where overridden to recompute the limits if they are undefined.