### PR TITLE
fixed bug in FifoDoubleErrorDataSet and added unit-testing

### DIFF
--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/FifoDoubleErrorDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/FifoDoubleErrorDataSetTests.java
@@ -1,0 +1,73 @@
+package de.gsi.dataset.spi;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import de.gsi.dataset.DataSet;
+
+/**
+ * Unit testing for {@link de.gsi.dataset.spi.FifoDoubleErrorDataSet} implementation.
+ *
+ * @author rstein
+ */
+public class FifoDoubleErrorDataSetTests {
+    @Test
+    public void testConstructors() {
+        assertDoesNotThrow(() -> new FifoDoubleErrorDataSet("test data set", 10));
+        assertDoesNotThrow(() -> new FifoDoubleErrorDataSet("test data set", 10, 10.0));
+
+        assertThrows(IllegalArgumentException.class, () -> new FifoDoubleErrorDataSet("test data set", 0, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> new FifoDoubleErrorDataSet("test data set", -1, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> new FifoDoubleErrorDataSet("test data set", 10, 0));
+        assertThrows(IllegalArgumentException.class, () -> new FifoDoubleErrorDataSet("test data set", 10, -1));
+
+        FifoDoubleErrorDataSet testDataSet = new FifoDoubleErrorDataSet("test data set", 10, 8.0);
+        assertEquals(0, testDataSet.getDataCount());
+
+        assertEquals(8.0, testDataSet.getMaxDistance());
+        testDataSet.setMaxDistance(10.0);
+        assertEquals(10.0, testDataSet.getMaxDistance());
+
+        assertNotNull(testDataSet.getData());
+    }
+
+    @Test
+    public void testDataSetAdders() {
+        FifoDoubleErrorDataSet testDataSet = new FifoDoubleErrorDataSet("test data set", 10, 10.0);
+        assertEquals(0, testDataSet.getDataCount());
+
+        final double[] xValues = new double[] { 1, 2, 3, 4, 5, 6 };
+        final double[] yValues = new double[] { 11, 12, 13, 14, 15, 16 };
+        final double[] yErrorNeg = new double[] { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6 };
+        final double[] yErrorPos = new double[] { 1.1, 1.2, 1.3, 1.4, 1.5, 1.6 };
+        final double[] xError = new double[] { 0, 0, 0, 0, 0, 0 };
+        testDataSet.add(xValues, yValues, yErrorNeg, yErrorPos);
+        assertEquals(6, testDataSet.getDataCount());
+        assertArrayEquals(xValues, testDataSet.getValues(DataSet.DIM_X));
+        assertArrayEquals(yValues, testDataSet.getValues(DataSet.DIM_Y));
+        assertArrayEquals(xError, testDataSet.getErrorsNegative(DataSet.DIM_X));
+        assertArrayEquals(xError, testDataSet.getErrorsPositive(DataSet.DIM_X));
+        assertArrayEquals(yErrorNeg, testDataSet.getErrorsNegative(DataSet.DIM_Y));
+        assertArrayEquals(yErrorPos, testDataSet.getErrorsPositive(DataSet.DIM_Y));
+
+        testDataSet.add(Double.NaN, 2, 0.0, 0.0);
+        assertEquals(6, testDataSet.getDataCount());
+        testDataSet.add(8, Double.NaN, 0.0, 0.0);
+        assertEquals(7, testDataSet.getDataCount());
+
+        testDataSet.reset();
+        assertEquals(0, testDataSet.getDataCount());
+        testDataSet.add(0.0, 2, 0.0, 0.0, "data label", "data style");
+        assertEquals(1, testDataSet.getDataCount());
+        assertEquals("data label", testDataSet.getDataLabel(0));
+        assertEquals("data style", testDataSet.getStyle(0));
+
+        testDataSet.expire(10.0001);
+        assertEquals(0, testDataSet.getDataCount());
+    }
+}

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/LimitedQueueTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/LimitedQueueTests.java
@@ -1,0 +1,41 @@
+package de.gsi.dataset.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit testing for {@link de.gsi.dataset.utils.LimitedQueueTests} implementation.
+ *
+ * @author rstein
+ */
+public class LimitedQueueTests {
+    @Test
+    public void testConstructors() {
+        assertDoesNotThrow(() -> new LimitedQueue<>(10));
+
+        assertThrows(IllegalArgumentException.class, () -> new LimitedQueue<>(0));
+        assertThrows(IllegalArgumentException.class, () -> new LimitedQueue<>(-1));
+
+        LimitedQueue<Double> testQueue = new LimitedQueue<>(1);
+        assertEquals(1, testQueue.getLimit());
+        assertEquals(0, testQueue.size());
+
+        assertThrows(IllegalArgumentException.class, () -> testQueue.setLimit(0));
+        testQueue.setLimit(3);
+        assertEquals(3, testQueue.getLimit());
+
+        assertEquals(0, testQueue.size());
+        assertTrue(testQueue.add(Double.valueOf(1.0)));
+        assertEquals(1, testQueue.size());
+        assertTrue(testQueue.add(Double.valueOf(2.0)));
+        assertEquals(2, testQueue.size());
+        assertTrue(testQueue.add(Double.valueOf(3.0)));
+        assertEquals(3, testQueue.size());
+        assertTrue(testQueue.add(Double.valueOf(4.0)));
+        assertEquals(3, testQueue.size());
+    }
+}


### PR DESCRIPTION
N.B. bug(s) reported by awalter
* removed superfluous AxisRange computation/additions
* replaced duplicate LimitedQueue implementation in favour for
de.gsi.dataset.utils.LimitedQueue (more features/interfaces implemented)
* fixed bug/consistency error setter/getter - DataSet interface
suggested asymmetric in Y (ie. -dy/+dy) but super was symmetric for both
-> changed to asymmetric y (N.B. this is the more common use-case, x is
usually time-related and not affected by measurement errors)