### PR TITLE
Remove FxSwingUtils dependency on javafx-swing by implementing our own png image exporter

### DIFF
--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>icu4j</artifactId>
             <version>${chartfx.icu4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId> <!-- needed to for benchmark saving images to file -->
+            <version>${chartfx.javafx.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -32,11 +32,6 @@
             <version>${chartfx.javafx.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-swing</artifactId> <!-- needed to for saving images to file -->
-            <version>${chartfx.javafx.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
             <version>4.0.16-alpha</version>

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/Screenshot.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/Screenshot.java
@@ -3,11 +3,8 @@ package de.gsi.chart.plugins;
 import java.io.File;
 import java.io.IOException;
 
-import javax.imageio.ImageIO;
-
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Orientation;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Alert;
@@ -35,6 +32,7 @@ import org.controlsfx.glyphfont.Glyph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.gsi.chart.utils.WriteFxImage;
 import de.gsi.dataset.DataSet; // NOPMD - needed for JavaDoc
 import de.gsi.dataset.utils.DataSetUtils;
 
@@ -253,7 +251,7 @@ public class Screenshot extends ChartPlugin {
      */
     private static void saveImage(final Image image, final File file) {
         try {
-            ImageIO.write(SwingFXUtils.fromFXImage(image, null), "png", file);
+            WriteFxImage.savePng(image, file);
         } catch (IOException e) {
             LOGGER.atError().addArgument(file.getName()).log("Error saving screenshot to {}");
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/PeriodicScreenCapture.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/PeriodicScreenCapture.java
@@ -26,7 +26,6 @@ import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.embed.swing.SwingFXUtils;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.Scene;
@@ -47,7 +46,6 @@ public class PeriodicScreenCapture implements Observable {
     private static final Logger LOGGER = LoggerFactory.getLogger(PeriodicScreenCapture.class);
     private static final String DEFAULT_TIME_FORMAT = "yyyyMMdd_HHmmss";
     private static final String FILE_LOGGING_SUFFIX = ".png";
-    private static final String IMAGE_FORMAT = "png";
     private final Scene primaryScene;
     private final Path path;
     private final String fileName;
@@ -169,7 +167,7 @@ public class PeriodicScreenCapture implements Observable {
                 LOGGER.info("needed to create directory for file: " + longFileName);
             }
 
-            ImageIO.write(SwingFXUtils.fromFXImage(image, null), IMAGE_FORMAT, file);
+            WriteFxImage.savePng(image, file);
             Files.move(Paths.get(tempFileName), Paths.get(longFileName), REPLACE_EXISTING);
             fireInvalidated();
             LOGGER.debug("write screenshot to " + tempFileName + " -> " + longFileName);

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -16,7 +16,7 @@ import de.gsi.dataset.utils.ArrayCache;
 
 /**
  * Writes a JavaFx Image into a ByteBuffer or file
- * 
+ *
  * possible improvements:
  * - use multiple IDAT chunks to use fixed buffer size and limit memory footprint
  * - implement filtering of lines before compression for smaller file sizes
@@ -25,8 +25,8 @@ import de.gsi.dataset.utils.ArrayCache;
  * @author Alexander Krimm
  */
 public final class WriteFxImage {
-    protected static final int HEADER_SIZE = 8 + (12 + 13) + 12 + 12; // size of all the headers and other Metadata
-    protected static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
+    private static final int HEADER_SIZE = 8 + 12 + 13 + 12 + 12; // size of all the headers and other Metadata
+    private static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
 
     /**
      * private constructor for static utility class
@@ -35,40 +35,41 @@ public final class WriteFxImage {
     }
 
     /**
-     * Encodes a JavaFx image as an RGB png image with maximum (lossless) compression 
+     * Encodes a JavaFx image as an RGB png image with fastest (lossless) compression
      *
      * @param image The input image to be encoded
      * @return a byte buffer with the encoded image
      * @see <a href="https://tools.ietf.org/html/rfc2083">rfc2083</a>
      */
     public static ByteBuffer encode(final Image image) {
-        return encode(image, null, true, Deflater.BEST_COMPRESSION, null);
+        return encode(image, null, true, Deflater.BEST_SPEED, null);
     }
 
     /**
      * Encodes a JavaFx image as an RGB png image.
      * If you pass in a ByteBuffer to use, please make sure that it has enough capacity to fit the encoded image or
      * handle errors (IndexOutOfBoundsException) accordingly. If you want to be on the safe side, use
-     * {@link #getCompressedSizeBound(int, int, boolean) getCompressedSizeBound(width, height, alpha)} to get an upper bound for the output size.
-     * 
+     * {@link #getCompressedSizeBound(int, int, boolean) getCompressedSizeBound(width, height, alpha)} 
+     * to get an upper bound for the output size.
+     *
      * @param image The input image to be encoded
      * @param byteBuffer optional byte buffer to store the output in, pass null to return a new one.
-     * @param alpha wheter to include alpha information in the image
+     * @param alpha whether to include alpha information in the image
      * @param compressionLevel {@link Deflater#BEST_COMPRESSION} (9) to {@link Deflater#BEST_SPEED} (0)
      * @param metaInfo an optional map which will be filled with debugging information like compression efficiency
      * @return a byte buffer with the encoded image
      * @see "https://tools.ietf.org/html/rfc2083"
      */
-    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer,final boolean alpha,
+    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer, final boolean alpha,
             final int compressionLevel, final Map<String, Object> metaInfo) {
         // get meta info
         final int w = (int) image.getWidth();
         final int h = (int) image.getHeight();
         // allocate output buffer if necessary. conservative allocation, assume upper bound for deflate algorithm
-        final ByteBuffer outputByteBuffer = byteBuffer != null ? byteBuffer : ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha));
+        final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha)) : byteBuffer;
         // get necessary helper classes
         final PixelReader pr = image.getPixelReader();
-        CRC32 crc = new CRC32();
+        final CRC32 crc = new CRC32();
         final Deflater compressor = new Deflater(compressionLevel);
         // actual PNG encoding
         writeImageHeader(w, h, alpha, outputByteBuffer, crc);
@@ -81,7 +82,7 @@ public final class WriteFxImage {
             final int bytesPerPixel = alpha ? 4 : 3;
             metaInfo.put("bufferSize", outputByteBuffer.capacity());
             metaInfo.put("outputSizeBound", getCompressedSizeBound(w, h, alpha));
-            metaInfo.put("compression", ((double) compressor.getBytesWritten()) / (w * h * bytesPerPixel));
+            metaInfo.put("compression", (double) compressor.getBytesWritten() / (w * h * bytesPerPixel));
             metaInfo.put("width", w);
             metaInfo.put("height", h);
             metaInfo.put("colorMode", alpha ? "rgba" : "rgb");
@@ -92,22 +93,8 @@ public final class WriteFxImage {
     }
 
     /**
-     * Saves the given image as a png file.
-     *
-     * @param image The image to save
-     * @param file The filename to save the image to.
-     * @throws IOException if the file cannot be written
-     */
-    public static void savePng(Image image, File file) throws IOException {
-        try (OutputStream os = Files.newOutputStream(file.toPath())) {
-            ByteBuffer buffer = WriteFxImage.encode(image);
-            os.write(buffer.array(), 0, buffer.limit());
-        }
-    }
-
-    /**
      * Returns the conservative upper bound for the compressed image size.
-     * 
+     *
      * @param width Image width
      * @param height Image height
      * @param alpha Alpha enabled
@@ -116,41 +103,52 @@ public final class WriteFxImage {
      */
     public static int getCompressedSizeBound(final int width, final int height, final boolean alpha) {
         final int bytesPerPixel = alpha ? 4 : 3;
-        int uncompressedSize = (width) * height * bytesPerPixel + height + HEADER_SIZE;
-        int compressedSize = uncompressedSize + ((uncompressedSize + 7) >> 3) + ((uncompressedSize + 63) >> 6) + 5;
+        final int uncompressedSize = width * height * bytesPerPixel + height + HEADER_SIZE;
+        final int compressedSize = uncompressedSize + (uncompressedSize + 7 >> 3) + (uncompressedSize + 63 >> 6) + 5;
         return compressedSize + HEADER_SIZE;
     }
 
     /**
-     * Writes the PNG file header and IHDR meta-information block
-     * 
-     * @param width The with of the image
-     * @param height The height of the image
-     * @param alpha whether to support alpha
-     * @param outputByteBuffer the buffer to write into
-     * @param crc the checksum calculator
+     * Saves the given image as a png file.
+     *
+     * @param image The image to save
+     * @param file The filename to save the image to.
+     * @throws IOException if the file cannot be written
      */
-    private static void writeImageHeader(int width, int height, boolean alpha, ByteBuffer outputByteBuffer, CRC32 crc) {
-        // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
-        outputByteBuffer.put(new byte[] { (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a });
-        // IHDR
-        outputByteBuffer.putInt(13); // length of IHDR chunk
-        crc.reset(); // checksum starts after length field
-        write("IHDR".getBytes(), outputByteBuffer, crc);
-        write(width, outputByteBuffer, crc); // with 4 bytes
-        write(height, outputByteBuffer, crc); // height 4 bytes
-        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
-        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
-        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
-        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
-        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
-        write(alpha ? new byte[] { 8, 6, 0, 0, 0 } : new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB(A) Mode
-        outputByteBuffer.putInt((int) crc.getValue());
+    public static void savePng(final Image image, final File file) throws IOException {
+        try (OutputStream os = Files.newOutputStream(file.toPath())) {
+            final ByteBuffer buffer = WriteFxImage.encode(image);
+            os.write(buffer.array(), 0, buffer.limit());
+        }
+    }
+
+    /**
+     * Writes a byte array to the buffer and updates the checksum.
+     *
+     * @param b byteArray to put into buffer
+     * @param buffer output buffer
+     * @param crc checksum calculator
+     */
+    private static void write(final byte[] b, final ByteBuffer buffer, final CRC32 crc) {
+        buffer.put(b);
+        crc.update(b);
+    }
+
+    /**
+     * Writes an integer value to the buffer and updates the checksum.
+     *
+     * @param i integer value to write
+     * @param buffer the buffer to write to
+     * @param crc the checksum to be updated
+     */
+    private static void write(final int i, final ByteBuffer buffer, final CRC32 crc) {
+        final byte[] b = { (byte) (i >> 24 & 0xff), (byte) (i >> 16 & 0xff), (byte) (i >> 8 & 0xff), (byte) (i & 0xff) };
+        write(b, buffer, crc);
     }
 
     /**
      * Writes the IDAT chunk of a png file, which contains the compressed image data to the supplied buffer.
-     * 
+     *
      * @param pr PixelWriter
      * @param w with of the image
      * @param h height of the image
@@ -158,8 +156,8 @@ public final class WriteFxImage {
      * @param outputByteBuffer the byte buffer to write to
      * @param crc checksum calculator
      */
-    private static void writeImageData(PixelReader pr, int w, int h, boolean alpha, Deflater compressor,
-            ByteBuffer outputByteBuffer, CRC32 crc) {
+    private static void writeImageData(final PixelReader pr, final int w, final int h, final boolean alpha, final Deflater compressor,
+            final ByteBuffer outputByteBuffer, final CRC32 crc) {
         // get raw image data
         final int bytesPerPixel = alpha ? 4 : 3;
         final int rawDataSize = w * h * bytesPerPixel + h; // image dimensions times bytesPerPixel + line filtering flag
@@ -169,9 +167,9 @@ public final class WriteFxImage {
             for (int y = 0; y < h; y++) {
                 uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
                 for (int x = 0; x < w; x++) {
-                    int pixel = pr.getArgb(x, y);
-                    uncompressedImageData[i++] = (byte) ((pixel >> 16) & 0xff); //red
-                    uncompressedImageData[i++] = (byte) ((pixel >> 8) & 0xff); // green
+                    final int pixel = pr.getArgb(x, y);
+                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); //red
+                    uncompressedImageData[i++] = (byte) (pixel >> 8 & 0xff); // green
                     uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
                     uncompressedImageData[i++] = (byte) (pixel >> 24 & 0xff); // alpha
                 }
@@ -180,9 +178,9 @@ public final class WriteFxImage {
             for (int y = 0; y < h; y++) {
                 uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
                 for (int x = 0; x < w; x++) {
-                    int pixel = pr.getArgb(x, y);
-                    uncompressedImageData[i++] = (byte) ((pixel >> 16) & 0xff); //red
-                    uncompressedImageData[i++] = (byte) ((pixel >> 8) & 0xff); // green
+                    final int pixel = pr.getArgb(x, y);
+                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); //red
+                    uncompressedImageData[i++] = (byte) (pixel >> 8 & 0xff); // green
                     uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
                 }
             }
@@ -206,11 +204,11 @@ public final class WriteFxImage {
 
     /**
      * Writes the end marker for the png file format
-     * 
+     *
      * @param outputByteBuffer the buffer to write into
      * @param crc The checksum calculator
      */
-    private static void writeImageFooter(ByteBuffer outputByteBuffer, CRC32 crc) {
+    private static void writeImageFooter(final ByteBuffer outputByteBuffer, final CRC32 crc) {
         outputByteBuffer.putInt(0);
         crc.reset();
         write("IEND".getBytes(), outputByteBuffer, crc);
@@ -218,27 +216,29 @@ public final class WriteFxImage {
     }
 
     /**
-     * Writes a byte array to the buffer and updates the checksum.
+     * Writes the PNG file header and IHDR meta-information block
      *
-     * @param b byteArray to put into buffer
-     * @param buffer output buffer
-     * @param crc checksum calculator
+     * @param width The with of the image
+     * @param height The height of the image
+     * @param alpha whether to support alpha
+     * @param outputByteBuffer the buffer to write into
+     * @param crc the checksum calculator
      */
-    private static void write(byte[] b, ByteBuffer buffer, CRC32 crc) {
-        buffer.put(b);
-        crc.update(b);
-    }
-
-    /**
-     * Writes an integer value to the buffer and updates the checksum.
-     *
-     * @param i integer value to write
-     * @param buffer the buffer to write to
-     * @param crc the checksum to be updated
-     */
-    private static void write(int i, ByteBuffer buffer, CRC32 crc) {
-        byte[] b = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
-                (byte) (i & 0xff) };
-        write(b, buffer, crc);
+    private static void writeImageHeader(final int width, final int height, final boolean alpha, final ByteBuffer outputByteBuffer, final CRC32 crc) {
+        // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
+        outputByteBuffer.put(new byte[] { (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a });
+        // IHDR
+        outputByteBuffer.putInt(13); // length of IHDR chunk
+        crc.reset(); // checksum starts after length field
+        write("IHDR".getBytes(), outputByteBuffer, crc);
+        write(width, outputByteBuffer, crc); // with 4 bytes
+        write(height, outputByteBuffer, crc); // height 4 bytes
+        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
+        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
+        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
+        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
+        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
+        write(alpha ? new byte[] { 8, 6, 0, 0, 0 } : new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB(A) Mode
+        outputByteBuffer.putInt((int) crc.getValue());
     }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -1,0 +1,190 @@
+package de.gsi.chart.utils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes a JavaFx Image into a ByteBuffer or file
+ * TODO: possible improvements
+ * - use multiple IDAT chunks to use fixed buffer size and limit memory footprint
+ * - implement filtering for smaller file sizes
+ * - Optionally add tEXT chunks for metadata (EXIF)
+ *
+ * @author Alexander Krimm
+ */
+public class WriteFxImage {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImage.class);
+    private static final int HEADER_SIZE = 8 + (12 + 13) + 12 + 12; // size of all the headers and other Metadata
+    private static final int BUFFER_MARGIN = 200; // how many additional bytes to allocate for the buffers
+
+    /**
+     * private constructor for static utility class
+     */
+    private WriteFxImage() {
+    }
+
+    /**
+     * Encodes a JavaFx image as an RGB png image
+     *
+     * @param image an javafx.scene.image.Image
+     * @return a byte buffer with the encoded image
+     * @see "https://tools.ietf.org/html/rfc2083"
+     */
+    public static ByteBuffer encode(final Image image) {
+        return encode(image, null);
+    }
+
+    /**
+     * Encodes a JavaFx image as an RGB png image.
+     * If you pass in a ByteBuffer to use, please make sure that it has enough capacity to fit the encoded image or
+     * handle errors (IndexOutOfBoundsException) accordingly.
+     * 
+     * @param image an javafx.scene.image.Image
+     * @param byteBuffer optional byte buffer to store the output in, pass null to return a new one.
+     * @return a byte buffer with the encoded image
+     * @see "https://tools.ietf.org/html/rfc2083"
+     */
+    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer) {
+        if (byteBuffer != null) {
+            byteBuffer.clear();
+        }
+        int w = (int) image.getWidth();
+        int h = (int) image.getHeight();
+        // conservative allocation, assume zero compression
+        final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate((w + 1) * h * 3 + HEADER_SIZE + BUFFER_MARGIN) : byteBuffer;
+        final PixelReader pr = image.getPixelReader();
+        CRC32 crc = new CRC32();
+
+        // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
+        outputByteBuffer.put(new byte[] { 0x89 - 0xff - 1, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a });
+
+        // IHDR
+        write(13, outputByteBuffer); // length of IHDR chunk
+        crc.reset(); // checksum starts after length field
+        write("IHDR".getBytes(), outputByteBuffer, crc);
+        write(w, outputByteBuffer, crc); // with 4 bytes
+        write(h, outputByteBuffer, crc); // height 4 bytes
+        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
+        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
+        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
+        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
+        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
+        write(new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB Mode
+        write((int) crc.getValue(), outputByteBuffer);
+
+        int sizePos = outputByteBuffer.position();
+        write(0, outputByteBuffer); // zero size, will later be overwritten when we know the size
+        crc.reset();
+        write("IDAT".getBytes(), outputByteBuffer, crc);
+        // compress image data
+        final Deflater compressor = new Deflater(Deflater.BEST_COMPRESSION);
+        final ByteBuffer uncompressedImageData = ByteBuffer.allocate((w + 1) * h * 3);
+        compressor.setInput(uncompressedImageData);
+        for (int y = 0; y < h; y++) {
+            uncompressedImageData.put((byte) 0); // line filtering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
+            for (int x = 0; x < w; x++) {
+                int pixel = pr.getArgb(x, y);
+                uncompressedImageData.put((byte) ((pixel >> 16) & 0xff));
+                uncompressedImageData.put((byte) ((pixel >> 8) & 0xff));
+                uncompressedImageData.put((byte) (pixel & 0xff));
+            }
+        }
+        // Does not work because rgb pixel format is not writable even if isWritable says so -.-
+        // final WritablePixelFormat<ByteBuffer> pixelformat = (WritablePixelFormat<ByteBuffer>) PixelFormat
+        //         .getByteRgbInstance();
+        // uncompressedImageData.put((byte) 0); // line filtering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
+        // pr.getPixels(0, 0, w, h, pixelformat, uncompressedImageData, w + 1); // stride of w+1 puts line filtering to 0(None)
+        uncompressedImageData.flip();
+        compressor.finish();
+        compressor.deflate(outputByteBuffer, Deflater.FULL_FLUSH);
+        // update crc
+        crc.update(outputByteBuffer.array(), sizePos + 8, compressor.getTotalOut());
+        outputByteBuffer.putInt(sizePos, compressor.getTotalOut());
+        write((int) crc.getValue(), outputByteBuffer);
+
+        // IEND chunk
+        write(0, outputByteBuffer);
+        crc.reset();
+        write("IEND".getBytes(), outputByteBuffer, crc);
+        write((int) crc.getValue(), outputByteBuffer);
+
+        outputByteBuffer.flip();
+
+        // DEGBUG output
+        if (LOGGER.isDebugEnabled()) {
+            final float compression = (100.0f * compressor.getBytesWritten()) / compressor.getBytesRead();
+            LOGGER.atDebug() //
+                    .addArgument(w)
+                    .addArgument(h) //
+                    .addArgument(compressor.getBytesRead()) //
+                    .addArgument(compressor.getBytesWritten()) //
+                    .addArgument(compression) //
+                    .addArgument(outputByteBuffer.limit() - outputByteBuffer.position()) //
+                    .log("Convertet Image({}x{}) to png: IN: {} bytes, OUT: {} bytes, compression: {}%, total file size: {} bytes");
+        }
+
+        return outputByteBuffer;
+    }
+
+    /**
+     * Saves the given Image as a png file.
+     *
+     * @param image The image to save
+     * @param file The filename to save the image to.
+     * @throws IOException if the file cannot be written
+     */
+    public static void savePng(Image image, File file) throws IOException {
+        try (FileOutputStream os = new FileOutputStream(file); FileChannel wChannel = os.getChannel()) {
+            ByteBuffer buffer = WriteFxImage.encode(image);
+            wChannel.write(buffer);
+        }
+    }
+
+    /**
+     * Writes a byte array to the buffer and updates the checksum.
+     *
+     * @param b
+     * @param buffer
+     * @param crc
+     */
+    private static void write(byte b[], ByteBuffer buffer, CRC32 crc) {
+        buffer.put(b);
+        crc.update(b);
+    }
+
+    /**
+     * Writes an integer value to the buffer.
+     *
+     * @param i integer value to write
+     * @param buffer the buffer to write to
+     */
+    private static void write(int i, ByteBuffer buffer) {
+        byte b[] = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
+            (byte) (i & 0xff) };
+        buffer.put(b);
+    }
+
+    /**
+     * Writes an integer value to the buffer and updates the checksum.
+     *
+     * @param i integer value to write
+     * @param buffer the buffer to write to
+     * @param crc the checksum to be updated
+     */
+    private static void write(int i, ByteBuffer buffer, CRC32 crc) {
+        byte b[] = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
+            (byte) (i & 0xff) };
+        write(b, buffer, crc);
+    }
+}

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -1,32 +1,32 @@
 package de.gsi.chart.utils;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.util.Map;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelReader;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import de.gsi.dataset.utils.ArrayCache;
 
 /**
  * Writes a JavaFx Image into a ByteBuffer or file
- * TODO: possible improvements
+ * 
+ * possible improvements:
  * - use multiple IDAT chunks to use fixed buffer size and limit memory footprint
- * - implement filtering for smaller file sizes
+ * - implement filtering of lines before compression for smaller file sizes
  * - Optionally add tEXT chunks for metadata (EXIF)
  *
  * @author Alexander Krimm
  */
-public class WriteFxImage {
-    private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImage.class);
-    private static final int HEADER_SIZE = 8 + (12 + 13) + 12 + 12; // size of all the headers and other Metadata
-    private static final int BUFFER_MARGIN = 200; // how many additional bytes to allocate for the buffers
+public final class WriteFxImage {
+    protected static final int HEADER_SIZE = 8 + (12 + 13) + 12 + 12; // size of all the headers and other Metadata
+    protected static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
 
     /**
      * private constructor for static utility class
@@ -35,144 +35,198 @@ public class WriteFxImage {
     }
 
     /**
-     * Encodes a JavaFx image as an RGB png image
+     * Encodes a JavaFx image as an RGB png image with maximum (lossless) compression 
      *
-     * @param image an javafx.scene.image.Image
+     * @param image The input image to be encoded
      * @return a byte buffer with the encoded image
-     * @see "https://tools.ietf.org/html/rfc2083"
+     * @see <a href="https://tools.ietf.org/html/rfc2083">rfc2083</a>
      */
     public static ByteBuffer encode(final Image image) {
-        return encode(image, null);
+        return encode(image, null, true, Deflater.BEST_COMPRESSION, null);
     }
 
     /**
      * Encodes a JavaFx image as an RGB png image.
      * If you pass in a ByteBuffer to use, please make sure that it has enough capacity to fit the encoded image or
-     * handle errors (IndexOutOfBoundsException) accordingly.
+     * handle errors (IndexOutOfBoundsException) accordingly. If you want to be on the safe side, use
+     * {@link #getCompressedSizeBound(int, int, boolean) getCompressedSizeBound(width, height, alpha)} to get an upper bound for the output size.
      * 
-     * @param image an javafx.scene.image.Image
+     * @param image The input image to be encoded
      * @param byteBuffer optional byte buffer to store the output in, pass null to return a new one.
+     * @param alpha wheter to include alpha information in the image
+     * @param compressionLevel {@link Deflater#BEST_COMPRESSION} (9) to {@link Deflater#BEST_SPEED} (0)
+     * @param metaInfo an optional map which will be filled with debugging information like compression efficiency
      * @return a byte buffer with the encoded image
      * @see "https://tools.ietf.org/html/rfc2083"
      */
-    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer) {
-        if (byteBuffer != null) {
-            byteBuffer.clear();
-        }
-        int w = (int) image.getWidth();
-        int h = (int) image.getHeight();
-        // conservative allocation, assume zero compression
-        final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate((w + 1) * h * 3 + HEADER_SIZE + BUFFER_MARGIN) : byteBuffer;
+    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer,final boolean alpha,
+            final int compressionLevel, final Map<String, Object> metaInfo) {
+        // get meta info
+        final int w = (int) image.getWidth();
+        final int h = (int) image.getHeight();
+        // allocate output buffer if necessary. conservative allocation, assume upper bound for deflate algorithm
+        final ByteBuffer outputByteBuffer = byteBuffer != null ? byteBuffer : ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha));
+        // get necessary helper classes
         final PixelReader pr = image.getPixelReader();
         CRC32 crc = new CRC32();
-
-        // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
-        outputByteBuffer.put(new byte[] { 0x89 - 0xff - 1, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a });
-
-        // IHDR
-        write(13, outputByteBuffer); // length of IHDR chunk
-        crc.reset(); // checksum starts after length field
-        write("IHDR".getBytes(), outputByteBuffer, crc);
-        write(w, outputByteBuffer, crc); // with 4 bytes
-        write(h, outputByteBuffer, crc); // height 4 bytes
-        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
-        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
-        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
-        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
-        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
-        write(new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB Mode
-        write((int) crc.getValue(), outputByteBuffer);
-
-        int sizePos = outputByteBuffer.position();
-        write(0, outputByteBuffer); // zero size, will later be overwritten when we know the size
-        crc.reset();
-        write("IDAT".getBytes(), outputByteBuffer, crc);
-        // compress image data
-        final Deflater compressor = new Deflater(Deflater.BEST_COMPRESSION);
-        final ByteBuffer uncompressedImageData = ByteBuffer.allocate((w + 1) * h * 3);
-        compressor.setInput(uncompressedImageData);
-        for (int y = 0; y < h; y++) {
-            uncompressedImageData.put((byte) 0); // line filtering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
-            for (int x = 0; x < w; x++) {
-                int pixel = pr.getArgb(x, y);
-                uncompressedImageData.put((byte) ((pixel >> 16) & 0xff));
-                uncompressedImageData.put((byte) ((pixel >> 8) & 0xff));
-                uncompressedImageData.put((byte) (pixel & 0xff));
-            }
-        }
-        // Does not work because rgb pixel format is not writable even if isWritable says so -.-
-        // final WritablePixelFormat<ByteBuffer> pixelformat = (WritablePixelFormat<ByteBuffer>) PixelFormat
-        //         .getByteRgbInstance();
-        // uncompressedImageData.put((byte) 0); // line filtering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
-        // pr.getPixels(0, 0, w, h, pixelformat, uncompressedImageData, w + 1); // stride of w+1 puts line filtering to 0(None)
-        uncompressedImageData.flip();
-        compressor.finish();
-        compressor.deflate(outputByteBuffer, Deflater.FULL_FLUSH);
-        // update crc
-        crc.update(outputByteBuffer.array(), sizePos + 8, compressor.getTotalOut());
-        outputByteBuffer.putInt(sizePos, compressor.getTotalOut());
-        write((int) crc.getValue(), outputByteBuffer);
-
-        // IEND chunk
-        write(0, outputByteBuffer);
-        crc.reset();
-        write("IEND".getBytes(), outputByteBuffer, crc);
-        write((int) crc.getValue(), outputByteBuffer);
-
+        final Deflater compressor = new Deflater(compressionLevel);
+        // actual PNG encoding
+        writeImageHeader(w, h, alpha, outputByteBuffer, crc);
+        writeImageData(pr, w, h, alpha, compressor, outputByteBuffer, crc);
+        writeImageFooter(outputByteBuffer, crc);
+        // prepare to return outputBuffer
         outputByteBuffer.flip();
-
         // DEGBUG output
-        if (LOGGER.isDebugEnabled()) {
-            final float compression = (100.0f * compressor.getBytesWritten()) / compressor.getBytesRead();
-            LOGGER.atDebug() //
-                    .addArgument(w)
-                    .addArgument(h) //
-                    .addArgument(compressor.getBytesRead()) //
-                    .addArgument(compressor.getBytesWritten()) //
-                    .addArgument(compression) //
-                    .addArgument(outputByteBuffer.limit() - outputByteBuffer.position()) //
-                    .log("Convertet Image({}x{}) to png: IN: {} bytes, OUT: {} bytes, compression: {}%, total file size: {} bytes");
+        if (metaInfo != null) {
+            final int bytesPerPixel = alpha ? 4 : 3;
+            metaInfo.put("bufferSize", outputByteBuffer.capacity());
+            metaInfo.put("outputSizeBound", getCompressedSizeBound(w, h, alpha));
+            metaInfo.put("compression", ((double) compressor.getBytesWritten()) / (w * h * bytesPerPixel));
+            metaInfo.put("width", w);
+            metaInfo.put("height", h);
+            metaInfo.put("colorMode", alpha ? "rgba" : "rgb");
+            metaInfo.put("compressionLevel", compressionLevel);
+            metaInfo.put("outputSize", outputByteBuffer.limit() - outputByteBuffer.position());
         }
-
         return outputByteBuffer;
     }
 
     /**
-     * Saves the given Image as a png file.
+     * Saves the given image as a png file.
      *
      * @param image The image to save
      * @param file The filename to save the image to.
      * @throws IOException if the file cannot be written
      */
     public static void savePng(Image image, File file) throws IOException {
-        try (FileOutputStream os = new FileOutputStream(file); FileChannel wChannel = os.getChannel()) {
+        try (OutputStream os = Files.newOutputStream(file.toPath())) {
             ByteBuffer buffer = WriteFxImage.encode(image);
-            wChannel.write(buffer);
+            os.write(buffer.array(), 0, buffer.limit());
         }
+    }
+
+    /**
+     * Returns the conservative upper bound for the compressed image size.
+     * 
+     * @param width Image width
+     * @param height Image height
+     * @param alpha Alpha enabled
+     * @return the upper bound for the size of the resulting png in bytes
+     * @see <a href="https://github.com/madler/zlib/blob/master/deflate.c#L659-L661">zlib sourcefor deflate upper bound</a>
+     */
+    public static int getCompressedSizeBound(final int width, final int height, final boolean alpha) {
+        final int bytesPerPixel = alpha ? 4 : 3;
+        int uncompressedSize = (width) * height * bytesPerPixel + height + HEADER_SIZE;
+        int compressedSize = uncompressedSize + ((uncompressedSize + 7) >> 3) + ((uncompressedSize + 63) >> 6) + 5;
+        return compressedSize + HEADER_SIZE;
+    }
+
+    /**
+     * Writes the PNG file header and IHDR meta-information block
+     * 
+     * @param width The with of the image
+     * @param height The height of the image
+     * @param alpha whether to support alpha
+     * @param outputByteBuffer the buffer to write into
+     * @param crc the checksum calculator
+     */
+    private static void writeImageHeader(int width, int height, boolean alpha, ByteBuffer outputByteBuffer, CRC32 crc) {
+        // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
+        outputByteBuffer.put(new byte[] { (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a });
+        // IHDR
+        outputByteBuffer.putInt(13); // length of IHDR chunk
+        crc.reset(); // checksum starts after length field
+        write("IHDR".getBytes(), outputByteBuffer, crc);
+        write(width, outputByteBuffer, crc); // with 4 bytes
+        write(height, outputByteBuffer, crc); // height 4 bytes
+        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
+        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
+        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
+        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
+        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
+        write(alpha ? new byte[] { 8, 6, 0, 0, 0 } : new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB(A) Mode
+        outputByteBuffer.putInt((int) crc.getValue());
+    }
+
+    /**
+     * Writes the IDAT chunk of a png file, which contains the compressed image data to the supplied buffer.
+     * 
+     * @param pr PixelWriter
+     * @param w with of the image
+     * @param h height of the image
+     * @param alpha whether to include alpha information
+     * @param outputByteBuffer the byte buffer to write to
+     * @param crc checksum calculator
+     */
+    private static void writeImageData(PixelReader pr, int w, int h, boolean alpha, Deflater compressor,
+            ByteBuffer outputByteBuffer, CRC32 crc) {
+        // get raw image data
+        final int bytesPerPixel = alpha ? 4 : 3;
+        final int rawDataSize = w * h * bytesPerPixel + h; // image dimensions times bytesPerPixel + line filtering flag
+        final byte[] uncompressedImageData = ArrayCache.getCachedByteArray(INTERNAL_ARRAY_CACHE_NAME, rawDataSize);
+        int i = 0;
+        if (alpha) {
+            for (int y = 0; y < h; y++) {
+                uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
+                for (int x = 0; x < w; x++) {
+                    int pixel = pr.getArgb(x, y);
+                    uncompressedImageData[i++] = (byte) ((pixel >> 16) & 0xff); //red
+                    uncompressedImageData[i++] = (byte) ((pixel >> 8) & 0xff); // green
+                    uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
+                    uncompressedImageData[i++] = (byte) (pixel >> 24 & 0xff); // alpha
+                }
+            }
+        } else {
+            for (int y = 0; y < h; y++) {
+                uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
+                for (int x = 0; x < w; x++) {
+                    int pixel = pr.getArgb(x, y);
+                    uncompressedImageData[i++] = (byte) ((pixel >> 16) & 0xff); //red
+                    uncompressedImageData[i++] = (byte) ((pixel >> 8) & 0xff); // green
+                    uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
+                }
+            }
+        }
+        // write compressed image data to IDAT block
+        compressor.setInput(uncompressedImageData);
+        outputByteBuffer.mark();
+        outputByteBuffer.putInt(0); // zero size, will later be overwritten when we know the size
+        outputByteBuffer.put("IDAT".getBytes());
+        compressor.finish();
+        compressor.deflate(outputByteBuffer, Deflater.FULL_FLUSH);
+        outputByteBuffer.limit(outputByteBuffer.position());
+        outputByteBuffer.reset();
+        outputByteBuffer.putInt(compressor.getTotalOut());
+        crc.reset();
+        crc.update(outputByteBuffer);
+        outputByteBuffer.limit(outputByteBuffer.capacity());
+        outputByteBuffer.putInt((int) crc.getValue());
+        ArrayCache.release(INTERNAL_ARRAY_CACHE_NAME, uncompressedImageData);
+    }
+
+    /**
+     * Writes the end marker for the png file format
+     * 
+     * @param outputByteBuffer the buffer to write into
+     * @param crc The checksum calculator
+     */
+    private static void writeImageFooter(ByteBuffer outputByteBuffer, CRC32 crc) {
+        outputByteBuffer.putInt(0);
+        crc.reset();
+        write("IEND".getBytes(), outputByteBuffer, crc);
+        outputByteBuffer.putInt((int) crc.getValue());
     }
 
     /**
      * Writes a byte array to the buffer and updates the checksum.
      *
-     * @param b
-     * @param buffer
-     * @param crc
+     * @param b byteArray to put into buffer
+     * @param buffer output buffer
+     * @param crc checksum calculator
      */
-    private static void write(byte b[], ByteBuffer buffer, CRC32 crc) {
+    private static void write(byte[] b, ByteBuffer buffer, CRC32 crc) {
         buffer.put(b);
         crc.update(b);
-    }
-
-    /**
-     * Writes an integer value to the buffer.
-     *
-     * @param i integer value to write
-     * @param buffer the buffer to write to
-     */
-    private static void write(int i, ByteBuffer buffer) {
-        byte b[] = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
-            (byte) (i & 0xff) };
-        buffer.put(b);
     }
 
     /**
@@ -183,8 +237,8 @@ public class WriteFxImage {
      * @param crc the checksum to be updated
      */
     private static void write(int i, ByteBuffer buffer, CRC32 crc) {
-        byte b[] = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
-            (byte) (i & 0xff) };
+        byte[] b = { (byte) ((i >> 24) & 0xff), (byte) ((i >> 16) & 0xff), (byte) ((i >> 8) & 0xff),
+                (byte) (i & 0xff) };
         write(b, buffer, crc);
     }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -62,6 +62,9 @@ public final class WriteFxImage {
      */
     public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer, final boolean alpha,
             final int compressionLevel, final Map<String, Object> metaInfo) {
+        if (image == null) {
+            throw new IllegalArgumentException("image must not be null");
+        }
         // get meta info
         final int w = (int) image.getWidth();
         final int h = (int) image.getHeight();
@@ -69,6 +72,9 @@ public final class WriteFxImage {
         final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha)) : byteBuffer;
         // get necessary helper classes
         final PixelReader pr = image.getPixelReader();
+        if (pr == null) {
+            throw new IllegalStateException("image PixelReader not available");
+        }
         final CRC32 crc = new CRC32();
         final Deflater compressor = new Deflater(compressionLevel);
         // actual PNG encoding

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageBenchmark.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageBenchmark.java
@@ -1,0 +1,165 @@
+package de.gsi.chart.utils;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.Deflater;
+
+import javax.imageio.ImageIO;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javafx.application.Platform;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelBuffer;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.WritableImage;
+import javafx.scene.paint.Color;
+
+/**
+ * Checking the performance of writing a PNG image from a JavaFx Image
+ * 
+ * @author Alexander Krimm
+ */
+public class WriteFxImageBenchmark {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImageBenchmark.class);
+    private static int N_ITER = 50;
+
+    private static int w = 333;
+    private static int h = 777;
+    private static ByteBuffer noisePixels;
+    private static PixelBuffer<ByteBuffer> noiseBuffer;
+    private static WritableImage testimage;
+    private static int w2 = 777;
+    private static int h2 = 333;
+    private static Image testimage2;
+    private static AtomicBoolean initialized = new AtomicBoolean(false);
+
+    public static void initalizeImage() {
+        noisePixels = ByteBuffer.allocate(w * h * 4);
+        noiseBuffer = new PixelBuffer<>(w, h, noisePixels, PixelFormat.getByteBgraPreInstance());
+        testimage = new WritableImage(noiseBuffer);
+        final Canvas noiseCanvas = new Canvas(w, h);
+        final GraphicsContext noiseContext = noiseCanvas.getGraphicsContext2D();
+        byte[] randomArray = new byte[w * h * 4];
+        new Random().nextBytes(randomArray);
+        noiseContext.getPixelWriter().setPixels(0, 0, w, h, PixelFormat.getByteBgraInstance(), randomArray, 0, w);
+        noiseCanvas.snapshot(null, testimage);
+
+        final Canvas easyCanvas = new Canvas(w2, h2);
+        final GraphicsContext easyContext = easyCanvas.getGraphicsContext2D();
+        easyContext.setStroke(Color.BLUE);
+        easyContext.strokeOval(20, 30, 40, 50);
+        easyContext.setStroke(Color.RED);
+        easyContext.strokeOval(30, 40, 50, 60);
+        easyContext.setStroke(Color.GREEN);
+        easyContext.strokeOval(40, 50, 60, 70);
+        easyContext.setStroke(Color.ORANGE);
+        easyContext.strokeRect(0, 0, w2, h2);
+        testimage2 = easyCanvas.snapshot(null, null);
+
+        initialized.set(true);
+    }
+
+    static void writeFxImage(Image image, boolean alpha, boolean keepBuffer, int compression) {
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(
+                WriteFxImage.getCompressedSizeBound((int) image.getWidth(), (int) image.getHeight(), alpha));
+        int size = 0;
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < N_ITER; i++) {
+            ByteBuffer bb = WriteFxImage.encode(image, keepBuffer ? byteBuffer : null, alpha, compression, null);
+            size += bb.limit();
+        }
+        long stop = System.currentTimeMillis();
+        LOGGER.atInfo() //
+                .addArgument(image.getWidth()).addArgument(image.getHeight()) //
+                .addArgument(size / (double) N_ITER) //
+                .addArgument((stop - start) / (double) N_ITER) //
+                .addArgument(alpha ? "rgba" : "rgb") //
+                .addArgument(keepBuffer ? "keepBuffer" : "discardBuffer") //
+                .addArgument(compression) //
+                .log("FxImage: \t size {}x{} \t compressed size: {} bytes \t {}ms/image \t {} {} Compression: {}");
+    }
+
+    static void writeImageIoImage(Image image, boolean keepStream, boolean keepBImg) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream(w * h * 4);
+        BufferedImage bimg = null;
+        int size = 0;
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < N_ITER; i++) {
+            final BufferedImage newbimg = SwingFXUtils.fromFXImage(image, bimg);
+            ImageIO.write(newbimg, "PNG", os);
+            if (keepBImg) {
+                bimg = newbimg;
+            }
+            size += os.size();
+            if (keepStream) {
+                os.reset();
+            } else {
+                os = new ByteArrayOutputStream(w * h * 4);
+            }
+        }
+        long stop = System.currentTimeMillis();
+        LOGGER.atInfo() //
+                .addArgument(image.getWidth()).addArgument(image.getHeight()) //
+                .addArgument(size / (double) N_ITER) //
+                .addArgument((stop - start) / (double) N_ITER) //
+                .addArgument(keepStream ? "keepStream" : "reallocateStream") //
+                .addArgument(keepBImg ? "keepBufferedImage" : "reallocateBufferedImage") //
+                .log("ImageIO: \t size {}x{} \t compressed size: {} bytes \t {} ms/image \t {} {}");
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        // get the image on the javafx application thread for snapshot to work
+        Platform.startup(() -> initalizeImage());
+        while (!initialized.get()) {
+            //
+        }
+        Platform.exit();
+
+        LOGGER.atInfo().log("Image with noise data (difficult to compress)");
+        writeFxImage(testimage, false, false, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage, false, true, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage, false, false, Deflater.BEST_SPEED);
+        writeFxImage(testimage, false, true, Deflater.BEST_SPEED);
+        writeFxImage(testimage, false, false, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage, false, true, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage, true, false, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage, true, true, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage, false, false, Deflater.BEST_SPEED);
+        writeFxImage(testimage, false, true, Deflater.BEST_SPEED);
+        writeFxImage(testimage, true, false, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage, true, true, Deflater.NO_COMPRESSION);
+        writeImageIoImage(testimage, false, false);
+        writeImageIoImage(testimage, true, false);
+        writeImageIoImage(testimage, false, true);
+        writeImageIoImage(testimage, true, true);
+
+        LOGGER.atInfo().log("Image with simple shapes (easy to compress)");
+        writeFxImage(testimage2, false, false, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage2, false, true, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage2, false, false, Deflater.BEST_SPEED);
+        writeFxImage(testimage2, false, true, Deflater.BEST_SPEED);
+        writeFxImage(testimage2, false, false, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage2, false, true, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage2, true, false, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage2, true, true, Deflater.BEST_COMPRESSION);
+        writeFxImage(testimage2, true, false, Deflater.BEST_SPEED);
+        writeFxImage(testimage2, true, true, Deflater.BEST_SPEED);
+        writeFxImage(testimage2, true, false, Deflater.NO_COMPRESSION);
+        writeFxImage(testimage2, true, true, Deflater.NO_COMPRESSION);
+        writeImageIoImage(testimage2, false, false);
+        writeImageIoImage(testimage2, true, false);
+        writeImageIoImage(testimage2, false, true);
+        writeImageIoImage(testimage2, true, true);
+
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -3,6 +3,7 @@ package de.gsi.chart.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -258,5 +259,12 @@ public class WriteFxImageTests {
                 assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
             }
         }
+    }
+    
+    @Test
+    public void assertExceptions() {
+        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
+        
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.encode(null, pngOutput, true, Deflater.BEST_SPEED, null));
     }
 }

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -260,11 +260,11 @@ public class WriteFxImageTests {
             }
         }
     }
-    
+
     @Test
     public void assertExceptions() {
         final ByteBuffer pngOutput = ByteBuffer.allocate(100);
-        
+
         assertThrows(IllegalArgumentException.class, () -> WriteFxImage.encode(null, pngOutput, true, Deflater.BEST_SPEED, null));
     }
 }

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -32,11 +32,10 @@ import org.slf4j.LoggerFactory;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
-import de.gsi.chart.utils.WriteFxImage;
 import de.gsi.dataset.utils.ArrayCache;
 
 /**
- * Tests for {@link de.gsi.chart.ui.utils.WriteFxImage}.
+ * Tests for {@link de.gsi.chart.utils.WriteFxImage}.
  *
  * @author Alexander Krimm
  */
@@ -44,9 +43,10 @@ import de.gsi.dataset.utils.ArrayCache;
 @ExtendWith(ApplicationExtension.class)
 public class WriteFxImageTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImageBenchmark.class);
-    Image imageOvals;
-    Image imageRandom;
-    Image image1x1;
+    private static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
+    private Image imageOvals;
+    private Image imageRandom;
+    private Image image1x1;
 
     @Start
     public void setUp(@SuppressWarnings("unused") final Stage stage) {
@@ -100,10 +100,10 @@ public class WriteFxImageTests {
         int h = (int) imageOvals.getHeight();
         // Initialize cached array so implementation cannot rely on zero initialization
         final int rawDataSize = w * h * 4 + h; // image dimensions times bytesPerPixel + line filtering flag
-        final byte[] byteArray = ArrayCache.getCachedByteArray(WriteFxImage.INTERNAL_ARRAY_CACHE_NAME, rawDataSize);
+        final byte[] byteArray = ArrayCache.getCachedByteArray(INTERNAL_ARRAY_CACHE_NAME, rawDataSize);
         final byte fillByte = (byte) 0x03; // important to use a valid line filtering value (1-4) here, other values will be ignored
         Arrays.fill(byteArray, fillByte);
-        ArrayCache.release(WriteFxImage.INTERNAL_ARRAY_CACHE_NAME, byteArray); // allow WriteFxImage to use the buffer
+        ArrayCache.release(INTERNAL_ARRAY_CACHE_NAME, byteArray); // allow WriteFxImage to use the buffer
         // convert to png
         final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
         final Map<String, Object> metaInfo = new HashMap<>();
@@ -128,13 +128,12 @@ public class WriteFxImageTests {
         assertEquals(1, metaInfo.get("compressionLevel"));
         assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
         assertEquals(0.02, (double) metaInfo.get("compression"), 0.02);
-        
+
         // Check that the array we preinitialized was actually used
         assertNotEquals(fillByte, byteArray[15]);
 
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
-                pngOutput.limit())) {
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
             final Image recovered = new Image(is);
             // compare against original
             assertImageEqual(imageOvals, recovered);
@@ -172,8 +171,7 @@ public class WriteFxImageTests {
         assertEquals(1, (double) metaInfo.get("compression"), 0.02);
 
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
-                pngOutput.limit())) {
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
             final Image recovered = new Image(is);
             // compare against original
             assertImageEqual(imageOvals, recovered);
@@ -210,8 +208,7 @@ public class WriteFxImageTests {
         assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
         assertEquals(0.21, (double) metaInfo.get("compression"), 0.02);
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
-                pngOutput.limit())) {
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
             final Image recovered = new Image(is);
             // compare against original
             assertImageEqual(imageRandom, recovered);
@@ -244,8 +241,7 @@ public class WriteFxImageTests {
         assertEquals(1, metaInfo.get("compressionLevel"));
         assertEquals(3, (double) metaInfo.get("compression"), 1.0);
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
-                pngOutput.limit())) {
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
             final Image recovered = new Image(is);
             // compare against original
             assertImageEqual(image1x1, recovered);

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -1,7 +1,9 @@
 package de.gsi.chart.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -9,19 +11,29 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.zip.Deflater;
 
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
 import javafx.scene.paint.Color;
+import javafx.stage.Stage;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
 
-import de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
-import de.gsi.chart.ui.utils.TestFx;
 import de.gsi.chart.utils.WriteFxImage;
+import de.gsi.dataset.utils.ArrayCache;
 
 /**
  * Tests for {@link de.gsi.chart.ui.utils.WriteFxImage}.
@@ -30,47 +42,17 @@ import de.gsi.chart.utils.WriteFxImage;
  */
 
 @ExtendWith(ApplicationExtension.class)
-@ExtendWith(SelectiveJavaFxInterceptor.class)
 public class WriteFxImageTests {
-    @TestFx // needs to be on the application thread for the snapshot method
-    public void testWritingImageToFile(@TempDir File tempDir) throws IOException {
-        File tmpfile = new File(tempDir.getPath() + "test.png");
-        int w = 200;
-        int h = 300;
-        // generate test image
-        Canvas originalCanvas = new Canvas(w, h);
-        GraphicsContext originalContext = originalCanvas.getGraphicsContext2D();
-        originalContext.setStroke(Color.BLUE);
-        originalContext.strokeOval(20, 30, 40, 50);
-        originalContext.setStroke(Color.RED);
-        originalContext.strokeOval(30, 40, 50, 60);
-        originalContext.setStroke(Color.GREEN);
-        originalContext.strokeOval(40, 50, 60, 70);
-        originalContext.setStroke(Color.ORANGE);
-        originalContext.strokeRect(0, 0, w, h);
-        Image original = originalCanvas.snapshot(null, null);
-        // convert to png
-        WriteFxImage.savePng(original, tmpfile);
-        // load from png
-        try (InputStream is = new FileInputStream(tmpfile.getPath())) {
-            Image recovered = new Image(is);
-            // compare against original
-            assertEquals(original.getWidth(), recovered.getWidth());
-            assertEquals(original.getHeight(), recovered.getHeight());
-            for (int x = 0; x < w; x++) {
-                for (int y = 0; y < h; y++) {
-                    assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
-                }
-            }
-        }
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImageBenchmark.class);
+    Image imageOvals;
+    Image imageRandom;
+    Image image1x1;
 
-    @TestFx // needs to be on the application thread for the snapshot method
-    public void testWritingImageByteBuffer() throws IOException {
+    @Start
+    public void setUp(@SuppressWarnings("unused") final Stage stage) {
         int w = 200;
         int h = 300;
-        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 3 + 100);
-        // generate test image
+        // generate test image with simple shapes
         final Canvas originalCanvas = new Canvas(w, h);
         final GraphicsContext originalContext = originalCanvas.getGraphicsContext2D();
         originalContext.setStroke(Color.BLUE);
@@ -81,21 +63,203 @@ public class WriteFxImageTests {
         originalContext.strokeOval(40, 50, 60, 70);
         originalContext.setStroke(Color.ORANGE);
         originalContext.strokeRect(0, 0, w, h);
-        final Image original = originalCanvas.snapshot(null, null);
+        imageOvals = originalCanvas.snapshot(null, null);
+
+        //generate test image with noise data (not very compressible)
+        final Canvas noiseCanvas = new Canvas(600, 333);
+        final GraphicsContext noiseContext = noiseCanvas.getGraphicsContext2D();
+        byte[] randomArray = new byte[600 * 333 * 4];
+        new Random().nextBytes(randomArray);
+        noiseContext.getPixelWriter().setPixels(0, 0, 600, 333, PixelFormat.getByteBgraInstance(), randomArray, 0, 600);
+        imageRandom = noiseCanvas.snapshot(null, null);
+
+        // generate test image with minimal dimensions
+        final Canvas onexoneCanvas = new Canvas(1, 1);
+        final GraphicsContext onexoneContext = onexoneCanvas.getGraphicsContext2D();
+        onexoneContext.getPixelWriter().setArgb(0, 0, 0xdeadbeef);
+        image1x1 = onexoneCanvas.snapshot(null, null);
+    }
+
+    @Test
+    public void testWritingImageToFile(@TempDir File tempDir) throws IOException {
+        File tmpfile = new File(tempDir.getPath() + "test.png");
         // convert to png
-        final ByteBuffer pngOutReal = WriteFxImage.encode(original, pngOutput);
+        WriteFxImage.savePng(imageOvals, tmpfile);
+        // load from png
+        try (InputStream is = new FileInputStream(tmpfile.getPath())) {
+            Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(imageOvals, recovered);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBuffer() throws IOException {
+        // image metadata
+        int w = (int) imageOvals.getWidth();
+        int h = (int) imageOvals.getHeight();
+        // Initialize cached array so implementation cannot rely on zero initialization
+        final int rawDataSize = w * h * 4 + h; // image dimensions times bytesPerPixel + line filtering flag
+        final byte[] byteArray = ArrayCache.getCachedByteArray(WriteFxImage.INTERNAL_ARRAY_CACHE_NAME, rawDataSize);
+        final byte fillByte = (byte) 0x03; // important to use a valid line filtering value (1-4) here, other values will be ignored
+        Arrays.fill(byteArray, fillByte);
+        ArrayCache.release(WriteFxImage.INTERNAL_ARRAY_CACHE_NAME, byteArray); // allow WriteFxImage to use the buffer
+        // convert to png
+        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutReal = WriteFxImage.encode(imageOvals, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
         // assert that the provided buffer was used
         assertSame(pngOutput, pngOutReal);
+        assertEquals(w, metaInfo.get("width"));
+        assertEquals(h, metaInfo.get("height"));
+        assertEquals("rgba", metaInfo.get("colorMode"));
+        assertEquals(w * h * 4 + 100, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(274220, metaInfo.get("outputSizeBound"));
+        assertEquals(1, metaInfo.get("compressionLevel"));
+        assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
+        assertEquals(0.02, (double) metaInfo.get("compression"), 0.02);
+        
+        // Check that the array we preinitialized was actually used
+        assertNotEquals(fillByte, byteArray[15]);
+
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
+                pngOutput.limit())) {
             final Image recovered = new Image(is);
             // compare against original
-            assertEquals(original.getWidth(), recovered.getWidth());
-            assertEquals(original.getHeight(), recovered.getHeight());
-            for (int x = 0; x < w; x++) {
-                for (int y = 0; y < h; y++) {
-                    assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
-                }
+            assertImageEqual(imageOvals, recovered);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBufferRandomRbgNoCompression() throws IOException {
+        // convert to png
+        int w = (int) imageOvals.getWidth();
+        int h = (int) imageOvals.getHeight();
+        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 3 + 1000);
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutReal = WriteFxImage.encode(imageOvals, pngOutput, false, Deflater.NO_COMPRESSION,
+                metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        assertEquals(w, metaInfo.get("width"));
+        assertEquals(h, metaInfo.get("height"));
+        assertEquals("rgb", metaInfo.get("colorMode"));
+        assertEquals(w * h * 3 + 1000, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(205783, metaInfo.get("outputSizeBound"));
+        assertEquals(0, metaInfo.get("compressionLevel"));
+        assertTrue(w * h * 3 < (int) metaInfo.get("outputSize"));
+        assertEquals(1, (double) metaInfo.get("compression"), 0.02);
+
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
+                pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(imageOvals, recovered);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBufferRandom() throws IOException {
+        // convert to png
+        int w = (int) imageRandom.getWidth();
+        int h = (int) imageRandom.getHeight();
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
+        final ByteBuffer pngOutReal = WriteFxImage.encode(imageRandom, pngOutput, true, Deflater.BEST_COMPRESSION,
+                metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        assertEquals(w, metaInfo.get("width"));
+        assertEquals(h, metaInfo.get("height"));
+        assertEquals("rgba", metaInfo.get("colorMode"));
+        assertEquals(w * h * 4 + 100, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(912095, metaInfo.get("outputSizeBound"));
+        assertEquals(9, metaInfo.get("compressionLevel"));
+        assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
+        assertEquals(0.21, (double) metaInfo.get("compression"), 0.02);
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
+                pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(imageRandom, recovered);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBuffer1x1() throws IOException {
+        // convert to png
+        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutReal = WriteFxImage.encode(image1x1, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        assertEquals(1, metaInfo.get("width"));
+        assertEquals(1, metaInfo.get("height"));
+        assertEquals("rgba", metaInfo.get("colorMode"));
+        assertEquals(100, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(133, metaInfo.get("outputSizeBound"));
+        assertEquals(1, metaInfo.get("compressionLevel"));
+        assertEquals(3, (double) metaInfo.get("compression"), 1.0);
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(),
+                pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(image1x1, recovered);
+        }
+    }
+
+    private static void assertImageEqual(Image original, Image recovered) {
+        final int w = (int) original.getWidth();
+        final int h = (int) original.getHeight();
+        assertEquals(w, recovered.getWidth());
+        assertEquals(h, recovered.getHeight());
+        for (int x = 0; x < w; x++) {
+            for (int y = 0; y < h; y++) {
+                assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
             }
         }
     }

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -1,0 +1,102 @@
+package de.gsi.chart.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.image.Image;
+import javafx.scene.paint.Color;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+import de.gsi.chart.ui.utils.TestFx;
+import de.gsi.chart.utils.WriteFxImage;
+
+/**
+ * Tests for {@link de.gsi.chart.ui.utils.WriteFxImage}.
+ *
+ * @author Alexander Krimm
+ */
+
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class WriteFxImageTests {
+    @TestFx // needs to be on the application thread for the snapshot method
+    public void testWritingImageToFile(@TempDir File tempDir) throws IOException {
+        File tmpfile = new File(tempDir.getPath() + "test.png");
+        int w = 200;
+        int h = 300;
+        // generate test image
+        Canvas originalCanvas = new Canvas(w, h);
+        GraphicsContext originalContext = originalCanvas.getGraphicsContext2D();
+        originalContext.setStroke(Color.BLUE);
+        originalContext.strokeOval(20, 30, 40, 50);
+        originalContext.setStroke(Color.RED);
+        originalContext.strokeOval(30, 40, 50, 60);
+        originalContext.setStroke(Color.GREEN);
+        originalContext.strokeOval(40, 50, 60, 70);
+        originalContext.setStroke(Color.ORANGE);
+        originalContext.strokeRect(0, 0, w, h);
+        Image original = originalCanvas.snapshot(null, null);
+        // convert to png
+        WriteFxImage.savePng(original, tmpfile);
+        // load from png
+        try (InputStream is = new FileInputStream(tmpfile.getPath())) {
+            Image recovered = new Image(is);
+            // compare against original
+            assertEquals(original.getWidth(), recovered.getWidth());
+            assertEquals(original.getHeight(), recovered.getHeight());
+            for (int x = 0; x < w; x++) {
+                for (int y = 0; y < h; y++) {
+                    assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
+                }
+            }
+        }
+    }
+
+    @TestFx // needs to be on the application thread for the snapshot method
+    public void testWritingImageByteBuffer() throws IOException {
+        int w = 200;
+        int h = 300;
+        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 3 + 100);
+        // generate test image
+        final Canvas originalCanvas = new Canvas(w, h);
+        final GraphicsContext originalContext = originalCanvas.getGraphicsContext2D();
+        originalContext.setStroke(Color.BLUE);
+        originalContext.strokeOval(20, 30, 40, 50);
+        originalContext.setStroke(Color.RED);
+        originalContext.strokeOval(30, 40, 50, 60);
+        originalContext.setStroke(Color.GREEN);
+        originalContext.strokeOval(40, 50, 60, 70);
+        originalContext.setStroke(Color.ORANGE);
+        originalContext.strokeRect(0, 0, w, h);
+        final Image original = originalCanvas.snapshot(null, null);
+        // convert to png
+        final ByteBuffer pngOutReal = WriteFxImage.encode(original, pngOutput);
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertEquals(original.getWidth(), recovered.getWidth());
+            assertEquals(original.getHeight(), recovered.getHeight());
+            for (int x = 0; x < w; x++) {
+                for (int y = 0; y < h; y++) {
+                    assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements exporting a JavaFx Image to png either directly to file or to a ByteBuffer, uses it to replace all occurences of FXSwingUtils and remove the javafx-swing dependency.