### PR TITLE
added JUnit5 extension to execute @Test within JavaFX UI thread

### DIFF
--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/JavaFxInterceptor.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/JavaFxInterceptor.java
@@ -1,0 +1,59 @@
+package de.gsi.chart.utils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+/**
+ * Simple JUnit 5 extension to ensure that {@code @Test} statements are executed in the JavaFX UI thread. 
+ * This is (strictly) necessary when testing setter and/or getter methods of JavaFX classes (ie. Node derived, properties etc).
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * @ExtendWith(ApplicationExtension.class)
+ * @ExtendWith(JavaFxInterceptor.class)
+ * public class SquareButtonTest {
+ *     @Start
+ *     public void start(Stage stage) {
+ *         // usual FX initialisation
+ *         // ...
+ *     }
+ *
+ *    @Test
+ *    public void testSetterGetter() throws InterruptedException, ExecutionException {
+ *        FXUtils.assertJavaFxThread(); // verifies that this test is indeed executed in the JavaFX thread
+ *        // perform the regular JavaFX thread safe assertion tests 
+ *        // ...
+ *    }
+ * }
+ *
+ * }</pre>
+ * 
+ * @author rstein
+ */
+public class JavaFxInterceptor implements InvocationInterceptor {
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext) throws Throwable {
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+        // N.B. explicit run and wait since the test should only continue
+        // if the previous JavaFX access as been finished.
+        FXUtils.runAndWait(() -> {
+            try {
+                // executes function after @Test
+                invocation.proceed();
+            } catch (Throwable t) {
+                throwable.set(t);
+            }
+        });
+        Throwable t = throwable.get();
+        if (t != null) {
+            throw t;
+        }
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/viewer/SquareButtonTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/viewer/SquareButtonTest.java
@@ -20,6 +20,7 @@ import org.testfx.framework.junit5.Start;
 
 import de.gsi.chart.ui.TilingPane.Layout;
 import de.gsi.chart.utils.FXUtils;
+import de.gsi.chart.utils.JavaFxInterceptor;
 
 /**
  * Tests {@link de.gsi.chart.ui.SquareButton }
@@ -27,6 +28,7 @@ import de.gsi.chart.utils.FXUtils;
  * @author rstein
  */
 @ExtendWith(ApplicationExtension.class)
+@ExtendWith(JavaFxInterceptor.class)
 public class SquareButtonTest {
     private Node icon;
     private SquareButton field;
@@ -47,20 +49,22 @@ public class SquareButtonTest {
 
     @Test
     public void testSetterGetter() throws InterruptedException, ExecutionException {
+        FXUtils.assertJavaFxThread();
+
         assertEquals(null, field.getText(), "getText()");
         assertNotNull(field.toString(), "toString()");
         // could not check for identity since ButtonBase slightly modifies the Graphics (css-related)
         assertEquals(icon, field.getGraphic());
         assertNotNull(field.getGraphic(), "getGraphic()");
 
-        FXUtils.runAndWait(() -> field.setMinWidth(50));
+        field.setMinWidth(50);
         assertEquals(field.getHeight(), field.getWidth(), "getHeight() == getWidth()");
 
-        FXUtils.runAndWait(() -> field.setMinWidth(60));
+        field.setMinWidth(60);
         assertEquals(field.getHeight(), field.getWidth(), "getHeight() == getWidth()");
 
-        FXUtils.runAndWait(() -> root.getChildren().remove(field));
-        FXUtils.runAndWait(() -> field.setMinHeight(Region.USE_COMPUTED_SIZE));
+        root.getChildren().remove(field);
+        field.setMinHeight(Region.USE_COMPUTED_SIZE);
 
         assertDoesNotThrow(() -> group = new Group(field));
         assertDoesNotThrow(() -> group.getChildren().remove(field));


### PR DESCRIPTION
Simple JUnit 5 extension to ensure that @Test statements are executed in
the JavaFX UI thread. This is (strictly) necessary when testing setter
and/or getter methods of JavaFX classes (ie. Node derived, properties
etc).