### PR TITLE
Update README with more add-opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ modules available and accessible to chartfx:
 --add-modules=javafx.swing,javafx.graphics,javafx.fxml,javafx.media,javafx.web
 --add-reads javafx.graphics=ALL-UNNAMED
 --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED
+--add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED


### PR DESCRIPTION
This PR adds another `--add-opens` for `javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED`. I needed to add this to get the `11.1.3` version to work with the `MetaDataRendererSample` exampe.