### PR TITLE
Fix mvn build for local builds and external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 
 after_success:
   # create and upload coverage report
-  - mvn jacoco:report-aggregate coveralls:report
+  - mvn jacoco:report-aggregate
   - if [ -n "$CODACY_API_TOKEN" ]; then mvn -pl chartfx-report codacy:coverage; fi
   - bash <(curl -s https://codecov.io/bash) -s chartfx-report/target/site/jacoco-aggregate/
   # upload runtime data to perform exhaustive statical analysis on coverity if enabled for this build

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ install:
   - mvn --settings .maven.xml install -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V -Drevision=${REVISION} -Dchangelist=${CHANGELIST}
 
 script:
-  # deploy maven project
+  # deploy maven project if credentials are available
   - if [ -n "$GPG_KEY" ]; then mvn clean deploy --settings .maven.xml -Prelease -Drevision=${REVISION} -Dchangelist=${CHANGELIST}; fi
 
 after_success:
   # create and upload coverage report
   - mvn jacoco:report-aggregate coveralls:report
-  - mvn -pl chartfx-report codacy:coverage
+  - if [ -n "$CODACY_API_TOKEN" ]; then mvn -pl chartfx-report codacy:coverage; fi
   - bash <(curl -s https://codecov.io/bash) -s chartfx-report/target/site/jacoco-aggregate/
   # upload runtime data to perform exhaustive statical analysis on coverity if enabled for this build
   - echo "TRAVIS_EVENT_TYPE = '${TRAVIS_EVENT_TYPE}'  TRAVIS_BRANCH = '${TRAVIS_BRANCH}' TRAVIS_TAG = '${TRAVIS_TAG}'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ os: linux
 dist: xenial
 jdk:
         - openjdk11
-env:
-        - _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw"
-
 
 before_install:
   # setup pgp signing key

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Maven calls java with the corresponding options so that JavaFX is working. Becau
 ```sh
 git clone
 cd chart-fx
-mvn compile install
+mvn compile install # -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw # <- add options to run tests in headless mode
 mvn exec:java
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Maven calls java with the corresponding options so that JavaFX is working. Becau
 ```sh
 git clone
 cd chart-fx
-mvn compile install # -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw # <- add options to run tests in headless mode
+mvn compile install
 mvn exec:java
 ```
 

--- a/chartfx-dataset/src/test/resources/junit-platform.properties
+++ b/chartfx-dataset/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/chartfx-report/pom.xml
+++ b/chartfx-report/pom.xml
@@ -54,15 +54,6 @@
                     <codacyApiBaseUrl>https://api.codacy.com</codacyApiBaseUrl>
                     <failOnMissingReportFile>false</failOnMissingReportFile>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>post-test</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>coverage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
                     <!-- which jacoco will not instrument. Hence it is important
                         to add -->
                     <!-- those command-line params here (${argLine} holds those params) -->
-                    <argLine>${argLine} -Xms256m -Xmx2048m</argLine>
+                    <argLine>${argLine} -Xms256m -Xmx2048m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
                     <forkCount>1</forkCount>
                     <runOrder>random</runOrder>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
         <chartfx.awaitility.version>4.0.2</chartfx.awaitility.version>
         <chartfx.jacoco.version>0.8.5</chartfx.jacoco.version>
         <chartfx.surefire.version>2.22.2</chartfx.surefire.version>
-        <chartfx.coveralls.version>3.2.0</chartfx.coveralls.version>
     </properties>
 
     <licenses>
@@ -266,11 +265,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>${chartfx.coveralls.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Remove execution phase for codacy upload so it is only triggered by running `mvn codacy:coverage` explicitly.
Only run coverage upload if codacy api token environment variable is set.
Add headless options to build command in configuration.