### PR TITLE
mini fixes

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/Axis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/Axis.java
@@ -2,13 +2,6 @@ package de.gsi.chart.axes;
 
 import java.util.List;
 
-import de.gsi.chart.axes.spi.AxisRange;
-import de.gsi.chart.axes.spi.MetricPrefix;
-import de.gsi.chart.axes.spi.TickMark;
-import de.gsi.chart.ui.geometry.Side;
-import de.gsi.dataset.AxisDescription;
-import de.gsi.dataset.event.EventSource;
-import de.gsi.dataset.event.UpdateEvent;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -19,8 +12,15 @@ import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
 import javafx.util.StringConverter;
 
-public interface Axis extends AxisDescription, EventSource {
+import de.gsi.chart.axes.spi.AxisRange;
+import de.gsi.chart.axes.spi.MetricPrefix;
+import de.gsi.chart.axes.spi.TickMark;
+import de.gsi.chart.ui.geometry.Side;
+import de.gsi.dataset.AxisDescription;
+import de.gsi.dataset.event.EventSource;
+import de.gsi.dataset.event.UpdateEvent;
 
+public interface Axis extends AxisDescription, EventSource {
     /**
      * This is true when the axis determines its range from the data automatically
      *
@@ -121,6 +121,11 @@ public interface Axis extends AxisDescription, EventSource {
      * @return the gap between tick labels and the tick mark lines
      */
     double getTickLabelGap();
+
+    /**
+     * @return the minimum gap between tick labels
+     */
+    double getTickLabelSpacing();
 
     /**
      * Get the string label name for a tick mark with the given value

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -575,8 +575,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // calculate tick mark length
         final double tickMarkLength = isTickMarkVisible() && (getTickLength() > 0) ? getTickLength() : 0;
         // calculate label height
-        final double labelHeight = (axisLabel.getText() == null) || axisLabel.getText().isEmpty() ? 0
-                                                                                                  : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
+        final Text axisLabel = getAxisLabel();
+        final String axisLabelText = axisLabel.getText();
+        final double labelHeight = (axisLabelText == null) || axisLabelText.isEmpty() ? 0 : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
         final double shiftedLabels = ((getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT) && isLabelOverlapping())
                                                      || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
                                              ? labelHeight
@@ -619,8 +620,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // calculate tick mark length
         final double tickMarkLength = isTickMarkVisible() && (getTickLength() > 0) ? getTickLength() : 0;
         // calculate label height
-        final double labelHeight = (axisLabel.getText() == null) || axisLabel.getText().isEmpty() ? 0
-                                                                                                  : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
+        final Text axisLabel = getAxisLabel();
+        final String axisLabelText = axisLabel.getText();
+        final double labelHeight = (axisLabelText == null) || axisLabelText.isEmpty() ? 0 : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
 
         final double shiftedLabels = ((getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT) && isLabelOverlapping())
                                                      || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
@@ -1277,7 +1279,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             double totalLabelsSize = 0;
             double maxLabelSize = 0;
             for (final TickMark m : getTickMarks()) {
-                final double tickSize = side.isHorizontal() ? m.getWidth() : m.getHeight() + (2 * getTickLabelGap());
+                final double tickSize = (side.isHorizontal() ? m.getWidth() : m.getHeight()) + (2 * getTickLabelSpacing());
                 totalLabelsSize += tickSize;
                 maxLabelSize = Math.round(Math.max(maxLabelSize, tickSize));
             }
@@ -1444,9 +1446,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         }
         lastCssUpdate = now;
         callCssUpdater = false;
-        majorTickStyle.applyCss();
-        minorTickStyle.applyCss();
-        axisLabel.applyCss();
+        getMajorTickStyle().applyCss();
+        getMinorTickStyle().applyCss();
+        getAxisLabel().applyCss();
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
@@ -53,7 +53,7 @@ public abstract class AbstractChartMeasurement implements EventListener {
         title = AbstractChartMeasurement.this.getClass().getSimpleName();
         dataSet = null;
         VBox.setMargin(displayPane, Insets.EMPTY);
-        chart.getMeasurementBar(chart.getMeasurementBarSide()).getChildren().addAll(displayPane, new Pane());
+        chart.getMeasurementBar(chart.getMeasurementBarSide()).getChildren().addAll(displayPane);
 
         alert = new Alert(AlertType.CONFIRMATION);
         alert.setTitle("Measurement Config Dialog");

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/AbstractChartMeasurement.java
@@ -4,13 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import de.gsi.chart.Chart;
-import de.gsi.chart.XYChart;
-import de.gsi.chart.plugins.measurements.utils.CheckedValueField;
-import de.gsi.chart.plugins.measurements.utils.DataSetSelector;
-import de.gsi.dataset.DataSet;
-import de.gsi.dataset.event.EventListener;
-import impl.org.controlsfx.skin.DecorationPane;
 import javafx.geometry.Insets;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -21,11 +14,19 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 
+import de.gsi.chart.Chart;
+import de.gsi.chart.XYChart;
+import de.gsi.chart.plugins.measurements.utils.CheckedValueField;
+import de.gsi.chart.plugins.measurements.utils.DataSetSelector;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.event.EventListener;
+
+import impl.org.controlsfx.skin.DecorationPane;
+
 /**
  * @author rstein
  */
 public abstract class AbstractChartMeasurement implements EventListener {
-
     protected static final int PREFERRED_WIDTH = 300;
     protected static int markerCount;
 
@@ -146,5 +147,4 @@ public abstract class AbstractChartMeasurement implements EventListener {
         }
         alert.close();
     }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/SimpleMeasurements.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/SimpleMeasurements.java
@@ -8,6 +8,7 @@ import static de.gsi.chart.plugins.measurements.SimpleMeasurements.MeasurementCa
 import static de.gsi.chart.plugins.measurements.SimpleMeasurements.MeasurementType.VALUE_HOR;
 import static de.gsi.chart.plugins.measurements.SimpleMeasurements.MeasurementType.VALUE_VER;
 
+import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
 
@@ -218,7 +219,7 @@ public class SimpleMeasurements extends ValueIndicator {
     public void initialize() {
         final Node node = Borders.wrap(valueField).lineBorder().title(title).color(Color.BLACK).build().build();
         node.setMouseTransparent(true);
-        displayPane.getChildren().add(node);
+        displayPane.getChildren().add(new Group(node));
 
         sliderIndicator1.valueProperty().addListener((ch, oldValue, newValue) -> {
             if (oldValue != newValue) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/ValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/ValueIndicator.java
@@ -5,6 +5,13 @@ import static de.gsi.chart.axes.AxisMode.X;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+
 import org.controlsfx.tools.Borders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,12 +27,6 @@ import de.gsi.chart.plugins.YValueIndicator;
 import de.gsi.chart.utils.FXUtils;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.event.UpdateEvent;
-import javafx.application.Platform;
-import javafx.scene.Group;
-import javafx.scene.Node;
-import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
-import javafx.scene.paint.Color;
 
 /**
  * @author rstein
@@ -36,7 +37,7 @@ public class ValueIndicator extends AbstractChartMeasurement {
     private static final String FORMAT_SMALL_SCALE = "0.###";
     private static final String FORMAT_LARGE_SCALE = "0.##E0";
     public static final int DEFAULT_SMALL_AXIS = 6; // [orders of magnitude],
-                                                    // e.g. '4' <-> [1,10000]
+            // e.g. '4' <-> [1,10000]
     protected final DecimalFormat formatterSmall = new DecimalFormat(ValueIndicator.FORMAT_SMALL_SCALE);
     protected final DecimalFormat formatterLarge = new DecimalFormat(ValueIndicator.FORMAT_LARGE_SCALE);
 
@@ -52,7 +53,7 @@ public class ValueIndicator extends AbstractChartMeasurement {
         final Axis axis = axisMode == X ? chart.getXAxis() : chart.getYAxis();
         if (!(axis instanceof Axis)) {
             ValueIndicator.LOGGER.warn("axis type " + axis.getClass().getSimpleName()
-                    + "not compatible with indicator (needs to derivce from Axis)");
+                                       + "not compatible with indicator (needs to derivce from Axis)");
             return;
         }
         final Axis numAxis = axis;
@@ -112,7 +113,6 @@ public class ValueIndicator extends AbstractChartMeasurement {
 
             valueLabel = axisFormatter.toString(val);
         } else {
-
             if (Math.abs(Math.log10(Math.abs(val))) < ValueIndicator.SMALL_FORMAT_THRESHOLD) {
                 formatter = formatterSmall;
             } else {
@@ -122,7 +122,6 @@ public class ValueIndicator extends AbstractChartMeasurement {
         }
 
         valueField.setValue(val, valueLabel);
-
     }
 
     @Override
@@ -155,5 +154,4 @@ public class ValueIndicator extends AbstractChartMeasurement {
         chart.getPlugins().remove(sliderIndicator1);
         chart.requestLayout();
     }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/ValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/ValueIndicator.java
@@ -21,6 +21,7 @@ import de.gsi.chart.utils.FXUtils;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.event.UpdateEvent;
 import javafx.application.Platform;
+import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -128,7 +129,7 @@ public class ValueIndicator extends AbstractChartMeasurement {
     public void initialize() {
         final Node node = Borders.wrap(valueField).lineBorder().title(title).color(Color.BLACK).build().build();
         node.setMouseTransparent(true);
-        displayPane.getChildren().add(node);
+        displayPane.getChildren().add(new Group(node));
 
         sliderIndicator1.valueProperty().addListener((ch, oldValue, newValue) -> {
             if (oldValue != newValue) {

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
@@ -2,6 +2,7 @@ package de.gsi.chart.axes.spi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,8 +15,6 @@ import javafx.scene.text.TextAlignment;
 import javafx.util.StringConverter;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.gsi.chart.axes.AxisLabelOverlapPolicy;
 import de.gsi.chart.axes.AxisTransform;
@@ -28,11 +27,39 @@ import de.gsi.chart.ui.geometry.Side;
  * @author rstein
  */
 public class AbstractAxisParameterTests {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAxisParameterTests.class);
+    @Test
+    public void testAutoGetterSetters() {
+        AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
+
+        assertTrue(axis.isAutoRanging());
+        assertEquals(axis.getAutoRange(), axis.getRange());
+        axis.setAutoRanging(false);
+        assertEquals(axis.getUserRange(), axis.getRange());
+        assertFalse(axis.isAutoRanging());
+        assertFalse(axis.isAutoGrowRanging());
+
+        axis.setAutoGrowRanging(true);
+        assertTrue(axis.isAutoGrowRanging());
+        assertEquals(axis.getAutoRange(), axis.getRange());
+        axis.setAutoGrowRanging(false);
+
+        axis.setAutoRangePadding(0.2);
+        assertEquals(0.2, axis.getAutoRangePadding());
+
+        assertFalse(axis.isAutoRangeRounding());
+        axis.setAutoRangeRounding(true);
+        assertTrue(axis.isAutoRangeRounding());
+        assertFalse(axis.isAutoRanging());
+        axis.setAutoRangeRounding(false);
+
+        assertFalse(axis.isAutoUnitScaling());
+        axis.setAutoUnitScaling(true);
+        assertTrue(axis.isAutoUnitScaling());
+        axis.setAutoUnitScaling(false);
+    }
 
     @Test
-    @SuppressWarnings("PMD.LongMethodRule") // necessary since the interface is extensive and an arbitrary break-up wouldn't help
-    public void testGetterSetters() {
+    public void testBasicGetterSetters() {
         AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
 
         assertFalse(axis.isValid());
@@ -41,7 +68,33 @@ public class AbstractAxisParameterTests {
         axis.invalidate();
         assertFalse(axis.isValid());
 
+        axis.set(Double.NaN, Double.NaN);
+        assertFalse(axis.isDefined());
+        axis.set(Double.NaN, +1.0);
+        assertFalse(axis.isDefined());
+        axis.set(-1.0, Double.NaN);
+        assertFalse(axis.isDefined());
         axis.set(-2.0, +2.0);
+        assertTrue(axis.isDefined());
+        assertEquals(-2.0, axis.getMin());
+        assertEquals(+2.0, axis.getMax());
+        assertTrue(axis.contains(0.0));
+        assertTrue(axis.contains(1.0));
+        assertTrue(axis.contains(-1.0));
+        assertFalse(axis.contains(-3.0));
+        assertFalse(axis.contains(+3.0));
+        assertFalse(axis.contains(Double.NaN));
+
+        // check add functions
+        axis.clear();
+        axis.set(0.0, 0.0);
+        axis.add(0.0);
+        assertEquals(0.0, axis.getMin());
+        assertEquals(0.0, axis.getMax());
+        axis.add(1.0);
+        assertEquals(0.0, axis.getMin());
+        assertEquals(+1.0, axis.getMax());
+        axis.add(new double[] { -2.0, +2.0, +3.0 }, 2);
         assertEquals(-2.0, axis.getMin());
         assertEquals(+2.0, axis.getMax());
 
@@ -50,6 +103,12 @@ public class AbstractAxisParameterTests {
         assertEquals("axis unit", axis.getUnit());
         assertEquals(-3.0, axis.getMin());
         assertEquals(+3.0, axis.getMax());
+
+        axis.set("axis name2", null, -3.0, +3.0);
+        assertEquals("axis name2", axis.getAxisLabel().getText());
+
+        axis.set("axis name2", "", -3.0, +3.0);
+        assertEquals("axis name2 []", axis.getAxisLabel().getText());
 
         axis.set("axis name2", "axis unit2");
         assertEquals("axis name2", axis.getName());
@@ -69,73 +128,6 @@ public class AbstractAxisParameterTests {
         axis.setAnimationDuration(10);
         assertEquals(10, axis.getAnimationDuration());
 
-        assertTrue(axis.isAutoRanging());
-        axis.setAutoRanging(false);
-        assertFalse(axis.isAutoRanging());
-        assertFalse(axis.isAutoGrowRanging());
-
-        axis.setAutoGrowRanging(true);
-        assertTrue(axis.isAutoGrowRanging());
-        axis.setAutoGrowRanging(false);
-
-        axis.setAutoRangePadding(0.2);
-        assertEquals(0.2, axis.getAutoRangePadding());
-
-        assertFalse(axis.isAutoRangeRounding());
-        axis.setAutoRangeRounding(true);
-        assertTrue(axis.isAutoRangeRounding());
-        assertFalse(axis.isAutoRanging());
-        axis.setAutoRangeRounding(false);
-
-        assertFalse(axis.isAutoUnitScaling());
-        axis.setAutoUnitScaling(true);
-        assertTrue(axis.isAutoUnitScaling());
-        axis.setAutoUnitScaling(false);
-
-        assertEquals(0.5, axis.getAxisCenterPosition());
-        axis.setAxisCenterPosition(0.2);
-        assertEquals(0.2, axis.getAxisCenterPosition());
-        axis.setAxisCenterPosition(0.5);
-
-        assertEquals(TextAlignment.CENTER, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
-        axis.setAxisLabelTextAlignment(TextAlignment.LEFT);
-        assertEquals(TextAlignment.LEFT, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
-        axis.setAxisLabelTextAlignment(TextAlignment.CENTER);
-
-        axis.setAxisLabelGap(5);
-        assertEquals(5, axis.getAxisLabelGap());
-
-        axis.setAxisPadding(6);
-        assertEquals(6, axis.getAxisPadding());
-
-        axis.setMax(0.5);
-        assertTrue(axis.setMax(1.0));
-        assertFalse(axis.setMax(1.0));
-        assertEquals(1.0, axis.getMax());
-
-        assertEquals(20, axis.getMaxMajorTickLabelCount());
-        axis.setMaxMajorTickLabelCount(9);
-        assertEquals(9, axis.getMaxMajorTickLabelCount());
-        axis.setMaxMajorTickLabelCount(20);
-
-        axis.setMin(-0.5);
-        assertTrue(axis.setMin(-1.0));
-        assertFalse(axis.setMin(-1.0));
-        assertEquals(-1.0, axis.getMin());
-
-        assertEquals(10, axis.getMinorTickCount());
-        axis.setMinorTickCount(9);
-        assertEquals(9, axis.getMinorTickCount());
-        axis.setMinorTickCount(10);
-
-        axis.setMinorTickLength(20);
-        assertEquals(20, axis.getMinorTickLength());
-
-        assertTrue(axis.isMinorTickVisible());
-        axis.setMinorTickVisible(false);
-        assertFalse(axis.isMinorTickVisible());
-        axis.setMinorTickVisible(true);
-
         axis.setName("test axis name");
         assertEquals("test axis name", axis.getName());
 
@@ -150,52 +142,15 @@ public class AbstractAxisParameterTests {
         for (Side side : Side.values()) {
             axis.setSide(side);
             assertEquals(side, axis.getSide());
+            if (side.isHorizontal()) {
+                assertEquals(axis.getWidth(), axis.getLength());
+            } else {
+                assertEquals(axis.getHeight(), axis.getLength());
+            }
         }
+        axis.setSide(null);
+        assertEquals(Double.NaN, axis.getLength());
         axis.setSide(Side.LEFT);
-
-        axis.setTickLabelFill(Color.RED);
-        assertEquals(Color.RED, axis.getTickLabelFill());
-
-        final Font font = Font.font("System", 10);
-        axis.setTickLabelFont(font);
-        assertEquals(font, axis.getTickLabelFont());
-
-        StringConverter<Number> myConverter = new StringConverter<Number>() {
-            @Override
-            public String toString(Number object) {
-                return null;
-            }
-
-            @Override
-            public Number fromString(String string) {
-                return null;
-            }
-        };
-        axis.setTickLabelFormatter(myConverter);
-        assertEquals(myConverter, axis.getTickLabelFormatter());
-
-        axis.setTickLabelGap(3);
-        assertEquals(3, axis.getTickLabelGap());
-
-        axis.setTickLabelRotation(10);
-        assertEquals(10, axis.getTickLabelRotation());
-
-        assertTrue(axis.isTickLabelsVisible());
-        axis.setTickLabelsVisible(false);
-        assertFalse(axis.isTickLabelsVisible());
-        axis.setTickLabelsVisible(true);
-
-        axis.setTickLength(20);
-        assertEquals(20, axis.getTickLength());
-
-        assertTrue(axis.isTickMarkVisible());
-        axis.setTickMarkVisible(false);
-        assertFalse(axis.isTickMarkVisible());
-        axis.setTickMarkVisible(true);
-
-        axis.setTickUnit(1e6);
-        assertEquals("test axis name", axis.getName());
-        assertEquals(1e6, axis.getTickUnit());
 
         assertFalse(axis.isTimeAxis());
         axis.setTimeAxis(true);
@@ -219,14 +174,138 @@ public class AbstractAxisParameterTests {
         assertTrue(axis.isInvertedAxis());
         axis.invertAxis(false); //TODO: rename function w.r.t. setter
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.atInfo().log("testGetterSetters() - done");
-        }
+        axis.setTickUnit(1e6);
+        assertEquals("test axis name", axis.getName());
+        assertEquals(1e6, axis.getTickUnit());
+
+        // test String helper
+        assertTrue(AbstractAxisParameter.equalString("String#1", "String#1"));
+        assertFalse(AbstractAxisParameter.equalString("String#1", "String#2"));
+        assertFalse(AbstractAxisParameter.equalString("String#1", null));
+        assertFalse(AbstractAxisParameter.equalString(null, "String#2"));
+        assertTrue(AbstractAxisParameter.equalString(null, null));
+
+        // style definitions must be non-null
+        assertNotNull(axis.getCssMetaData());
+    }
+
+    @Test
+    public void testPositionGetterSetters() {
+        AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
+
+        assertEquals(0.5, axis.getAxisCenterPosition());
+        axis.setAxisCenterPosition(0.2);
+        assertEquals(0.2, axis.getAxisCenterPosition());
+        axis.setAxisCenterPosition(0.5);
+
+        assertEquals(TextAlignment.CENTER, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
+        axis.setAxisLabelTextAlignment(TextAlignment.LEFT);
+        assertEquals(TextAlignment.LEFT, axis.getAxisLabelTextAlignment()); //TODO: rename function w.r.t. setter
+        axis.setAxisLabelTextAlignment(TextAlignment.CENTER);
+
+        axis.setAxisLabelGap(5);
+        assertEquals(5, axis.getAxisLabelGap());
+
+        axis.setAxisPadding(6);
+        assertEquals(6, axis.getAxisPadding());
+    }
+
+    @Test
+    public void testTickLabelGetterSetters() {
+        AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
+
+        axis.setTickLabelFill(Color.RED);
+        assertEquals(Color.RED, axis.getTickLabelFill());
+
+        final Font font = Font.font("System", 10);
+        axis.setTickLabelFont(font);
+        assertEquals(font, axis.getTickLabelFont());
+
+        StringConverter<Number> myConverter = new StringConverter<Number>() {
+            @Override
+            public Number fromString(String string) {
+                return null;
+            }
+
+            @Override
+            public String toString(Number object) {
+                return null;
+            }
+        };
+        axis.setTickLabelFormatter(myConverter);
+        assertEquals(myConverter, axis.getTickLabelFormatter());
+
+        axis.setTickLabelGap(3);
+        assertEquals(3, axis.getTickLabelGap());
+
+        axis.setTickLabelSpacing(5);
+        assertEquals(5, axis.getTickLabelSpacing());
+
+        axis.setTickLabelRotation(10);
+        assertEquals(10, axis.getTickLabelRotation());
+
+        assertTrue(axis.isTickLabelsVisible());
+        axis.setTickLabelsVisible(false);
+        assertFalse(axis.isTickLabelsVisible());
+        axis.setTickLabelsVisible(true);
+    }
+
+    @Test
+    public void testTickMarkGetterSetters() {
+        AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
+
+        assertEquals(20, axis.getMaxMajorTickLabelCount());
+        axis.setMaxMajorTickLabelCount(9);
+        assertEquals(9, axis.getMaxMajorTickLabelCount());
+        axis.setMaxMajorTickLabelCount(20);
+
+        axis.setMax(0.5);
+        assertTrue(axis.setMax(1.0));
+        assertFalse(axis.setMax(1.0));
+        assertEquals(1.0, axis.getMax());
+
+        axis.setMin(-0.5);
+        assertTrue(axis.setMin(-1.0));
+        assertFalse(axis.setMin(-1.0));
+        assertEquals(-1.0, axis.getMin());
+
+        assertEquals(10, axis.getMinorTickCount());
+        axis.setMinorTickCount(9);
+        assertEquals(9, axis.getMinorTickCount());
+        axis.setMinorTickCount(10);
+
+        axis.setMinorTickLength(20);
+        assertEquals(20, axis.getMinorTickLength());
+
+        assertTrue(axis.isMinorTickVisible());
+        axis.setMinorTickVisible(false);
+        assertFalse(axis.isMinorTickVisible());
+        axis.setMinorTickVisible(true);
+
+        axis.setTickLength(20);
+        assertEquals(20, axis.getTickLength());
+
+        assertTrue(axis.isTickMarkVisible());
+        axis.setTickMarkVisible(false);
+        assertFalse(axis.isTickMarkVisible());
+        axis.setTickMarkVisible(true);
+
+        assertNotNull(axis.getTickMarks());
+        assertNotNull(axis.getTickMarkValues());
+        assertNotNull(axis.getMajorTickStyle());
+        assertNotNull(axis.getMinorTickMarks());
+        assertNotNull(axis.getMinorTickMarkValues());
+        assertNotNull(axis.getMinorTickStyle());
     }
 
     protected class EmptyAbstractAxisParameter extends AbstractAxisParameter {
         @Override
         public void drawAxis(GraphicsContext gc, double axisWidth, double axisHeight) {
+            // deliberately not implemented
+        }
+
+        @Override
+        public void fireInvalidated() {
             // deliberately not implemented
         }
 
@@ -290,11 +369,6 @@ public class AbstractAxisParameterTests {
 
         @Override
         public void requestAxisLayout() {
-            // deliberately not implemented
-        }
-
-        @Override
-        public void fireInvalidated() {
             // deliberately not implemented
         }
     }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DimReductionDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DimReductionDataSetTests.java
@@ -26,6 +26,49 @@ public class DimReductionDataSetTests {
     private int nEvent = 0;
 
     @Test
+    public void testGetterSetterConsistency() {
+        LOGGER.atDebug().log("testGetterSetterConsistency");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DimReductionDataSet reducedDataSetX = new DimReductionDataSet(testData, DIM_X, Option.INTEGRAL);
+        DimReductionDataSet reducedDataSetY = new DimReductionDataSet(testData, DIM_Y, Option.INTEGRAL);
+
+        reducedDataSetX.setMinValue(0.0);
+        assertEquals(0.0, reducedDataSetX.getMinValue());
+        reducedDataSetX.setMinValue(2.0);
+        assertEquals(2.0, reducedDataSetX.getMinValue());
+
+        reducedDataSetX.setMaxValue(0.0);
+        assertEquals(0.0, reducedDataSetX.getMaxValue());
+        reducedDataSetX.setMaxValue(2.0);
+        assertEquals(2.0, reducedDataSetX.getMaxValue());
+
+        reducedDataSetX.setRange(1.5, 2.5);
+        assertEquals(1.5, reducedDataSetX.getMinValue());
+        assertEquals(2.5, reducedDataSetX.getMaxValue());
+
+        reducedDataSetY.setMinValue(0.0);
+        assertEquals(0.0, reducedDataSetY.getMinValue());
+        reducedDataSetY.setMinValue(2.0);
+        assertEquals(2.0, reducedDataSetY.getMinValue());
+
+        reducedDataSetY.setMaxValue(0.0);
+        assertEquals(0.0, reducedDataSetY.getMaxValue());
+        reducedDataSetY.setMaxValue(2.0);
+        assertEquals(2.0, reducedDataSetY.getMaxValue());
+
+        reducedDataSetY.setRange(1.5, 2.5);
+        assertEquals(1.5, reducedDataSetY.getMinValue());
+        assertEquals(2.5, reducedDataSetY.getMaxValue());
+    }
+
+    @Test
     public void testIntegralOptions() {
         LOGGER.atDebug().log("testIntegralOptions");
         DoubleDataSet3D testData = new DoubleDataSet3D("test", //
@@ -41,48 +84,49 @@ public class DimReductionDataSetTests {
 
         assertEquals(testData, sliceDataSetX.getSourceDataSet(), "equal source dataSet");
         assertEquals(testData, sliceDataSetY.getSourceDataSet(), "equal source dataSet");
-        assertEquals(Option.INTEGRAL, sliceDataSetX.getReductionOption(), "reduction option");
+        assertEquals(Option.INTEGRAL, sliceDataSetY.getReductionOption(), "reduction option");
 
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        assertEquals(0, sliceDataSetX.getMinIndex(DIM_X));
-        sliceDataSetX.setMinIndex(DIM_X, 2);
-        assertEquals(1, sliceDataSetX.getMinIndex(DIM_X));
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        assertEquals(0, sliceDataSetX.getMinIndex(DIM_X));
+        sliceDataSetY.setMinValue(0);
+        assertEquals(0, sliceDataSetY.getMinIndex());
+        sliceDataSetY.setMinValue(2);
+        assertEquals(1, sliceDataSetY.getMinIndex());
+        sliceDataSetY.setMinValue(0);
+        assertEquals(0, sliceDataSetY.getMinIndex());
 
-        sliceDataSetX.setMaxIndex(DIM_X, 2);
-        assertEquals(1, sliceDataSetX.getMaxIndex(DIM_X));
-        sliceDataSetX.setMaxIndex(DIM_X, 3);
-        assertEquals(2, sliceDataSetX.getMaxIndex(DIM_X));
+        sliceDataSetY.setMaxValue(2);
+        assertEquals(1, sliceDataSetY.getMaxIndex());
+        sliceDataSetY.setMaxValue(3);
+        assertEquals(2, sliceDataSetY.getMaxIndex());
 
-        sliceDataSetY.setMinIndex(DIM_Y, 5);
-        assertEquals(0, sliceDataSetY.getMinIndex(DIM_Y));
-        sliceDataSetY.setMinIndex(DIM_Y, 6);
-        assertEquals(0, sliceDataSetY.getMinIndex(DIM_Y));
-        sliceDataSetY.setMinIndex(DIM_Y, 7);
-        assertEquals(1, sliceDataSetY.getMinIndex(DIM_Y));
-        sliceDataSetY.setMinIndex(DIM_Y, 0);
+        sliceDataSetX.setMinValue(5);
+        assertEquals(0, sliceDataSetX.getMinIndex());
+        sliceDataSetX.setMinValue(6);
+        assertEquals(0, sliceDataSetX.getMinIndex());
+        sliceDataSetX.setMinValue(7);
+        assertEquals(1, sliceDataSetX.getMinIndex());
+        sliceDataSetX.setMinValue(0);
 
-        sliceDataSetY.setMaxIndex(DIM_Y, 7);
-        assertEquals(1, sliceDataSetY.getMaxIndex(DIM_Y));
-        sliceDataSetY.setMaxIndex(DIM_Y, 8);
-        assertEquals(2, sliceDataSetY.getMaxIndex(DIM_Y));
+        sliceDataSetX.setMaxValue(7);
+        assertEquals(1, sliceDataSetX.getMaxIndex());
+        sliceDataSetX.setMaxValue(8);
+        assertEquals(2, sliceDataSetX.getMaxIndex());
 
         // integral over full array
         final double[] integralX = new double[3];
         final double[] integralY = new double[3];
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                integralX[i] += testData.getZ(j, i);
-                integralY[j] += testData.getZ(j, i);
+                integralX[j] += testData.getZ(j, i);
+                integralY[i] += testData.getZ(j, i);
             }
         }
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        sliceDataSetX.setMaxIndex(DIM_X, 4);
-        sliceDataSetY.setMinIndex(DIM_Y, 0);
-        sliceDataSetY.setMaxIndex(DIM_Y, 9);
-        assertArrayEquals(integralY, sliceDataSetX.getValues(DIM_Y), "x-integral");
-        assertArrayEquals(integralX, sliceDataSetY.getValues(DIM_Y), "x-integral");
+        sliceDataSetY.setMinValue(0);
+        sliceDataSetY.setMaxValue(4);
+        sliceDataSetX.setMinValue(0);
+        sliceDataSetX.setMaxValue(9);
+
+        assertArrayEquals(integralX, sliceDataSetX.getValues(DIM_Y), "x-integral");
+        assertArrayEquals(integralY, sliceDataSetY.getValues(DIM_Y), "y-integral");
 
         LOGGER.atDebug().log("testIntegralOptions - done");
     }
@@ -110,16 +154,18 @@ public class DimReductionDataSetTests {
         final double[] maxX = new double[3];
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                maxX[i] = Math.max(testData.getZ(j, i), maxX[i]);
-                maxY[j] = Math.max(testData.getZ(j, i), maxY[i]);
+                maxX[j] = Math.max(testData.getZ(j, i), maxX[j]);
+                maxY[i] = Math.max(testData.getZ(j, i), maxY[i]);
             }
         }
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        sliceDataSetX.setMaxIndex(DIM_X, 4);
-        sliceDataSetY.setMinIndex(DIM_Y, 0);
-        sliceDataSetY.setMaxIndex(DIM_Y, 9);
-        assertArrayEquals(maxY, sliceDataSetX.getValues(DIM_Y), "x-max");
-        assertArrayEquals(maxX, sliceDataSetY.getValues(DIM_Y), "x-max");
+
+        sliceDataSetX.setMinValue(0);
+        sliceDataSetX.setMaxValue(10);
+        sliceDataSetY.setMinValue(0);
+        sliceDataSetY.setMaxValue(4);
+
+        assertArrayEquals(maxX, sliceDataSetX.getValues(DIM_Y), "x-max");
+        assertArrayEquals(maxY, sliceDataSetY.getValues(DIM_Y), "y-max");
 
         LOGGER.atDebug().log("testMaxOptions - done");
     }
@@ -147,17 +193,19 @@ public class DimReductionDataSetTests {
         final double[] meanY = new double[3];
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                meanX[i] += testData.getZ(j, i) / 3.0;
-                meanY[j] += testData.getZ(j, i) / 3.0;
+                meanX[j] += testData.getZ(j, i) / 3.0;
+                meanY[i] += testData.getZ(j, i) / 3.0;
             }
         }
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        sliceDataSetX.setMaxIndex(DIM_X, 4);
-        sliceDataSetY.setMinIndex(DIM_Y, 0);
-        sliceDataSetY.setMaxIndex(DIM_Y, 9);
+
+        sliceDataSetX.setMinValue(0);
+        sliceDataSetX.setMaxValue(10);
+        sliceDataSetY.setMinValue(0);
+        sliceDataSetY.setMaxValue(4);
+
         for (int i = 0; i < 3; i++) {
-            assertTrue(MathUtils.nearlyEqual(meanY[i], sliceDataSetX.getValues(DIM_Y)[i]), "x-integral");
-            assertTrue(MathUtils.nearlyEqual(meanX[i], sliceDataSetY.getValues(DIM_Y)[i]), "y-integral");
+            assertTrue(MathUtils.nearlyEqual(meanX[i], sliceDataSetX.getValues(DIM_Y)[i]), "x-integral");
+            assertTrue(MathUtils.nearlyEqual(meanY[i], sliceDataSetY.getValues(DIM_Y)[i]), "y-integral");
         }
 
         LOGGER.atDebug().log("testMeanOptions - done");
@@ -186,17 +234,18 @@ public class DimReductionDataSetTests {
         final double[] minX = new double[] { Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE };
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                minX[i] = Math.min(testData.getZ(j, i), minX[i]);
-                minY[j] = Math.min(testData.getZ(j, i), minY[j]);
+                minX[j] = Math.min(testData.getZ(j, i), minX[j]);
+                minY[i] = Math.min(testData.getZ(j, i), minY[i]);
             }
         }
-        sliceDataSetX.setMinIndex(DIM_X, 0);
-        sliceDataSetX.setMaxIndex(DIM_X, 4);
-        sliceDataSetY.setMinIndex(DIM_Y, 0);
-        sliceDataSetY.setMaxIndex(DIM_Y, 10);
 
-        assertArrayEquals(minY, sliceDataSetX.getValues(DIM_Y), "x-min");
-        assertArrayEquals(minX, sliceDataSetY.getValues(DIM_Y), "y-min");
+        sliceDataSetX.setMinValue(0);
+        sliceDataSetX.setMaxValue(10);
+        sliceDataSetY.setMinValue(0);
+        sliceDataSetY.setMaxValue(4);
+
+        assertArrayEquals(minX, sliceDataSetX.getValues(DIM_Y), "x-min");
+        assertArrayEquals(minY, sliceDataSetY.getValues(DIM_Y), "y-min");
 
         LOGGER.atDebug().log("testMinOptions - done");
     }
@@ -221,9 +270,7 @@ public class DimReductionDataSetTests {
 
         nEvent = 0;
         sliceDataSetX.addListener(evt -> {
-            if (evt.getSource().equals(sliceDataSetX)) {
-                nEvent++;
-            }
+            nEvent++;
         });
         testData.invokeListener(new UpdateEvent(testData, "testX"), true);
         assertEquals(1, nEvent, "DataSet3D event propagated");
@@ -234,11 +281,15 @@ public class DimReductionDataSetTests {
         assertArrayEquals(testData.getZValues()[0], sliceDataSetX.getValues(DIM_Y), "first row match");
         assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
 
-        sliceDataSetX.setMinIndex(DIM_X, 2.0);
+        sliceDataSetX.setMinValue(7.0);
         assertEquals(2, nEvent, "DataSet3D event propagated");
 
-        assertArrayEquals(testData.getZValues()[1], sliceDataSetX.getValues(DIM_Y), "first row match");
+        assertArrayEquals(testData.getZValues()[1], sliceDataSetX.getValues(DIM_Y), "second row match");
         assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
+
+        assertArrayEquals(new double[] { 1, 6, 9 }, sliceDataSetY.getValues(DIM_Y), "first column match");
+        sliceDataSetY.setMinValue(2.0);
+        assertArrayEquals(new double[] { 2, 5, 8 }, sliceDataSetY.getValues(DIM_Y), "second column match");
 
         LOGGER.atDebug().log("testSliceOptions - done");
     }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/DimReductionDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/DimReductionDataSetSample.java
@@ -53,7 +53,7 @@ public class DimReductionDataSetSample extends Application {
         DimReductionDataSet horizontalSlice = new DimReductionDataSet(waveletScalogram, DataSet.DIM_Y, Option.SLICE);
         XValueIndicator xValueIndicator = new XValueIndicator(waveletChart1.getXAxis(), 0.0, "slice-y");
         xValueIndicator.valueProperty()
-                .addListener((ch, o, n) -> horizontalSlice.setMinIndex(DataSet.DIM_X, n.doubleValue()));
+                .addListener((ch, o, n) -> horizontalSlice.setMinValue(n.doubleValue()));
         xValueIndicator.setValue(300.0);
         waveletChart1.getPlugins().addAll(xValueIndicator);
 
@@ -68,9 +68,9 @@ public class DimReductionDataSetSample extends Application {
         xRangeIndicator.upperBoundProperty().bindBidirectional(xRangeIndicatorMax.valueProperty());
         xRangeIndicator.setEditable(true);
         xRangeIndicator.lowerBoundProperty()
-                .addListener((ch, o, n) -> horizontalRange.setMinIndex(DataSet.DIM_X, n.doubleValue()));
+                .addListener((ch, o, n) -> horizontalRange.setMinValue(n.doubleValue()));
         xRangeIndicator.upperBoundProperty()
-                .addListener((ch, o, n) -> horizontalRange.setMaxIndex(DataSet.DIM_X, n.doubleValue()));
+                .addListener((ch, o, n) -> horizontalRange.setMaxValue(n.doubleValue()));
         xRangeIndicator.setLowerBound(200.0);
         xRangeIndicator.setUpperBound(600.0);
         waveletChart1.getPlugins().addAll(xRangeIndicator, xRangeIndicatorMin, xRangeIndicatorMax);
@@ -82,9 +82,9 @@ public class DimReductionDataSetSample extends Application {
         DimReductionDataSet verticalSlice = new DimReductionDataSet(waveletScalogram, DataSet.DIM_X, Option.SLICE);
         YValueIndicator yValueIndicator = new YValueIndicator(waveletChart1.getYAxis(), 0.0, "slice-x");
         yValueIndicator.valueProperty()
-                .addListener((ch, o, n) -> verticalSlice.setMinIndex(DataSet.DIM_Y, n.doubleValue()));
+                .addListener((ch, o, n) -> verticalSlice.setMinValue(n.doubleValue()));
         yValueIndicator.setValue(0.26);
-        verticalSlice.setMinIndex(DataSet.DIM_Y, 0.1);
+        verticalSlice.setMinValue(0.1);
         waveletChart2.getPlugins().add(yValueIndicator);
 
         // reduce wavelet data set to 2D by integrating over range
@@ -98,9 +98,9 @@ public class DimReductionDataSetSample extends Application {
         yRangeIndicator.upperBoundProperty().bindBidirectional(yRangeIndicatorMax.valueProperty());
         yRangeIndicator.setEditable(true);
         yRangeIndicator.lowerBoundProperty()
-                .addListener((ch, o, n) -> verticalRange.setMinIndex(DataSet.DIM_Y, n.doubleValue()));
+                .addListener((ch, o, n) -> verticalRange.setMinValue(n.doubleValue()));
         yRangeIndicator.upperBoundProperty()
-                .addListener((ch, o, n) -> verticalRange.setMaxIndex(DataSet.DIM_Y, n.doubleValue()));
+                .addListener((ch, o, n) -> verticalRange.setMaxValue(n.doubleValue()));
         yRangeIndicator.setLowerBound(0.175);
         yRangeIndicator.setUpperBound(0.225);
         waveletChart2.getPlugins().addAll(yRangeIndicator, yRangeIndicatorMin, yRangeIndicatorMax);

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RotatedAxisLabelSample.java
@@ -36,6 +36,7 @@ public class RotatedAxisLabelSample extends Application {
         chart.getPlugins().add(new Zoomer()); // standard plugin, useful for most cases
         final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1");
         chart.getDatasets().addAll(dataSet1);
+        chart.setLegendVisible(false);
 
         // set additional axes
         for (AxisLabelOverlapPolicy policy : AxisLabelOverlapPolicy.values()) {
@@ -49,6 +50,21 @@ public class RotatedAxisLabelSample extends Application {
             yAxis1.setOverlapPolicy(policy);
 
             chart.getAxes().addAll(xAxis1, yAxis1);
+
+            if (policy.equals(AxisLabelOverlapPolicy.SKIP_ALT)) {
+                final DefaultNumericAxis xAxis2 = getSynchedAxis(xAxis0, "x-axis (" + policy + ") + extra label spacing");
+                xAxis2.setSide(Side.BOTTOM);
+                xAxis2.setOverlapPolicy(policy);
+                xAxis2.setTickLabelSpacing(10);
+
+                final DefaultNumericAxis yAxis2 = getSynchedAxis(yAxis0, "y-axis (-90°, " + policy + ") + extra label spacing");
+                yAxis2.setSide(Side.LEFT);
+                yAxis2.setTickLabelRotation(-90);
+                yAxis2.setOverlapPolicy(policy);
+                yAxis2.setTickLabelSpacing(10);
+
+                chart.getAxes().addAll(xAxis2, yAxis2);
+            }
         }
 
         final DefaultNumericAxis xAxis1 = getSynchedAxis(xAxis0, "x-axis (45°)");


### PR DESCRIPTION
* fixes API of DimReductionDataSet
  - removed superfluous arguments etc
  - makes min/max values persistent and recompute min/max indices on DataSet changes
* added getTickLabelSpacing() as an additional free parameter to control number of labels
* workaround to improve unnecessary layout recomputations
   - N.B. better CPU performance when ParameterMeasurement are enabled)
   - see ErrorDataSetRendererSample and add 'Maximum' estimator from the toolbox for illustration