### PR TITLE
revert static tickmark computation back to automatic version in AbstractAxis

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -1241,10 +1241,10 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 newAxisRange = getAxisRange();
             }
 
-            if (isAutoRanging() || isAutoGrowRanging() || isInvertedAxis()) {
-                setTickUnit(computePreferredTickUnit(axisLength));
-            }
-            // setTickUnit(computePreferredTickUnit(axisLength));
+            // if (isAutoRanging() || isAutoGrowRanging() || isInvertedAxis()) {
+            //    setTickUnit(computePreferredTickUnit(axisLength));
+            //}
+            setTickUnit(computePreferredTickUnit(axisLength));
 
             newAxisRange.tickUnit = this.getTickUnit();
             updateAxisLabelAndUnit();


### PR DESCRIPTION
based on internal request, reverted commit d73b66c following issue #129

N.B. certain corner-use cases were broken by this commit. Sorry for the inconvenience.