### PR TITLE
Fix setupGitHooks.sh relative symlinks.

### DIFF
--- a/setupGitHooks.sh
+++ b/setupGitHooks.sh
@@ -1,4 +1,4 @@
 #/bin/bash
 # git config core.hooksPath $PWD/config/hooks
 # safe fall-back for older git versions
-ln -s ./config/hooks/pre* ./.git/hooks/
+ln -s -r ./config/hooks/pre* -t ./.git/hooks/


### PR DESCRIPTION
Fixes the relative symlinks generated for the clang-format pre-commit git hook.