### PR TITLE
Caching, FX Helper and PNGJ encoder updates

### DIFF
--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -80,6 +80,11 @@
             <version>${chartfx.javafx.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ar.com.hjg</groupId>
+            <artifactId>pngj</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 </project>
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistoryDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistoryDataSetRenderer.java
@@ -4,7 +4,11 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.canvas.GraphicsContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,10 +23,6 @@ import de.gsi.chart.utils.StyleParser;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.EditableDataSet;
 import de.gsi.dataset.utils.ProcessingProfiler;
-import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
-import javafx.scene.canvas.GraphicsContext;
 
 /**
  * Renders the data set with the pre-described
@@ -30,7 +30,6 @@ import javafx.scene.canvas.GraphicsContext;
  * @author R.J. Steinhagen
  */
 public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Renderer {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(HistoryDataSetRenderer.class);
     protected static final int DEFAULT_HISTORY_DEPTH = 3;
     protected final ObservableList<DataSet> emptyList = FXCollections.observableArrayList();
@@ -113,8 +112,8 @@ public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Rend
                     super.getDatasets().removeAll(renderer.getDatasets());
                     renderer.getDatasets().clear();
                 });
-            } catch (InterruptedException | ExecutionException e) {
-                HistoryDataSetRenderer.LOGGER.error("error in clearHistory()", e);
+            } catch (final Exception e) {
+                LOGGER.atError().setCause(e).log("clearHistory()");
             }
         }
     }
@@ -149,7 +148,6 @@ public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Rend
             map.put(XYChartCss.DATASET_INDEX, Integer.toString(dataSetIndex));
             dataSet.setStyle(StyleParser.mapToString(map));
         }
-
     }
 
     @Override
@@ -199,10 +197,9 @@ public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Rend
         if (!oldDataSetsToRemove.isEmpty()) {
             try {
                 FXUtils.runAndWait(() -> getDatasets().removeAll(oldDataSetsToRemove));
-            } catch (InterruptedException | ExecutionException e) {
-                HistoryDataSetRenderer.LOGGER.error("remove oldDataSetsToRemove ", e);
+            } catch (final Exception e) {
+                LOGGER.atError().setCause(e).log("oldDataSetsToRemove listener");
             }
-
         }
 
         // create local copy of to be shifted data set
@@ -231,16 +228,16 @@ public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Rend
                 if (!getDatasets().contains(ds)) {
                     try {
                         FXUtils.runAndWait(() -> getDatasets().add(ds));
-                    } catch (InterruptedException | ExecutionException e) {
-                        HistoryDataSetRenderer.LOGGER.error("add missing dataset", e);
+                    } catch (final Exception e) {
+                        LOGGER.atError().setCause(e).log("add missing dataset");
                     }
                 }
             }
 
             try {
                 FXUtils.runAndWait(() -> renderer.getDatasets().setAll(copyList));
-            } catch (InterruptedException | ExecutionException e) {
-                HistoryDataSetRenderer.LOGGER.error("add new copied dataset to getDatasets()", e);
+            } catch (final Exception e) {
+                LOGGER.atError().setCause(e).log("add new copied dataset to getDatasets()");
             }
         }
 
@@ -257,5 +254,4 @@ public class HistoryDataSetRenderer extends ErrorDataSetRenderer implements Rend
         map.put(XYChartCss.DATASET_INDEX, Integer.toString(count));
         return StyleParser.mapToString(map);
     }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/utils/DefaultRenderColorScheme.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/utils/DefaultRenderColorScheme.java
@@ -9,9 +9,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import de.gsi.chart.XYChartCss;
-import de.gsi.chart.utils.StyleParser;
-import de.gsi.dataset.utils.AssertUtils;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
@@ -26,6 +23,11 @@ import javafx.scene.paint.ImagePattern;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
 
+import de.gsi.chart.XYChartCss;
+import de.gsi.chart.utils.StyleParser;
+import de.gsi.dataset.utils.AssertUtils;
+
+@SuppressWarnings("PMD.FieldNamingConventions")
 public final class DefaultRenderColorScheme {
     private static final String DEFAULT_FONT = "Helvetia";
     private static final int DEFAULT_FONT_SIZE = 18;
@@ -41,7 +43,7 @@ public final class DefaultRenderColorScheme {
             Color.valueOf("#B276B2"), // (purple)
             Color.valueOf("#DECF3F"), // (yellow)
             Color.valueOf("#4D4D4D") // (gray)
-    ));
+            ));
 
     public static final ObservableList<Color> ADOBE = FXCollections.observableList(Arrays.asList( //
             Color.valueOf("#00a4e4"), // blue
@@ -51,7 +53,7 @@ public final class DefaultRenderColorScheme {
             Color.valueOf("#c1d82f"), // green
             Color.valueOf("#8a7967"), // brown
             Color.valueOf("#6a737b") // darkbrown/black
-    ));
+            ));
 
     public static final ObservableList<Color> DELL = FXCollections.observableList(Arrays.asList( //
             Color.valueOf("#0085c3"), //
@@ -62,7 +64,7 @@ public final class DefaultRenderColorScheme {
             Color.valueOf("#71c6c1"), //
             Color.valueOf("#009bbb"), //
             Color.valueOf("#444444") //
-    ));
+            ));
 
     public static final ObservableList<Color> EQUIDISTANT = FXCollections.observableList(Arrays.asList( //
             Color.valueOf("#003f5c"), //
@@ -73,7 +75,7 @@ public final class DefaultRenderColorScheme {
             Color.valueOf("#f95d6a"), //
             Color.valueOf("#ff7c43"), //
             Color.valueOf("#ffa600") //
-    ));
+            ));
 
     public static final ObservableList<Color> TUNEVIEWER = FXCollections.observableList(Arrays.asList( //
             // old legacy colour scheme from an earlier project
@@ -86,16 +88,13 @@ public final class DefaultRenderColorScheme {
             Color.DARKGRAY, // dark grey
             Color.PINK, // pink
             Color.BLACK // black
-    ));
+            ));
 
-    private static final ListProperty<Color> strokeColours = new SimpleListProperty<>(SELF, "defaulStrokeColours",
-            FXCollections.observableList(TUNEVIEWER));
+    private static final ListProperty<Color> strokeColours = new SimpleListProperty<>(SELF, "defaulStrokeColours", FXCollections.observableList(TUNEVIEWER));
 
-    private static final ListProperty<Color> fillColours = new SimpleListProperty<>(SELF, "defaulFillColours",
-            FXCollections.observableList(TUNEVIEWER));
+    private static final ListProperty<Color> fillColours = new SimpleListProperty<>(SELF, "defaulFillColours", FXCollections.observableList(TUNEVIEWER));
     private static ListProperty<Paint> fillStyles = new SimpleListProperty<>(SELF, "fillStyles");
-    private static final ObjectProperty<Font> defaultFont = new SimpleObjectProperty<>(SELF, "defaultFontSize",
-            Font.font(DEFAULT_FONT, DEFAULT_FONT_SIZE));
+    private static final ObjectProperty<Font> defaultFont = new SimpleObjectProperty<>(SELF, "defaultFontSize", Font.font(DEFAULT_FONT, DEFAULT_FONT_SIZE));
     private static final DoubleProperty markerLineWidth = new SimpleDoubleProperty(SELF, "defaultLineWidth", 0.5);
     private static final DoubleProperty lineWidth = new SimpleDoubleProperty(SELF, "lineWidth", 1.5);
     private static final DoubleProperty hatchShiftByIndex = new SimpleDoubleProperty(SELF, "hatchShiftByIndex", 1.5);
@@ -105,7 +104,6 @@ public final class DefaultRenderColorScheme {
     }
 
     private DefaultRenderColorScheme() {
-
     }
 
     private SimpleImmutableEntry<String, String> splitQueryParameter(final String it) {
@@ -266,9 +264,7 @@ public final class DefaultRenderColorScheme {
             return Collections.emptyMap();
         }
 
-        return Arrays.stream(styleString.split(";")).map(SELF::splitQueryParameter)
-                .collect(Collectors.groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new,
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+        return Arrays.stream(styleString.split(";")).map(SELF::splitQueryParameter).collect(Collectors.groupingBy(SimpleImmutableEntry::getKey, LinkedHashMap::new, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
     }
 
     public static ListProperty<Color> strokeColorProperty() {
@@ -276,7 +272,11 @@ public final class DefaultRenderColorScheme {
     }
 
     public enum Palette {
-        P_TUNEVIEWER(TUNEVIEWER), P_MISC(MISC), P_ADOBE(ADOBE), P_DELL(DELL), P_EQUIDISTANT(EQUIDISTANT);
+        P_TUNEVIEWER(TUNEVIEWER),
+        P_MISC(MISC),
+        P_ADOBE(ADOBE),
+        P_DELL(DELL),
+        P_EQUIDISTANT(EQUIDISTANT);
 
         ObservableList<Color> list;
 
@@ -296,6 +296,5 @@ public final class DefaultRenderColorScheme {
             }
             throw new IllegalArgumentException("unknown palette");
         }
-
     }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/PaletteQuantizer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/PaletteQuantizer.java
@@ -1,0 +1,13 @@
+package de.gsi.chart.utils;
+
+public interface PaletteQuantizer {
+    int[] getColor(int i);
+
+    int getColorCount();
+
+    int getTransparentIndex();
+
+    int lookup(int r, int g, int b);
+
+    int lookup(int r, int g, int b, int a);
+}

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/PaletteQuantizerNeuQuant.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/PaletteQuantizerNeuQuant.java
@@ -1,0 +1,532 @@
+package de.gsi.chart.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * NeuQuant Neural-Net Quantisation Algorithm
+ *
+ * Copyright (c) 1994 Anthony Dekker
+ *
+ * NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994. See
+ * "Kohonen neural networks for optimal colour quantization" in "Network: Computation in Neural Systems" Vol. 5 (1994)
+ * pp 351-367. for a discussion of the algorithm.
+ *
+ * Any party obtaining a copy of these files from the author, directly or indirectly, is granted, free of charge, a full
+ * and unrestricted irrevocable, world-wide, paid up, royalty-free, non-exclusive right and license to deal in this
+ * software and documentation files (the "Software"), including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sub-license, and/or sell copies of the Software, and to permit persons who receive copies
+ * from any such party to do so, with the only requirement being that this copyright notice remain intact.
+
+ * @author Anthony Dekker - original author
+ * @author Hernan J Gonzalez - modified for PngReader - no special colours - sequential read
+ * @author rstein adapted to a modern Java and chart-fx usage
+ *
+ */
+@SuppressWarnings("PMD") // original author's coding convention
+public class PaletteQuantizerNeuQuant implements PaletteQuantizer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaletteQuantizerNeuQuant.class);
+    // parameters - do not change during running - naming convention:
+    // parNcolors ... parameters setteable with set()
+    // _parMmaxnetpos ... derived parameter, not settaable, computed at initParams()
+    private int parNcolors = 256; // number of colours used
+
+    private int parNcycles = 330; // no. of learning cycles
+    private int _parCutnetsize; // = ncolors;//
+    private int _parMaxnetpos; // = ncolors - 1;
+    //private int _parInitrad; // = ncolors / 8; // for 256 cols, radius starts at 32
+
+    private int parRadiusbiasshift = 6;
+    private int _parRadiusbias; // = 1 << radiusbiasshift;
+    private int _parInitBiasRadius; // = initrad * radiusbias;
+    private int parRadiusdec = 30; // factor of 1/30 each cycle
+    private int parTransparencyThreshold = 127;
+
+    private int parAlphabiasshift = 10; // alpha starts at 1
+
+    private int _parIinitalpha; // = 1 << alphabiasshift; // biased by 10 bits
+    private double parGamma = 1024.0;
+
+    private double parBeta = 1.0 / 1024.0;
+    private double _parGammaBetta; // = beta * gamma;
+    private boolean parReserveAlphaColor = false;
+    private int parMaxPixelsToSample = 30000;
+
+    private int _parSamplefac; // 1-30
+    private double[][] network; // the network itself //WARNING: BGR
+    protected int[][] colormap; // the network itself //WARNING: BGR
+    private final int[] netindex = new int[256]; // for network lookup - really 256
+    private double[] bias; // = new double[parNcolors]; // bias and freq arrays for learnin//*g
+    private double[] freq; // = new double[parNcolors];
+    private final int width;
+    private final int height;
+    private final PixelGetter pixelGetter;
+    private boolean done = false;
+
+    public PaletteQuantizerNeuQuant(final int w, final int h, final PixelGetter pixelGetter) {
+        width = w;
+        height = h;
+        this.pixelGetter = pixelGetter;
+    }
+
+    public int[] convert(final int r, final int g, final int b) {
+        initGuard();
+        final int i = indexSearch(b, g, r);
+        final int bb = colormap[i][0];
+        final int gg = colormap[i][1];
+        final int rr = colormap[i][2];
+        return new int[] { rr, gg, bb };
+    }
+
+    public int[] convert(final int r, final int g, final int b, final int a) {
+        initGuard();
+        if (parReserveAlphaColor && a < parTransparencyThreshold) {
+            return new int[] { 0, 0, 0, 0 };
+        }
+        final int i = indexSearch(b, g, r);
+        final int bb = colormap[i][0];
+        final int gg = colormap[i][1];
+        final int rr = colormap[i][2];
+        return new int[] { rr, gg, bb };
+    }
+
+    @Override
+    public int[] getColor(final int i) {
+        initGuard();
+        int index = i;
+        if (parReserveAlphaColor) {
+            index--;
+            if (index < 0) {
+                return new int[] { 0, 0, 0, 0 };
+            }
+        }
+        if (index < 0 || index >= parNcolors) {
+            throw new IllegalArgumentException("index out of range [0, " + parNcolors + "[");
+        }
+        final int bb = colormap[index][0];
+        final int gg = colormap[index][1];
+        final int rr = colormap[index][2];
+        return new int[] { rr, gg, bb, 255 };
+    }
+
+    @Override
+    public int getColorCount() { // includes transparent color if applicable
+        initGuard();
+        return parReserveAlphaColor ? parNcolors + 1 : parNcolors;
+    }
+
+    @Override
+    public int getTransparentIndex() { // -1 if not exists
+        initGuard();
+        return parReserveAlphaColor ? 0 : -1;
+    }
+
+    public boolean isParReserveAlphaColor() {
+        return parReserveAlphaColor;
+    }
+
+    @Override
+    public int lookup(final int r, final int g, final int b) {
+        initGuard();
+        final int i = indexSearch(b, g, r);
+        return parReserveAlphaColor ? i + 1 : i;
+    }
+
+    @Override
+    public int lookup(final int r, final int g, final int b, final int a) {
+        //initGuard();
+        if (a < parTransparencyThreshold) {
+            return 0; // extra entry: transparent
+        }
+        return indexSearch(b, g, r) + 1;
+    }
+
+    public void run() {
+        if (done) {
+            return;
+        }
+        initParams();
+        setUpArrays();
+        learn();
+        fix();
+        inxbuild();
+        done = true;
+    }
+
+    public void setParAlphabiasshift(final int parAlphabiasshift) {
+        this.parAlphabiasshift = parAlphabiasshift;
+    }
+
+    public void setParBeta(final double parBeta) {
+        this.parBeta = parBeta;
+    }
+
+    public void setParGamma(final double parGamma) {
+        this.parGamma = parGamma;
+    }
+
+    public void setParMaxPixelsToSample(final int parMaxPixelsToSample) {
+        this.parMaxPixelsToSample = parMaxPixelsToSample;
+    }
+
+    public void setParNcolors(final int parNcolors) {
+        this.parNcolors = parNcolors;
+    }
+
+    public void setParNcycles(final int parNcycles) {
+        this.parNcycles = parNcycles;
+    }
+
+    public void setParRadiusbiasshift(final int parRadiusbiasshift) {
+        this.parRadiusbiasshift = parRadiusbiasshift;
+    }
+
+    public void setParRadiusdec(final int parRadiusdec) {
+        this.parRadiusdec = parRadiusdec;
+    }
+
+    public void setParReserveAlphaColor(final boolean parReserveAlphaColor) {
+        this.parReserveAlphaColor = parReserveAlphaColor;
+    }
+
+    public void setParTransparencyThreshold(final int parTransparencyThreshold) {
+        this.parTransparencyThreshold = parTransparencyThreshold;
+    }
+
+    /**
+     * computes neural network if it hasn't been already done
+     */
+    protected void initGuard() {
+        if (done) {
+            return;
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.atDebug().log("need to execute run() computation - fallback should be done prior in user-land");
+        }
+        run();
+    }
+
+    protected int indexSearch(final int b, final int g, final int r) {
+        // Search for BGR values 0..255 and return colour index
+        int bestd = 1000; // biggest possible dist is 256*3
+        int best = -1;
+        int i = netindex[g]; // index on g
+        int j = i - 1; // start at netindex[g] and work outwards
+
+        while (i < parNcolors || j >= 0) {
+            if (i < parNcolors) {
+                final int[] p = colormap[i];
+                int dist = p[1] - g; // inx key
+                if (dist >= bestd) {
+                    i = parNcolors; // stop iter
+                } else {
+                    if (dist < 0) {
+                        dist = -dist;
+                    }
+                    int a = p[0] - b;
+                    if (a < 0) {
+                        a = -a;
+                    }
+                    dist += a;
+                    if (dist < bestd) {
+                        a = p[2] - r;
+                        if (a < 0) {
+                            a = -a;
+                        }
+                        dist += a;
+                        if (dist < bestd) {
+                            bestd = dist;
+                            best = i;
+                        }
+                    }
+                    i++;
+                }
+            }
+            if (j >= 0) {
+                final int[] p = colormap[j];
+                int dist = g - p[1]; // inx key - reverse dif
+                if (dist >= bestd) {
+                    j = -1; // stop iter
+                } else {
+                    dist = Math.abs(dist);
+                    int a = p[0] - b;
+                    if (a < 0) {
+                        a = -a;
+                    }
+                    dist += a;
+                    if (dist < bestd) {
+                        a = p[2] - r;
+                        if (a < 0) {
+                            a = -a;
+                        }
+                        dist += a;
+                        if (dist < bestd) {
+                            bestd = dist;
+                            best = j;
+                        }
+                    }
+                    j--;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    protected void setUpArrays() {
+        network = new double[parNcolors][3]; // the network itself //WARNING: BGR
+        colormap = new int[parNcolors][4]; // the network itself //WARNING: BGR
+        bias = new double[parNcolors];
+        freq = new double[parNcolors];
+        network[0][0] = 0.0; // black
+        network[0][1] = 0.0;
+        network[0][2] = 0.0;
+
+        network[1][0] = 255.0; // white
+        network[1][1] = 255.0;
+        network[1][2] = 255.0;
+
+        for (int i = 0; i < parNcolors; i++) {
+            final double[] p = network[i];
+            p[0] = 255.0 * i / _parCutnetsize;
+            p[1] = 255.0 * i / _parCutnetsize;
+            p[2] = 255.0 * i / _parCutnetsize;
+
+            freq[i] = 1.0 / parNcolors;
+            bias[i] = 0.0;
+        }
+    }
+
+    private void alterneigh(final double alpha, final int rad, final int i, final double b, final double g, final double r) {
+        int lo = i - rad;
+        if (lo < -1) {
+            lo = -1;
+        }
+        int hi = i + rad;
+        if (hi > parNcolors) {
+            hi = parNcolors;
+        }
+
+        int j = i + 1;
+        int k = i - 1;
+        int q = 0;
+        while (j < hi || k > lo) {
+            final double a = alpha * (rad * rad - q * q) / (rad * rad);
+            q++;
+            if (j < hi) {
+                final double[] p = network[j];
+                p[0] -= a * (p[0] - b);
+                p[1] -= a * (p[1] - g);
+                p[2] -= a * (p[2] - r);
+                j++;
+            }
+            if (k > lo) {
+                final double[] p = network[k];
+                p[0] -= a * (p[0] - b);
+                p[1] -= a * (p[1] - g);
+                p[2] -= a * (p[2] - r);
+                k--;
+            }
+        }
+    }
+
+    private void altersingle(final double alpha, final int i, final double b, final double g, final double r) {
+        // Move neuron i towards biased (b,g,r) by factor alpha
+        final double[] n = network[i]; // alter hit neuron
+        n[0] -= alpha * (n[0] - b);
+        n[1] -= alpha * (n[1] - g);
+        n[2] -= alpha * (n[2] - r);
+    }
+
+    private int contest(final double b, final double g, final double r) { // Search for biased BGR values
+        // finds closest neuron (min dist) and updates freq
+        // finds best neuron (min dist-bias) and returns position
+        // for frequently chosen neurons, freq[i] is high and bias[i] is negative
+        // bias[i] = gamma*((1/netsize)-freq[i])
+
+        double bestd = Float.MAX_VALUE;
+        double bestbiasd = bestd;
+        int bestpos = -1;
+        int bestbiaspos = bestpos;
+
+        for (int i = 0; i < parNcolors; i++) {
+            final double[] n = network[i];
+            double dist = n[0] - b;
+            if (dist < 0) {
+                dist = -dist;
+            }
+            double a = n[1] - g;
+            if (a < 0) {
+                a = -a;
+            }
+            dist += a;
+            a = n[2] - r;
+            if (a < 0) {
+                a = -a;
+            }
+            dist += a;
+            if (dist < bestd) {
+                bestd = dist;
+                bestpos = i;
+            }
+            final double biasdist = dist - bias[i];
+            if (biasdist < bestbiasd) {
+                bestbiasd = biasdist;
+                bestbiaspos = i;
+            }
+            freq[i] -= parBeta * freq[i];
+            bias[i] += _parGammaBetta * freq[i];
+        }
+        freq[bestpos] += parBeta;
+        bias[bestpos] -= _parGammaBetta;
+        return bestbiaspos;
+    }
+
+    private void fix() {
+        for (int i = 0; i < parNcolors; i++) {
+            for (int j = 0; j < 3; j++) {
+                int x = (int) (0.5 + network[i][j]);
+                x = Math.max(Math.min(255, x), 0);
+                colormap[i][j] = x;
+            }
+            colormap[i][3] = i;
+        }
+    }
+
+    private void initParams() {
+        if (parReserveAlphaColor && parNcolors % 2 == 0) {
+            parNcolors--;
+        }
+        _parGammaBetta = parBeta * parGamma;
+        _parCutnetsize = parNcolors; //
+        _parMaxnetpos = parNcolors - 1;
+        final int _parInitrad = (parNcolors + 7) / 8; // for 256 cols, radius starts at 32
+        _parRadiusbias = 1 << parRadiusbiasshift;
+        _parInitBiasRadius = _parInitrad * _parRadiusbias;
+        _parIinitalpha = 1 << parAlphabiasshift; // biased by 10 bits
+        _parSamplefac = width * height / parMaxPixelsToSample;
+        if (_parSamplefac < 1) {
+            _parSamplefac = 1;
+        } else if (_parSamplefac > 30) {
+            _parSamplefac = 30;
+        }
+    }
+
+    private void inxbuild() {
+        // Insertion sort of network and building of netindex[0..255]
+
+        int previouscol = 0;
+        int startpos = 0;
+
+        for (int i = 0; i < parNcolors; i++) {
+            final int[] p = colormap[i];
+            int[] q = null;
+            int smallpos = i;
+            int smallval = p[1]; // index on g
+            // find smallest in i..netsize-1
+            for (int j = i + 1; j < parNcolors; j++) {
+                q = colormap[j];
+                if (q[1] < smallval) { // index on g
+                    smallpos = j;
+                    smallval = q[1]; // index on g
+                }
+            }
+            q = colormap[smallpos];
+            // swap p (i) and q (smallpos) entries
+            if (i != smallpos) {
+                int j = q[0];
+                q[0] = p[0];
+                p[0] = j;
+                j = q[1];
+                q[1] = p[1];
+                p[1] = j;
+                j = q[2];
+                q[2] = p[2];
+                p[2] = j;
+                j = q[3];
+                q[3] = p[3];
+                p[3] = j;
+            }
+            // smallval entry is now in position i
+            if (smallval != previouscol) {
+                netindex[previouscol] = startpos + i >> 1;
+                for (int j = previouscol + 1; j < smallval; j++) {
+                    netindex[j] = i;
+                }
+                previouscol = smallval;
+                startpos = i;
+            }
+        }
+        netindex[previouscol] = startpos + _parMaxnetpos >> 1;
+        for (int j = previouscol + 1; j < 256; j++) {
+            netindex[j] = _parMaxnetpos; // really 256
+        }
+    }
+
+    private void learn() {
+        int biasRadius = _parInitBiasRadius;
+        final int alphadec = 30 + (_parSamplefac - 1) / 3;
+        final int lengthcount = width * height;
+        int samplepixels = lengthcount / _parSamplefac;
+        if (samplepixels < 1000) {
+            samplepixels = 1000;
+        }
+        if (samplepixels > lengthcount) {
+            samplepixels = lengthcount;
+        }
+        int delta = samplepixels / parNcycles;
+        if (delta < 1) {
+            delta = 1;
+        }
+        int alpha = _parIinitalpha;
+        final int stepx = (int) (Math.sqrt(lengthcount / samplepixels) + 0.5);
+        int stepy = (int) (lengthcount / (samplepixels * (double) stepx) + 0.5);
+        stepy = Math.max(1, stepy);
+        int rad = biasRadius >> parRadiusbiasshift;
+        if (rad <= 1) {
+            rad = 0;
+        }
+
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.atTrace().addArgument(samplepixels).addArgument(rad).log("beginning 1D learning: samplepixels = {} rad = {}");
+        }
+        int i = 1;
+        for (int row = 0; row < height; row += stepy) {
+            for (int col = 0; col < width; col += stepx) {
+                final int rgbaPixel = pixelGetter.getPixel(row, (col + row) % width);
+                final int aaa = !parReserveAlphaColor ? 255 : rgbaPixel >> 24 & 0xff; // alpha
+                if (aaa < parTransparencyThreshold) {
+                    continue;
+                }
+                final double r = rgbaPixel >> 16 & 0xff; //red
+                final double g = rgbaPixel >> 8 & 0xff; // green
+                final double b = rgbaPixel & 0xff; // blue
+
+                final int j = contest(b, g, r);
+
+                final double a = 1.0 * alpha / _parIinitalpha;
+                altersingle(a, j, b, g, r);
+                if (rad > 0) {
+                    alterneigh(a, rad, j, b, g, r); // alter neighbours
+                }
+                i++;
+                if (i % delta == 0) {
+                    alpha -= alpha / alphadec;
+                    biasRadius -= biasRadius / parRadiusdec;
+                    rad = biasRadius >> parRadiusbiasshift;
+                    if (rad <= 1) {
+                        rad = 0;
+                    }
+                }
+            }
+        }
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.atTrace().addArgument((1.0 * alpha) / _parIinitalpha).log("finished 1D learning: final alpha = {}");
+        }
+    }
+
+    public interface PixelGetter {
+        // 3 ints if not alpha, 4 if alpha
+        int getPixel(int row, int col);
+    }
+}

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/SimplePerformanceMeter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/SimplePerformanceMeter.java
@@ -3,7 +3,6 @@ package de.gsi.chart.utils;
 import java.lang.management.ManagementFactory;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ExecutionException;
 
 import javafx.animation.AnimationTimer;
 import javafx.beans.property.DoubleProperty;
@@ -45,11 +44,7 @@ public class SimplePerformanceMeter extends AnimationTimer {
         timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
-                try {
-                    FXUtils.runLater(SimplePerformanceMeter.this::updateProperties);
-                } catch (ExecutionException e) {
-                    // not of concern
-                }
+                FXUtils.runFX(SimplePerformanceMeter.this::updateProperties);
             }
         }, 0, updateDuration);
     }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WritableImageCache.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WritableImageCache.java
@@ -1,0 +1,70 @@
+package de.gsi.chart.utils;
+
+import java.lang.ref.Reference;
+
+import javafx.scene.image.WritableImage;
+
+import de.gsi.dataset.utils.CacheCollection;
+
+/**
+ * Implements WritableImage cache collection to minimise memory re-allocation.
+ *  
+ * <p> 
+ * N.B. This is useful to re-use short-lived data storage container to minimise the amount of garbage to be collected. This is used in situation replacing e.g.
+ * <pre>
+ *  {@code
+ *      public returnValue frequentlyExecutedFunction(...) {
+ *          final WritableImage storage = new WritableImage(width, heigth); // allocate new memory block (costly)
+ *          // [...] do short-lived computation on storage
+ *          // storage is implicitly finalised by garbage collector (costly)
+ *      }
+ *  }
+ * </pre>
+ * with
+ * <pre>
+ *  {@code
+ *      // ...
+ *      private final WritableImageCache cache = new WritableImageCache();
+ *      // ...
+ *      
+ *      public returnValue frequentlyExecutedFunction(...) {
+ *          final byte[] storage = cache.getImage(width, height); // return previously allocated image (cheap) or allocated new if necessary 
+ *          // [...] do short-lived computation on storage
+ *          cache.add(storage); // return object to cache
+ *      }
+ *  }
+ * </pre>
+ *  
+ * @author rstein
+ *
+ */
+public class WritableImageCache extends CacheCollection<WritableImage> {
+    public WritableImage getImage(final int requiredWidth, final int requiredHeight) {
+        synchronized (contents) {
+            WritableImage bestFit = null;
+
+            for (final Reference<WritableImage> candidate : contents) {
+                final WritableImage localRef = candidate.get();
+                if (localRef == null) {
+                    continue;
+                }
+                final int localWidth = (int) localRef.getWidth();
+                final int localHeight = (int) localRef.getHeight();
+
+                if (localWidth == requiredWidth && localHeight == requiredHeight) {
+                    bestFit = localRef;
+                    break;
+                }
+            }
+
+            if (bestFit == null) {
+                // could not find any cached, return new WritableImage
+                bestFit = new WritableImage(requiredWidth, requiredHeight);
+                return bestFit;
+            }
+
+            remove(bestFit);
+            return bestFit;
+        }
+    }
+}

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -15,21 +15,39 @@ import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.gsi.dataset.utils.ArrayCache;
+import de.gsi.dataset.utils.ByteBufferOutputStream;
+
+import ar.com.hjg.pngj.FilterType;
+import ar.com.hjg.pngj.ImageInfo;
+import ar.com.hjg.pngj.ImageLineHelper;
+import ar.com.hjg.pngj.ImageLineInt;
+import ar.com.hjg.pngj.PngWriter;
+import ar.com.hjg.pngj.chunks.PngChunkPLTE;
+import ar.com.hjg.pngj.chunks.PngChunkTRNS;
+import ar.com.hjg.pngj.pixels.PixelsWriterDefault;
 
 /**
  * Writes a JavaFx Image into a ByteBuffer or file
  *
- * possible improvements:
- * - use multiple IDAT chunks to use fixed buffer size and limit memory footprint
- * - implement filtering of lines before compression for smaller file sizes
- * - Optionally add tEXT chunks for metadata (EXIF)
+ * possible improvements: - use multiple IDAT chunks to use fixed buffer size
+ * and limit memory footprint - implement filtering of lines before compression
+ * for smaller file sizes - Optionally add tEXT chunks for metadata (EXIF)
  *
  * @author Alexander Krimm
  */
+@SuppressWarnings("PMD.GodClass")
 public final class WriteFxImage {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImage.class);
+    private static final int DEFAULT_PALETTE_COLOR_COUNT = 256;
+    private static final String IMAGE_PIXEL_READER_NOT_AVAILABLE = "image PixelReader not available";
+    private static final String IMAGE_MUST_NOT_BE_NULL = "image must not be null";
     private static final int HEADER_SIZE = 8 + 12 + 13 + 12 + 12; // size of all the headers and other Metadata
     private static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
+    private static final String INTERNAL_LINE_ARRAY_CACHE_NAME = "WriteFxImage-internalLineArray";
 
     /**
      * private constructor for static utility class
@@ -59,8 +77,35 @@ public final class WriteFxImage {
         return writableImage;
     }
 
+    public static void copyImageDataToPixelBuffer(final Image image, final int[] uncompressedImageData) {
+        if (image == null) {
+            throw new IllegalArgumentException("image is null");
+        }
+        final PixelReader pr = image.getPixelReader();
+        if (pr == null) {
+            throw new IllegalStateException(IMAGE_PIXEL_READER_NOT_AVAILABLE);
+        }
+        if (uncompressedImageData == null) {
+            throw new IllegalArgumentException("uncompressedImageData is null");
+        }
+        final int w = (int) image.getWidth();
+        final int h = (int) image.getHeight();
+        final int requiredSize = w * h;
+        if (uncompressedImageData.length < requiredSize) {
+            throw new IllegalArgumentException("uncompressedImageData.length = " //
+                                               + uncompressedImageData.length + " too small, should be at least" + requiredSize);
+        }
+        int i = 0;
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                uncompressedImageData[i++] = pr.getArgb(x, y);
+            }
+        }
+    }
+
     /**
-     * Encodes a JavaFx image as an RGB png image with fastest (lossless) compression
+     * Encodes a JavaFx image as an RGB png image with fastest (lossless)
+     * compression
      *
      * @param image The input image to be encoded
      * @return a byte buffer with the encoded image
@@ -71,35 +116,104 @@ public final class WriteFxImage {
     }
 
     /**
-     * Encodes a JavaFx image as an RGB png image.
-     * If you pass in a ByteBuffer to use, please make sure that it has enough capacity to fit the encoded image or
-     * handle errors (IndexOutOfBoundsException) accordingly. If you want to be on the safe side, use
-     * {@link #getCompressedSizeBound(int, int, boolean) getCompressedSizeBound(width, height, alpha)} 
-     * to get an upper bound for the output size.
+     * Encodes a JavaFx image as an RGB png image. If you pass in a ByteBuffer to
+     * use, please make sure that it has enough capacity to fit the encoded image or
+     * handle errors (IndexOutOfBoundsException) accordingly. If you want to be on
+     * the safe side, use {@link #getCompressedSizeBound(int, int, boolean)
+     * getCompressedSizeBound(width, height, alpha)} to get an upper bound for the
+     * output size.
      *
-     * @param image The input image to be encoded
-     * @param byteBuffer optional byte buffer to store the output in, pass null to return a new one.
-     * @param alpha whether to include alpha information in the image
-     * @param compressionLevel {@link Deflater#BEST_COMPRESSION} (9) to {@link Deflater#BEST_SPEED} (0)
-     * @param metaInfo an optional map which will be filled with debugging information like compression efficiency
+     * @param image            The input image to be encoded
+     * @param byteBuffer       optional byte buffer to store the output in, pass
+     *                         null to return a new one.
+     * @param alpha            whether to include alpha information in the image
+     * @param compressionLevel {@link Deflater#BEST_COMPRESSION} (9) to
+     *                         {@link Deflater#BEST_SPEED} (0)
+     * @param filterType       filter as outlines in https://tools.ietf.org/html/rfc2083#section-6
+     *                         plus some custom additional options implemented in the undelying
+     *                         PNG encode implementation
      * @return a byte buffer with the encoded image
      * @see "https://tools.ietf.org/html/rfc2083"
      */
-    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer, final boolean alpha,
-            final int compressionLevel, final Map<String, Object> metaInfo) {
+    public static ByteBuffer encode(final Image image, final ByteBuffer byteBuffer, final boolean alpha, final int compressionLevel, final FilterType filterType) {
         if (image == null) {
-            throw new IllegalArgumentException("image must not be null");
+            throw new IllegalArgumentException(IMAGE_MUST_NOT_BE_NULL);
         }
         // get meta info
+        final PixelReader pr = image.getPixelReader();
+        if (pr == null) {
+            throw new IllegalStateException(IMAGE_PIXEL_READER_NOT_AVAILABLE);
+        }
         final int w = (int) image.getWidth();
         final int h = (int) image.getHeight();
-        // allocate output buffer if necessary. conservative allocation, assume upper bound for deflate algorithm
         final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha)) : byteBuffer;
+        try (ByteBufferOutputStream os = new ByteBufferOutputStream(outputByteBuffer, false)) {
+            PngWriter png = new PngWriter(os, new ImageInfo(w, h, 8, alpha, false, false));
+            ((PixelsWriterDefault) png.getPixelsWriter()).setFilterType(filterType == null ? FilterType.FILTER_NONE : filterType);
+            png.setIdatMaxSize(0x10000);
+            png.setCompLevel(compressionLevel);
+
+            ImageLineInt line = new ImageLineInt(png.imgInfo);
+            if (alpha) {
+                for (int y = 0; y < h; y++) {
+                    for (int x = 0; x < w; x++) {
+                        final int pixel = pr.getArgb(x, y);
+                        ImageLineHelper.setPixelRGBA8(line, x, pixel);
+                    }
+                    png.writeRow(line, y);
+                }
+            } else {
+                for (int y = 0; y < h; y++) {
+                    for (int x = 0; x < w; x++) {
+                        final int pixel = pr.getArgb(x, y);
+                        ImageLineHelper.setPixelRGB8(line, x, pixel);
+                    }
+                    png.writeRow(line, y);
+                }
+            }
+            png.end();
+            return os.buffer().flip();
+        } catch (IOException e) {
+            LOGGER.atError().setCause(e).log("buffer couldn't be closes");
+        }
+        return null;
+    }
+
+    /**
+     * Encodes a JavaFx image as an RGB png image. If you pass in a ByteBuffer to
+     * use, please make sure that it has enough capacity to fit the encoded image or
+     * handle errors (IndexOutOfBoundsException) accordingly. If you want to be on
+     * the safe side, use {@link #getCompressedSizeBound(int, int, boolean)
+     * getCompressedSizeBound(width, height, alpha)} to get an upper bound for the
+     * output size.
+     *
+     * @param image            The input image to be encoded
+     * @param byteBuffer       optional byte buffer to store the output in, pass
+     *                         null to return a new one.
+     * @param alpha            whether to include alpha information in the image
+     * @param compressionLevel {@link Deflater#BEST_COMPRESSION} (9) to
+     *                         {@link Deflater#BEST_SPEED} (0)
+     * @param metaInfo         an optional map which will be filled with debugging
+     *                         information like compression efficiency
+     * @return a byte buffer with the encoded image
+     * @see "https://tools.ietf.org/html/rfc2083"
+     */
+    public static ByteBuffer encodeAlt(final Image image, final ByteBuffer byteBuffer, final boolean alpha, final int compressionLevel, final Map<String, Object> metaInfo) {
+        if (image == null) {
+            throw new IllegalArgumentException(IMAGE_MUST_NOT_BE_NULL);
+        }
+        // get meta info
         // get necessary helper classes
         final PixelReader pr = image.getPixelReader();
         if (pr == null) {
-            throw new IllegalStateException("image PixelReader not available");
+            throw new IllegalStateException(IMAGE_PIXEL_READER_NOT_AVAILABLE);
         }
+        final int w = (int) image.getWidth();
+        final int h = (int) image.getHeight();
+
+        // allocate output buffer if necessary. conservative allocation, assume upper
+        // bound for deflate algorithm
+        final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate(getCompressedSizeBound(w, h, alpha)) : byteBuffer;
         final CRC32 crc = new CRC32();
         final Deflater compressor = new Deflater(compressionLevel);
         // actual PNG encoding
@@ -123,14 +237,113 @@ public final class WriteFxImage {
         return outputByteBuffer;
     }
 
+    public static ByteBuffer encodePalette(final Image image, final ByteBuffer byteBuffer, final boolean alpha, final int compressionLevel, final FilterType filterType, final PaletteQuantizer... userPalette) { // NOPMD w.r.t path complexity
+        if (image == null) {
+            throw new IllegalArgumentException(IMAGE_MUST_NOT_BE_NULL);
+        }
+        // get meta info
+        final int w = (int) image.getWidth();
+        final int h = (int) image.getHeight();
+        final int nPixel = w * h;
+        final int[] uncompressedImageData = ArrayCache.getCachedIntArray(INTERNAL_ARRAY_CACHE_NAME, nPixel);
+        copyImageDataToPixelBuffer(image, uncompressedImageData);
+
+        PaletteQuantizer palette = userPalette.length > 0 && userPalette[0] != null ? userPalette[0] : estimatePalette(uncompressedImageData, w, h, alpha, DEFAULT_PALETTE_COLOR_COUNT);
+        // add in addition ~ 256*(3..4) bytes to store palette info
+        // N.B. alpha with palette has a bug, thus forcing it here
+        final int bytesPerPixel = 3; // (alpha ? 4 : 3);
+        final int bytesPerPalette = bytesPerPixel * palette.getColorCount();
+        final int requiredSize = getCompressedSizeBound(w, h, alpha) + bytesPerPalette;
+        final ByteBuffer outputByteBuffer = byteBuffer == null ? ByteBuffer.allocate(requiredSize) : byteBuffer;
+        try (ByteBufferOutputStream os = new ByteBufferOutputStream(outputByteBuffer, false)) {
+            // N.B. alpha with palette has a bug, thus forcing it here
+            ImageInfo imageInfo = new ImageInfo(w, h, 8, false /*alpha*/, false, true);
+            PngWriter pngWriter = new PngWriter(os, imageInfo);
+            ((PixelsWriterDefault) pngWriter.getPixelsWriter()).setFilterType(filterType);
+            pngWriter.setIdatMaxSize(requiredSize > 2 * 0x10000 ? 0x10000 : 32000);
+            pngWriter.setCompLevel(compressionLevel);
+
+            preparePaletteHeader(pngWriter, palette);
+
+            final int[] lineArray = ArrayCache.getCachedIntArray(INTERNAL_LINE_ARRAY_CACHE_NAME, w);
+            final ImageLineInt line = new ImageLineInt(pngWriter.imgInfo, lineArray);
+            if (alpha) {
+                int row = 0;
+                for (int i = 0; i < nPixel; i++) {
+                    final int lineIndex = i % w;
+                    final int pixel = uncompressedImageData[i];
+                    lineArray[lineIndex] = palette.lookup(pixel >> 16 & 0xFF, pixel >> 8 & 0xFF, pixel & 0xFF, pixel >> 24 & 0xFF);
+                    if (lineIndex == w - 1) {
+                        pngWriter.writeRow(line, row++);
+                    }
+                }
+            } else {
+                for (int i = 0; i < nPixel; i++) {
+                    final int lineIndex = i % w;
+                    final int pixel = uncompressedImageData[i];
+                    lineArray[lineIndex] = palette.lookup(pixel >> 16 & 0xFF, pixel >> 8 & 0xFF, pixel & 0xFF);
+                    if (lineIndex == w - 1) {
+                        pngWriter.writeRow(line);
+                    }
+                }
+            }
+            pngWriter.end();
+            ArrayCache.release(INTERNAL_ARRAY_CACHE_NAME, uncompressedImageData);
+            ArrayCache.release(INTERNAL_LINE_ARRAY_CACHE_NAME, lineArray);
+            return os.buffer().flip();
+        } catch (IOException e) {
+            LOGGER.atError().setCause(e).log("buffer couldn't be closed");
+        }
+        return null;
+    }
+
+    public static PaletteQuantizer estimatePalette(final Image image, final boolean alpha, final int nColors) {
+        if (image == null) {
+            throw new IllegalArgumentException(IMAGE_MUST_NOT_BE_NULL);
+        }
+        // get meta info
+        final PixelReader pr = image.getPixelReader();
+        if (pr == null) {
+            throw new IllegalStateException(IMAGE_PIXEL_READER_NOT_AVAILABLE);
+        }
+        final int w = (int) image.getWidth();
+        final int h = (int) image.getHeight();
+
+        PaletteQuantizerNeuQuant cuant = new PaletteQuantizerNeuQuant(w, h, (x, y) -> pr.getArgb(y, x));
+        cuant.setParReserveAlphaColor(alpha);
+        cuant.setParNcolors(nColors);
+        cuant.run();
+
+        return cuant;
+    }
+
+    public static PaletteQuantizer estimatePalette(final int[] pixelArray, final int width, final int heigth, final boolean alpha, final int nColors) {
+        if (pixelArray == null) {
+            throw new IllegalArgumentException("pixelArray must not be null");
+        }
+
+        if (pixelArray.length < width * heigth) {
+            throw new IllegalArgumentException("pixelArray.length(" + pixelArray.length + " must be >= " + (width * heigth) + " = " + width + " (width) x" + heigth + " (height)");
+        }
+
+        PaletteQuantizerNeuQuant cuant = new PaletteQuantizerNeuQuant(width, heigth, (x, y) -> pixelArray[x * width + y]);
+        cuant.setParReserveAlphaColor(alpha);
+        cuant.setParNcolors(nColors);
+        cuant.run();
+
+        return cuant;
+    }
+
     /**
      * Returns the conservative upper bound for the compressed image size.
      *
-     * @param width Image width
+     * @param width  Image width
      * @param height Image height
-     * @param alpha Alpha enabled
+     * @param alpha  Alpha enabled
      * @return the upper bound for the size of the resulting png in bytes
-     * @see <a href="https://github.com/madler/zlib/blob/master/deflate.c#L659-L661">zlib sourcefor deflate upper bound</a>
+     * @see <a href=
+     *      "https://github.com/madler/zlib/blob/master/deflate.c#L659-L661">zlib
+     *      sourcefor deflate upper bound</a>
      */
     public static int getCompressedSizeBound(final int width, final int height, final boolean alpha) {
         final int bytesPerPixel = alpha ? 4 : 3;
@@ -143,7 +356,7 @@ public final class WriteFxImage {
      * Saves the given image as a png file.
      *
      * @param image The image to save
-     * @param file The filename to save the image to.
+     * @param file  The filename to save the image to.
      * @throws IOException if the file cannot be written
      */
     public static void savePng(final Image image, final File file) throws IOException {
@@ -153,12 +366,30 @@ public final class WriteFxImage {
         }
     }
 
+    private static void preparePaletteHeader(PngWriter pngWriter, PaletteQuantizer cuant) {
+        // create palette
+        PngChunkPLTE palette = pngWriter.getMetadata().createPLTEChunk();
+        final int ncolors = cuant.getColorCount();
+        palette.setNentries(ncolors);
+        for (int i = 0; i < ncolors; i++) {
+            int[] col = cuant.getColor(i);
+            palette.setEntry(i, col[0], col[1], col[2]);
+        }
+
+        int transparentIndex = cuant.getTransparentIndex();
+        if (transparentIndex >= 0) {
+            PngChunkTRNS transparent = new PngChunkTRNS(pngWriter.imgInfo);
+            transparent.setIndexEntryAsTransparent(transparentIndex);
+            pngWriter.getChunksList().queue(transparent);
+        }
+    }
+
     /**
      * Writes a byte array to the buffer and updates the checksum.
      *
-     * @param b byteArray to put into buffer
+     * @param b      byteArray to put into buffer
      * @param buffer output buffer
-     * @param crc checksum calculator
+     * @param crc    checksum calculator
      */
     private static void write(final byte[] b, final ByteBuffer buffer, final CRC32 crc) {
         buffer.put(b);
@@ -168,9 +399,9 @@ public final class WriteFxImage {
     /**
      * Writes an integer value to the buffer and updates the checksum.
      *
-     * @param i integer value to write
+     * @param i      integer value to write
      * @param buffer the buffer to write to
-     * @param crc the checksum to be updated
+     * @param crc    the checksum to be updated
      */
     private static void write(final int i, final ByteBuffer buffer, final CRC32 crc) {
         final byte[] b = { (byte) (i >> 24 & 0xff), (byte) (i >> 16 & 0xff), (byte) (i >> 8 & 0xff), (byte) (i & 0xff) };
@@ -178,17 +409,17 @@ public final class WriteFxImage {
     }
 
     /**
-     * Writes the IDAT chunk of a png file, which contains the compressed image data to the supplied buffer.
+     * Writes the IDAT chunk of a png file, which contains the compressed image data
+     * to the supplied buffer.
      *
-     * @param pr PixelWriter
-     * @param w with of the image
-     * @param h height of the image
-     * @param alpha whether to include alpha information
+     * @param pr               PixelWriter
+     * @param w                with of the image
+     * @param h                height of the image
+     * @param alpha            whether to include alpha information
      * @param outputByteBuffer the byte buffer to write to
-     * @param crc checksum calculator
+     * @param crc              checksum calculator
      */
-    private static void writeImageData(final PixelReader pr, final int w, final int h, final boolean alpha, final Deflater compressor,
-            final ByteBuffer outputByteBuffer, final CRC32 crc) {
+    private static void writeImageData(final PixelReader pr, final int w, final int h, final boolean alpha, final Deflater compressor, final ByteBuffer outputByteBuffer, final CRC32 crc) {
         // get raw image data
         final int bytesPerPixel = alpha ? 4 : 3;
         final int rawDataSize = w * h * bytesPerPixel + h; // image dimensions times bytesPerPixel + line filtering flag
@@ -199,7 +430,7 @@ public final class WriteFxImage {
                 uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
                 for (int x = 0; x < w; x++) {
                     final int pixel = pr.getArgb(x, y);
-                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); //red
+                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); // red
                     uncompressedImageData[i++] = (byte) (pixel >> 8 & 0xff); // green
                     uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
                     uncompressedImageData[i++] = (byte) (pixel >> 24 & 0xff); // alpha
@@ -210,7 +441,7 @@ public final class WriteFxImage {
                 uncompressedImageData[i++] = 0; // LineFiltering: 0: None 1: Sub 2: Up 3: Average 4: Paeth
                 for (int x = 0; x < w; x++) {
                     final int pixel = pr.getArgb(x, y);
-                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); //red
+                    uncompressedImageData[i++] = (byte) (pixel >> 16 & 0xff); // red
                     uncompressedImageData[i++] = (byte) (pixel >> 8 & 0xff); // green
                     uncompressedImageData[i++] = (byte) (pixel & 0xff); // blue
                 }
@@ -237,7 +468,7 @@ public final class WriteFxImage {
      * Writes the end marker for the png file format
      *
      * @param outputByteBuffer the buffer to write into
-     * @param crc The checksum calculator
+     * @param crc              The checksum calculator
      */
     private static void writeImageFooter(final ByteBuffer outputByteBuffer, final CRC32 crc) {
         outputByteBuffer.putInt(0);
@@ -249,11 +480,11 @@ public final class WriteFxImage {
     /**
      * Writes the PNG file header and IHDR meta-information block
      *
-     * @param width The with of the image
-     * @param height The height of the image
-     * @param alpha whether to support alpha
+     * @param width            The with of the image
+     * @param height           The height of the image
+     * @param alpha            whether to support alpha
      * @param outputByteBuffer the buffer to write into
-     * @param crc the checksum calculator
+     * @param crc              the checksum calculator
      */
     private static void writeImageHeader(final int width, final int height, final boolean alpha, final ByteBuffer outputByteBuffer, final CRC32 crc) {
         // File Signature - "\211PNG\r\n\032\n" - 8950 4e47 0d0a 1a0a
@@ -264,11 +495,13 @@ public final class WriteFxImage {
         write("IHDR".getBytes(), outputByteBuffer, crc);
         write(width, outputByteBuffer, crc); // with 4 bytes
         write(height, outputByteBuffer, crc); // height 4 bytes
-        // Bit depth:          1 byte  1*,2*,4*,8,16° (*:indexed only, °: not indexed)
-        // Color type:         1 byte  0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha), and 6 (RGBA).
-        // Compression method: 1 byte  0 (deflate/inflate compression with a 32K sliding window)
-        // Filter method:      1 byte  0 (adaptive filtering with five basic filter types)
-        // Interlace method:   1 byte  0 (no interlace) or 1 (Adam7 interlace)
+        // Bit depth: 1 byte 1*,2*,4*,8,16° (*:indexed only, °: not indexed)
+        // Color type: 1 byte 0 (grayscale), 2 (RGB), 3 (Indexed), 4 (grayscale+alpha),
+        // and 6 (RGBA).
+        // Compression method: 1 byte 0 (deflate/inflate compression with a 32K sliding
+        // window)
+        // Filter method: 1 byte 0 (adaptive filtering with five basic filter types)
+        // Interlace method: 1 byte 0 (no interlace) or 1 (Adam7 interlace)
         write(alpha ? new byte[] { 8, 6, 0, 0, 0 } : new byte[] { 8, 2, 0, 0, 0 }, outputByteBuffer, crc); // RGB(A) Mode
         outputByteBuffer.putInt((int) crc.getValue());
     }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WriteFxImage.java
@@ -11,6 +11,9 @@ import java.util.zip.Deflater;
 
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelReader;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+import javafx.scene.paint.Color;
 
 import de.gsi.dataset.utils.ArrayCache;
 
@@ -32,6 +35,28 @@ public final class WriteFxImage {
      * private constructor for static utility class
      */
     private WriteFxImage() {
+    }
+
+    /**
+     * copy the given Image to a WritableImage
+     * 
+     * @param image the input image
+     * @return clone of image
+     */
+    public static WritableImage clone(Image image) {
+        int height = (int) image.getHeight();
+        int width = (int) image.getWidth();
+        PixelReader pixelReader = image.getPixelReader();
+        WritableImage writableImage = new WritableImage(width, height);
+        PixelWriter pixelWriter = writableImage.getPixelWriter();
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                Color color = pixelReader.getColor(x, y);
+                pixelWriter.setColor(x, y, color);
+            }
+        }
+        return writableImage;
     }
 
     /**

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/LabelledMarkerRendererTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/LabelledMarkerRendererTests.java
@@ -10,7 +10,6 @@ import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.compareAndWriteReference
 import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.writeTestImage;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
@@ -87,7 +86,7 @@ public class LabelledMarkerRendererTests {
     }
 
     @Test
-    public void defaultTests() throws IOException, InterruptedException, ExecutionException {
+    public void defaultTests() throws IOException, Exception {
         FXUtils.runAndWait(() -> chart.getDatasets().add(getTestDataSet()));
         FXUtils.runAndWait(() -> chart.requestLayout());
         assertTrue(FXUtils.waitForFxTicks(chart.getScene(), WAIT_N_FX_PULSES, MAX_TIMEOUT_MILLIS));

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/FXUtilsTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/FXUtilsTests.java
@@ -1,0 +1,154 @@
+package de.gsi.chart.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+import de.gsi.chart.ui.utils.TestFx;
+
+/**
+ * Tests {@link de.gsi.chart.renderer.spi.LabelledMarkerRenderer }
+ *
+ * @author rstein
+ *
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class FXUtilsTests {
+    private static final Class<?> clazz = FXUtilsTests.class;
+    private static final Logger LOGGER = LoggerFactory.getLogger(clazz);
+    private static final int WIDTH = 300;
+    private static final int HEIGHT = 200;
+    private Label testLabel;
+
+    @Start
+    public void start(@SuppressWarnings("unused") Stage stage) {
+        // needed only to initialize FX UI Thread infrastructure
+        testLabel = new Label("test label");
+        stage.setScene(new Scene(testLabel, WIDTH, HEIGHT));
+        stage.show();
+    }
+
+    @TestFx
+    public void testWithinFxThread() throws Exception {
+        FXUtils.assertJavaFxThread();
+        FXUtils.keepJavaFxAlive();
+
+        FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Runnable in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        assertTrue(FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Supplier in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return true;
+        }));
+
+        assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
+            LOGGER.atTrace().log("execute Function<R,T> in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return a;
+        }));
+
+        FXUtils.runFX(() -> {
+            LOGGER.atTrace().log("execute Runnable in runLater in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        Awaitility.setDefaultPollDelay(100, TimeUnit.MILLISECONDS);
+        Awaitility.pollInSameThread();
+        // FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        });
+
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
+        });
+
+        // test assertions
+        assertThrows(IllegalStateException.class, () -> FXUtils.runFX(() -> {
+            LOGGER.atTrace().log("execute Runnable with exception in runFX in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Runnable with exception in runAndWait in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+    }
+
+    @Test
+    public void testOutsideFxThread() throws Exception {
+        assertFalse(Platform.isFxApplicationThread());
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.assertJavaFxThread());
+
+        FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Runnable in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        assertTrue(FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Supplier in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return true;
+        }));
+
+        assertEquals(42.0, FXUtils.runAndWait(42.0, a -> {
+            LOGGER.atTrace().log("execute Function<R,T> in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+            return a;
+        }));
+
+        FXUtils.runFX(() -> {
+            LOGGER.atTrace().log("execute Runnable in runLater in JavaFX thread");
+            FXUtils.assertJavaFxThread();
+        });
+
+        Awaitility.setDefaultPollDelay(100, TimeUnit.MILLISECONDS);
+        Awaitility.pollInSameThread();
+        // FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3);
+        });
+
+        LOGGER.atInfo().log("following [FXUtils-thread] 'FXUtils::waitForTicks(..) interrupted by timeout' warning is the normal library behaviour");
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            return FXUtils.waitForFxTicks(testLabel.getScene(), 3, 100);
+        });
+
+        // check for own time-out
+        assertFalse(FXUtils.waitForFxTicks(testLabel.getScene(), 1000, 20));
+
+        // test assertions
+        // N.B. the exception thrown in runLater cannot be forwarded to the calling thread (asynchronicity)
+        // assertThrows(IllegalStateException.class, () -> FXUtils.runFX(() -> {
+        //      LOGGER.atInfo().log("execute Runnable with exception in runFX in JavaFX thread");
+        //      throw new IllegalStateException("should be caught and swallowed by unit-test");
+        // }));
+
+        assertThrows(IllegalStateException.class, () -> FXUtils.runAndWait(() -> {
+            LOGGER.atTrace().log("execute Runnable with exception in runAndWait in JavaFX thread");
+            throw new IllegalStateException("should be caught and swallowed by unit-test");
+        }));
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WritableImageCacheTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WritableImageCacheTests.java
@@ -1,0 +1,172 @@
+package de.gsi.chart.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javafx.scene.image.WritableImage;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * Tests implementation of {@link de.gsi.chart.utils.WritableImageCache} as well as implicitly {@link de.gsi.dataset.utils.CacheCollection}.
+ * 
+ * @author rstein
+ *
+ *         N.B. to run manually: javac WritableImageCacheTests.java java -Xms256m -Xmx256m WritableImageCacheTests
+ */
+public class WritableImageCacheTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WritableImageCacheTests.class);
+    private static final int N_ITERATIONS = 1000;
+    private static final int N_INITIAL_CACHE_OBJECTS = 10;
+    private static final int N_IMAGE_WIDTH = 200;
+    private static final int N_IMAGE_HEIGHT = 100;
+
+    @Test
+    public void testBasicFunction() {
+        final WritableImageCache cache = new WritableImageCache();
+        assertEquals(0, cache.size(), "initial cache size");
+
+        for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
+            cache.add(new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT));
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
+
+        // force release of SoftReferences (should work fine starting with > JDK11, JDK
+        // < may need VM parameter: `-XX:SoftRefLRUPolicyMSPerMB=0`
+        forceMemoryShortage();
+        assertEquals(0, cache.size(), "zero-ing memory and SoftReferenes");
+
+        cache.add(new WritableImage(N_IMAGE_WIDTH - 10, N_IMAGE_HEIGHT)); // to small
+        cache.add(new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT - 10)); // to small
+        cache.add(new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT)); // goldy locks, right size
+        cache.add(new WritableImage(N_IMAGE_WIDTH + 10, N_IMAGE_HEIGHT)); // to large
+        assertEquals(4, cache.size());
+
+        final WritableImage testImage = cache.getImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT);
+        assertEquals(N_IMAGE_WIDTH, (int) testImage.getWidth());
+        assertEquals(N_IMAGE_HEIGHT, (int) testImage.getHeight());
+        assertEquals(3, cache.size());
+
+        cache.clear();
+        assertEquals(0, cache.size());
+
+        // prevent adding twice
+        assertFalse(cache.contains(testImage));
+        assertTrue(cache.add(testImage));
+        assertTrue(cache.contains(testImage));
+        assertFalse(cache.add(testImage));
+
+        // check null safe-guard
+        assertFalse(cache.add(null));
+        assertFalse(cache.contains(null));
+        assertFalse(cache.remove(null));
+
+        // remove non-existent/unknown image
+        final WritableImage unknownImage = new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT);
+        assertFalse(cache.remove(unknownImage));
+    }
+
+    @Test
+    public void testIterators() {
+        final WritableImageCache cache = new WritableImageCache();
+        assertEquals(0, cache.size(), "initial cache size");
+
+        for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
+            cache.add(new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT));
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
+
+        final java.util.Iterator<WritableImage> iter = cache.iterator();
+        int count = 0;
+        while (iter.hasNext()) {
+            final WritableImage element = iter.next();
+            if (count == 0 || element == null) {
+                iter.remove();
+            }
+            count++;
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, count);
+    }
+
+    private static void forceMemoryShortage() {
+        boolean run = true;
+        List<byte[]> strongReference = Collections.synchronizedList(new ArrayList<>(100000));
+
+        while (run) {
+            try {
+                strongReference.add(new byte[10_000_000]);
+            } catch (final OutOfMemoryError e) {
+                run = false;
+            }
+        }
+
+        // to be garbage collected
+        strongReference = null;
+        Runtime.getRuntime().gc();
+        Runtime.getRuntime().gc();
+    }
+
+    private static double performanceCheckCached() {
+        final WritableImageCache cache = new WritableImageCache();
+        cache.add(new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT));
+
+        final long start = System.nanoTime();
+        for (int i = 0; i < N_ITERATIONS; i++) {
+            WritableImage image = cache.getImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT);
+
+            // simple check to minimise JIT optimisations
+            if ((int) image.getWidth() != N_IMAGE_WIDTH) {
+                throw new IllegalStateException("should not occur");
+            }
+
+            cache.add(image);
+            image = null;
+        }
+
+        final long stop = System.nanoTime();
+
+        return (stop - start) / (double) N_ITERATIONS;
+    }
+
+    private static double performanceCheckClassic() {
+        final long start = System.nanoTime();
+        for (int i = 0; i < N_ITERATIONS; i++) {
+            WritableImage image = new WritableImage(N_IMAGE_WIDTH, N_IMAGE_HEIGHT);
+
+            // simple check to minimise JIT optimisations
+            if ((int) image.getWidth() != N_IMAGE_WIDTH) {
+                throw new IllegalStateException("should not occur");
+            }
+
+            image = null;
+        }
+
+        final long stop = System.nanoTime();
+
+        return (stop - start) / (double) N_ITERATIONS;
+    }
+
+    public static void main(String[] args) {
+        final WritableImageCacheTests test = new WritableImageCacheTests();
+
+        test.testBasicFunction();
+        final double mem1 = Runtime.getRuntime().totalMemory();
+        final double classic = performanceCheckClassic();
+        final double mem2 = Runtime.getRuntime().totalMemory();
+        final double cached = performanceCheckCached();
+        final double mem3 = Runtime.getRuntime().totalMemory();
+        LOGGER.atInfo().addArgument(classic).addArgument(cached).log("WritableImageCache performance difference: {} ns (classic) vs. {} ns (cached)");
+        LOGGER.atInfo().addArgument(classic / cached * 100.0).log("WritableImageCache performance difference: {}& (classic/cached)");
+        LOGGER.atInfo().addArgument(mem1).log("memory before: {} Bytes");
+        LOGGER.atInfo().addArgument(mem2).log("after classic: {} Bytes");
+        LOGGER.atInfo().addArgument(mem3).log("after cached:  {} Bytes");
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -249,6 +249,13 @@ public class WriteFxImageTests {
         }
     }
 
+    @Test
+    public void testHelperFunctions() {
+        assertImageEqual(image1x1, WriteFxImage.clone(image1x1));
+        assertImageEqual(imageOvals, WriteFxImage.clone(imageOvals));
+        assertImageEqual(imageRandom, WriteFxImage.clone(imageRandom));
+    }
+
     private static void assertImageEqual(Image original, Image recovered) {
         final int w = (int) original.getWidth();
         final int h = (int) original.getHeight();

--- a/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/utils/WriteFxImageTests.java
@@ -1,7 +1,11 @@
 package de.gsi.chart.utils;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,10 +16,13 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Stream;
 import java.util.zip.Deflater;
 
 import javafx.scene.canvas.Canvas;
@@ -28,12 +35,18 @@ import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
 import de.gsi.dataset.utils.ArrayCache;
+
+import ar.com.hjg.pngj.FilterType;
 
 /**
  * Tests for {@link de.gsi.chart.utils.WriteFxImage}.
@@ -44,10 +57,18 @@ import de.gsi.dataset.utils.ArrayCache;
 @ExtendWith(ApplicationExtension.class)
 public class WriteFxImageTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(WriteFxImageBenchmark.class);
+    private static final int DEFAULT_PALETTE_COLOR_COUNT = 256;
     private static final String INTERNAL_ARRAY_CACHE_NAME = "WriteFxImage-internalArray";
     private Image imageOvals;
     private Image imageRandom;
     private Image image1x1;
+
+    @Test
+    public void assertExceptions() {
+        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
+
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.encode(null, pngOutput, true, Deflater.BEST_SPEED, null));
+    }
 
     @Start
     public void setUp(@SuppressWarnings("unused") final Stage stage) {
@@ -82,16 +103,64 @@ public class WriteFxImageTests {
     }
 
     @Test
-    public void testWritingImageToFile(@TempDir File tempDir) throws IOException {
-        File tmpfile = new File(tempDir.getPath() + "test.png");
-        // convert to png
-        WriteFxImage.savePng(imageOvals, tmpfile);
-        // load from png
-        try (InputStream is = new FileInputStream(tmpfile.getPath())) {
-            Image recovered = new Image(is);
-            // compare against original
-            assertImageEqual(imageOvals, recovered);
+    public void testHelperFunctions() {
+        assertImageEqual(image1x1, WriteFxImage.clone(image1x1));
+        assertImageEqual(imageOvals, WriteFxImage.clone(imageOvals));
+        assertImageEqual(imageRandom, WriteFxImage.clone(imageRandom));
+    }
+
+    @Test
+    public void testPaletteGeneratorGetterSetter() {
+        PaletteQuantizerNeuQuant test = new PaletteQuantizerNeuQuant(10, 10, (x, y) -> 0);
+
+        assertDoesNotThrow(() -> test.setParAlphabiasshift(10));
+        assertDoesNotThrow(() -> test.setParBeta(0.1));
+        assertDoesNotThrow(() -> test.setParGamma(0.2));
+        assertDoesNotThrow(() -> test.setParMaxPixelsToSample(2));
+        assertDoesNotThrow(() -> test.setParNcolors(3));
+        assertEquals(3, test.getColorCount());
+        assertDoesNotThrow(() -> test.setParNcycles(4));
+        assertDoesNotThrow(() -> test.setParRadiusbiasshift(5));
+        assertDoesNotThrow(() -> test.setParRadiusdec(6));
+        assertDoesNotThrow(() -> test.setParReserveAlphaColor(true));
+        assertEquals(true, test.isParReserveAlphaColor());
+        assertDoesNotThrow(() -> test.setParReserveAlphaColor(false));
+        assertEquals(false, test.isParReserveAlphaColor());
+        assertDoesNotThrow(() -> test.setParTransparencyThreshold(10));
+
+        assertNotNull(test.convert(0, 0, 0));
+        assertNotNull(test.convert(0, 0, 0, 0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 1, 2 })
+    public void testPaletteHelper(final int testImageID) {
+        final boolean alpha = true;
+        final Image testImage = getTestImage(testImageID);
+        int w = (int) testImage.getWidth();
+        int h = (int) testImage.getHeight();
+
+        final int requiredSize = w * h;
+        final int[] uncompressedImageData = new int[requiredSize];
+        WriteFxImage.copyImageDataToPixelBuffer(testImage, uncompressedImageData);
+
+        PaletteQuantizer palette1 = WriteFxImage.estimatePalette(testImage, alpha, DEFAULT_PALETTE_COLOR_COUNT);
+        PaletteQuantizer palette2 = WriteFxImage.estimatePalette(uncompressedImageData, w, h, alpha, DEFAULT_PALETTE_COLOR_COUNT);
+
+        assertEquals(palette1.getColorCount(), palette2.getColorCount());
+        for (int i = 0; i < palette1.getColorCount(); i++) {
+            assertArrayEquals(palette1.getColor(i), palette2.getColor(i), "colour index " + i);
         }
+
+        // test exceptions
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.copyImageDataToPixelBuffer(null, uncompressedImageData));
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.copyImageDataToPixelBuffer(testImage, null));
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.copyImageDataToPixelBuffer(testImage, new int[0]));
+
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.estimatePalette(null, true, DEFAULT_PALETTE_COLOR_COUNT));
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.estimatePalette(null, w, h, true, DEFAULT_PALETTE_COLOR_COUNT));
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.estimatePalette(uncompressedImageData, w + 10, h, true, DEFAULT_PALETTE_COLOR_COUNT));
+        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.estimatePalette(uncompressedImageData, w + 10, h + 10, true, DEFAULT_PALETTE_COLOR_COUNT));
     }
 
     @Test
@@ -108,7 +177,7 @@ public class WriteFxImageTests {
         // convert to png
         final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
         final Map<String, Object> metaInfo = new HashMap<>();
-        final ByteBuffer pngOutReal = WriteFxImage.encode(imageOvals, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
+        final ByteBuffer pngOutReal = WriteFxImage.encodeAlt(imageOvals, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
         LOGGER.atDebug() //
                 .addArgument(metaInfo.get("width")) //
                 .addArgument(metaInfo.get("height")) //
@@ -130,7 +199,7 @@ public class WriteFxImageTests {
         assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
         assertEquals(0.02, (double) metaInfo.get("compression"), 0.02);
 
-        // Check that the array we preinitialized was actually used
+        // Check that the array we pre-initialized was actually used
         assertNotEquals(fillByte, byteArray[15]);
 
         // load from png
@@ -141,6 +210,133 @@ public class WriteFxImageTests {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("testWritingImageByteBufferProvider")
+    public void testWritingImageByteBuffer(final int testImageID, final boolean allocateNewBuffer, final boolean encodeRGBA, final int compressionLevel, final FilterType filterType) throws IOException {
+        // convert to png
+        final Image testImage = getTestImage(testImageID);
+
+        int w = (int) testImage.getWidth();
+        int h = (int) testImage.getHeight();
+        final int requiredSize = WriteFxImage.getCompressedSizeBound(w, h, encodeRGBA);
+        final ByteBuffer pngOutput = allocateNewBuffer ? ByteBuffer.allocate(requiredSize) : null;
+        final ByteBuffer pngOutReal = WriteFxImage.encode(testImage, pngOutput, encodeRGBA, compressionLevel, filterType);
+
+        if (allocateNewBuffer) {
+            // assert that the provided buffer was used
+            assertSame(pngOutput, pngOutReal);
+        } else {
+            // user supplied output must be null
+            assertNull(pngOutput);
+        }
+
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutReal.array(), pngOutReal.position(), pngOutReal.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            //assertImageEqual(testImage, recovered, encodeRGBA);
+            assertImageSimilar(testImage, recovered, /* threshold */ 0.0, encodeRGBA);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBuffer1x1() throws IOException {
+        // convert to png
+        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutReal = WriteFxImage.encodeAlt(image1x1, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        assertEquals(1, metaInfo.get("width"));
+        assertEquals(1, metaInfo.get("height"));
+        assertEquals("rgba", metaInfo.get("colorMode"));
+        assertEquals(100, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(133, metaInfo.get("outputSizeBound"));
+        assertEquals(1, metaInfo.get("compressionLevel"));
+        assertEquals(3, (double) metaInfo.get("compression"), 1.0);
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(image1x1, recovered);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testWritingImageByteBufferProvider")
+    public void testWritingImageByteBufferPalette(final int testImageID, final boolean allocateNewBuffer, final boolean encodeRGBA, final int compressionLevel, final FilterType filterType) throws IOException {
+        final Image testImage = getTestImage(testImageID);
+
+        int w = (int) testImage.getWidth();
+        int h = (int) testImage.getHeight();
+        // add in addition ~ 256*(3..4) bytes to store palette info
+        final int requiredSize = WriteFxImage.getCompressedSizeBound(w, h, encodeRGBA) + 256 * 4;
+        final ByteBuffer pngOutput = allocateNewBuffer ? ByteBuffer.allocate(requiredSize) : null;
+        final ByteBuffer pngOutReal = WriteFxImage.encodePalette(testImage, pngOutput, encodeRGBA, compressionLevel, filterType);
+
+        if (allocateNewBuffer) {
+            // assert that the provided buffer was used
+            assertSame(pngOutput, pngOutReal);
+        } else {
+            // user supplied output must be null
+            assertNull(pngOutput);
+        }
+
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutReal.array(), pngOutReal.position(), pngOutReal.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original with color threshold
+            assertImageSimilar(testImage, recovered, /* threshold */ 0.2, encodeRGBA);
+        }
+    }
+
+    @Test
+    public void testWritingImageByteBufferRandom() throws IOException {
+        // convert to png
+        int w = (int) imageRandom.getWidth();
+        int h = (int) imageRandom.getHeight();
+        final Map<String, Object> metaInfo = new HashMap<>();
+        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
+        final ByteBuffer pngOutReal = WriteFxImage.encodeAlt(imageRandom, pngOutput, true, Deflater.BEST_COMPRESSION,
+                metaInfo);
+        LOGGER.atDebug() //
+                .addArgument(metaInfo.get("width")) //
+                .addArgument(metaInfo.get("height")) //
+                .addArgument(metaInfo.get("colorMode")) //
+                .addArgument(metaInfo.get("compressionLevel")) //
+                .addArgument(metaInfo.get("bufferSize")) //
+                .addArgument(metaInfo.get("outputSize")) //
+                .addArgument(metaInfo.get("compression")) //
+                .addArgument(metaInfo.get("outputSizeBound")) //
+                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
+        // assert that the provided buffer was used
+        assertSame(pngOutput, pngOutReal);
+        assertEquals(w, metaInfo.get("width"));
+        assertEquals(h, metaInfo.get("height"));
+        assertEquals("rgba", metaInfo.get("colorMode"));
+        assertEquals(w * h * 4 + 100, (Integer) metaInfo.get("bufferSize"));
+        assertEquals(912095, metaInfo.get("outputSizeBound"));
+        assertEquals(9, metaInfo.get("compressionLevel"));
+        assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
+        assertEquals(0.21, (double) metaInfo.get("compression"), 0.02);
+        // load from png
+        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
+            final Image recovered = new Image(is);
+            // compare against original
+            assertImageEqual(imageRandom, recovered);
+        }
+    }
+
     @Test
     public void testWritingImageByteBufferRandomRbgNoCompression() throws IOException {
         // convert to png
@@ -148,7 +344,7 @@ public class WriteFxImageTests {
         int h = (int) imageOvals.getHeight();
         final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 3 + 1000);
         final Map<String, Object> metaInfo = new HashMap<>();
-        final ByteBuffer pngOutReal = WriteFxImage.encode(imageOvals, pngOutput, false, Deflater.NO_COMPRESSION,
+        final ByteBuffer pngOutReal = WriteFxImage.encodeAlt(imageOvals, pngOutput, false, Deflater.NO_COMPRESSION,
                 metaInfo);
         LOGGER.atDebug() //
                 .addArgument(metaInfo.get("width")) //
@@ -180,98 +376,105 @@ public class WriteFxImageTests {
     }
 
     @Test
-    public void testWritingImageByteBufferRandom() throws IOException {
+    public void testWritingImageToFile(@TempDir File tempDir) throws IOException {
+        File tmpfile = new File(tempDir.getPath() + "test.png");
         // convert to png
-        int w = (int) imageRandom.getWidth();
-        int h = (int) imageRandom.getHeight();
-        final Map<String, Object> metaInfo = new HashMap<>();
-        final ByteBuffer pngOutput = ByteBuffer.allocate(w * h * 4 + 100);
-        final ByteBuffer pngOutReal = WriteFxImage.encode(imageRandom, pngOutput, true, Deflater.BEST_COMPRESSION,
-                metaInfo);
-        LOGGER.atDebug() //
-                .addArgument(metaInfo.get("width")) //
-                .addArgument(metaInfo.get("height")) //
-                .addArgument(metaInfo.get("colorMode")) //
-                .addArgument(metaInfo.get("compressionLevel")) //
-                .addArgument(metaInfo.get("bufferSize")) //
-                .addArgument(metaInfo.get("outputSize")) //
-                .addArgument(metaInfo.get("compression")) //
-                .addArgument(metaInfo.get("outputSizeBound")) //
-                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
-        // assert that the provided buffer was used
-        assertSame(pngOutput, pngOutReal);
-        assertEquals(w, metaInfo.get("width"));
-        assertEquals(h, metaInfo.get("height"));
-        assertEquals("rgba", metaInfo.get("colorMode"));
-        assertEquals(w * h * 4 + 100, (Integer) metaInfo.get("bufferSize"));
-        assertEquals(912095, metaInfo.get("outputSizeBound"));
-        assertEquals(9, metaInfo.get("compressionLevel"));
-        assertTrue(w * h * 4 > (int) metaInfo.get("outputSize"));
-        assertEquals(0.21, (double) metaInfo.get("compression"), 0.02);
+        WriteFxImage.savePng(imageOvals, tmpfile);
         // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
-            final Image recovered = new Image(is);
+        try (InputStream is = new FileInputStream(tmpfile.getPath())) {
+            Image recovered = new Image(is);
             // compare against original
-            assertImageEqual(imageRandom, recovered);
+            assertImageEqual(imageOvals, recovered);
         }
     }
 
-    @Test
-    public void testWritingImageByteBuffer1x1() throws IOException {
-        // convert to png
-        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
-        final Map<String, Object> metaInfo = new HashMap<>();
-        final ByteBuffer pngOutReal = WriteFxImage.encode(image1x1, pngOutput, true, Deflater.BEST_SPEED, metaInfo);
-        LOGGER.atDebug() //
-                .addArgument(metaInfo.get("width")) //
-                .addArgument(metaInfo.get("height")) //
-                .addArgument(metaInfo.get("colorMode")) //
-                .addArgument(metaInfo.get("compressionLevel")) //
-                .addArgument(metaInfo.get("bufferSize")) //
-                .addArgument(metaInfo.get("outputSize")) //
-                .addArgument(metaInfo.get("compression")) //
-                .addArgument(metaInfo.get("outputSizeBound")) //
-                .log("Compressed Image ({}x{} {}) using compression level {} to image buffer (cap: {}, size: {}). compression rate: {}, outputSizeUpperBound: {}");
-        // assert that the provided buffer was used
-        assertSame(pngOutput, pngOutReal);
-        assertEquals(1, metaInfo.get("width"));
-        assertEquals(1, metaInfo.get("height"));
-        assertEquals("rgba", metaInfo.get("colorMode"));
-        assertEquals(100, (Integer) metaInfo.get("bufferSize"));
-        assertEquals(133, metaInfo.get("outputSizeBound"));
-        assertEquals(1, metaInfo.get("compressionLevel"));
-        assertEquals(3, (double) metaInfo.get("compression"), 1.0);
-        // load from png
-        try (final InputStream is = new ByteArrayInputStream(pngOutput.array(), pngOutput.position(), pngOutput.limit())) {
-            final Image recovered = new Image(is);
-            // compare against original
-            assertImageEqual(image1x1, recovered);
+    private Image getTestImage(final int testImageID) {
+        final Image testImage;
+        switch (testImageID) {
+        case 0:
+            testImage = imageOvals;
+            break;
+        case 1:
+            testImage = imageRandom;
+            break;
+        case 2:
+        default:
+            testImage = image1x1;
+            break;
+        }
+        return testImage;
+    }
+
+    public static double colorDistance(final int colorARGB1, final int colorARGB2, final boolean checkAlpha) {
+        final int deltaA = ((colorARGB1 & 0xff000000) >>> 24) - ((colorARGB2 & 0xff000000) >>> 24);
+        final int deltaR = ((colorARGB1 & 0x00ff0000) >>> 16) - ((colorARGB2 & 0x00ff0000) >>> 16);
+        final int deltaG = ((colorARGB1 & 0x0000ff00) >>> 8) - ((colorARGB2 & 0x0000ff00) >>> 8);
+        final int deltaB = ((colorARGB1 & 0xff)) - ((colorARGB2 & 0xff));
+
+        return (checkAlpha ? Math.sqrt((deltaA * deltaA) + (deltaR * deltaR) + (deltaG * deltaG) + (deltaB * deltaB)) / (4.0 * 255.0) //
+                           : Math.sqrt((deltaR * deltaR) + (deltaG * deltaG) + (deltaB * deltaB)))
+                / (3.0 * 255.0);
+    }
+
+    private static void assertImageEqual(final Image original, final Image recovered, final boolean... assertRGBA) {
+        final int w = (int) original.getWidth();
+        final int h = (int) original.getHeight();
+        assertEquals(w, recovered.getWidth());
+        assertEquals(h, recovered.getHeight());
+        if (assertRGBA.length == 0 || assertRGBA[0]) {
+            for (int x = 0; x < w; x++) {
+                for (int y = 0; y < h; y++) {
+                    assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
+                }
+            }
+        } else {
+            for (int x = 0; x < w; x++) {
+                for (int y = 0; y < h; y++) {
+                    assertEquals((original.getPixelReader().getArgb(x, y) << 8) >> 8, (recovered.getPixelReader().getArgb(x, y) << 8) >> 8);
+                }
+            }
         }
     }
 
-    @Test
-    public void testHelperFunctions() {
-        assertImageEqual(image1x1, WriteFxImage.clone(image1x1));
-        assertImageEqual(imageOvals, WriteFxImage.clone(imageOvals));
-        assertImageEqual(imageRandom, WriteFxImage.clone(imageRandom));
-    }
-
-    private static void assertImageEqual(Image original, Image recovered) {
+    private static void assertImageSimilar(final Image original, final Image recovered, final double threshold, final boolean checkAlpha) {
         final int w = (int) original.getWidth();
         final int h = (int) original.getHeight();
         assertEquals(w, recovered.getWidth());
         assertEquals(h, recovered.getHeight());
         for (int x = 0; x < w; x++) {
             for (int y = 0; y < h; y++) {
-                assertEquals(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y));
+                final double colorDistance = colorDistance(original.getPixelReader().getArgb(x, y), recovered.getPixelReader().getArgb(x, y), checkAlpha);
+                assertTrue(colorDistance <= threshold, "colour distance mismatch for pixel(" + x + ", " + y + ") = " + colorDistance);
             }
         }
     }
 
-    @Test
-    public void assertExceptions() {
-        final ByteBuffer pngOutput = ByteBuffer.allocate(100);
+    private static Stream<Arguments> testWritingImageByteBufferProvider() { // NOPMD -- is used in annotation /not detected by PMD
+        List<Arguments> argumentList = new ArrayList<>();
+        // N.B. limit to some selected sub-cases and not test all (full parameter space takes too much time for regular CI/CD checks
+        for (int testImageID : new int[] { 0, 1, 2 }) {
+            for (boolean encodeRGBA : new boolean[] { true, false }) {
+                argumentList.add(Arguments.arguments(testImageID, true, encodeRGBA, Deflater.NO_COMPRESSION, FilterType.FILTER_NONE));
+            }
+            for (boolean allocateNewBuffer : new boolean[] { true, false }) {
+                argumentList.add(Arguments.arguments(testImageID, allocateNewBuffer, true, Deflater.NO_COMPRESSION, FilterType.FILTER_NONE));
+            }
 
-        assertThrows(IllegalArgumentException.class, () -> WriteFxImage.encode(null, pngOutput, true, Deflater.BEST_SPEED, null));
+            // loop through compression levels
+            for (int compressionLevel : new int[] { Deflater.NO_COMPRESSION, Deflater.BEST_SPEED, Deflater.BEST_COMPRESSION }) {
+                argumentList.add(Arguments.arguments(testImageID, true, true, compressionLevel, FilterType.FILTER_NONE));
+            }
+
+            // loop through PNG line filter settings
+            for (FilterType filterType : new FilterType[] { FilterType.FILTER_NONE, FilterType.FILTER_PAETH }) {
+                if (!FilterType.isValidStandard(filterType)) {
+                    continue;
+                }
+                argumentList.add(Arguments.arguments(testImageID, true, true, Deflater.NO_COMPRESSION, filterType));
+            }
+        }
+
+        //return Stream.of("apple", "banana");
+        return Stream.of(argumentList.toArray(new Arguments[0]));
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ByteArrayCache.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ByteArrayCache.java
@@ -1,0 +1,79 @@
+package de.gsi.dataset.utils;
+
+import java.lang.ref.Reference;
+
+/**
+ * Implements byte-array (byte[]) cache collection to minimise memory re-allocation.
+ *  
+ * <p> 
+ * N.B. This is useful to re-use short-lived data storage container to minimise the amount of garbage to be collected. This is used in situation replacing e.g.
+ * <pre>
+ *  {@code
+ *      public returnValue frequentlyExecutedFunction(...) {
+ *          final byte[] storage = new byte[10000]; // allocate new memory block (costly)
+ *          // [...] do short-lived computation on storage
+ *          // storage is implicitly finalised by garbage collector (costly)
+ *      }
+ *  }
+ * </pre>
+ * with
+ * <pre>
+ *  {@code
+ *      // ...
+ *      private final ByteArrayCache cache = new ByteArrayCache();
+ *      // ...
+ *      
+ *      public returnValue frequentlyExecutedFunction(...) {
+ *          final byte[] storage = cache.getArray(10000); // return previously allocated array (cheap) or allocated new if necessary 
+ *          // [...] do short-lived computation on storage
+ *          cache.add(storage); // return object to cache
+ *      }
+ *  }
+ * </pre>
+ *  
+ * @author rstein
+ *
+ */
+public class ByteArrayCache extends CacheCollection<byte[]> {
+    public byte[] getArray(final int requiredSize) {
+        return getArray(requiredSize, false);
+    }
+
+    public byte[] getArrayExact(final int requiredSize) {
+        return getArray(requiredSize, true);
+    }
+
+    private byte[] getArray(final int requiredSize, final boolean exact) {
+        synchronized (contents) {
+            byte[] bestFit = null;
+            int bestFitSize = Integer.MAX_VALUE;
+
+            for (final Reference<byte[]> candidate : contents) {
+                final byte[] localRef = candidate.get();
+                if (localRef == null) {
+                    continue;
+                }
+
+                final int sizeDiff = localRef.length - requiredSize;
+                if (sizeDiff == 0) {
+                    bestFit = localRef;
+                    break;
+                }
+
+                if (sizeDiff > 0 && sizeDiff < bestFitSize && !exact) {
+                    bestFitSize = sizeDiff;
+                    bestFit = localRef;
+                }
+            }
+
+            if (bestFit == null) {
+                // could not find any cached, return new byte[]
+                bestFit = new byte[requiredSize];
+                return bestFit;
+            }
+
+            remove(bestFit);
+            return bestFit;
+        }
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ByteBufferOutputStream.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ByteBufferOutputStream.java
@@ -1,0 +1,119 @@
+package de.gsi.dataset.utils;
+
+import java.io.OutputStream;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * Wraps a {@link ByteBuffer} so it can be used like an {@link OutputStream}. This is similar to a
+ * {@link java.io.ByteArrayOutputStream}, just that this uses a {@code ByteBuffer} instead of a
+ * {@code byte[]} as internal storage.
+ */
+public class ByteBufferOutputStream extends OutputStream {
+    private ByteBuffer wrappedBuffer;
+    private final boolean autoEnlarge;
+
+    public ByteBufferOutputStream(final ByteBuffer wrappedBuffer, final boolean... autoEnlarge) {
+        this.wrappedBuffer = wrappedBuffer;
+        this.autoEnlarge = autoEnlarge.length > 0 && autoEnlarge[0];
+    }
+
+    public ByteBuffer buffer() {
+        return wrappedBuffer;
+    }
+
+    /**
+     * Increases the capacity to ensure that it can hold at least the number of elements specified
+     * by the minimum capacity argument.
+     *
+     * @param minCapacity the desired minimum capacity
+     */
+    private void growTo(final int minCapacity) {
+        final int oldCapacity = wrappedBuffer.capacity();
+        int newCapacity = oldCapacity << 1;
+        if (newCapacity - minCapacity < 0) {
+            newCapacity = minCapacity;
+        }
+        final ByteBuffer oldWrappedBuffer = wrappedBuffer;
+        // create the new buffer
+        if (wrappedBuffer.isDirect()) {
+            wrappedBuffer = ByteBuffer.allocateDirect(newCapacity);
+        } else {
+            wrappedBuffer = ByteBuffer.allocate(newCapacity);
+        }
+        // copy over the old content into the new buffer
+        oldWrappedBuffer.flip();
+        wrappedBuffer.put(oldWrappedBuffer);
+    }
+
+    @Override
+    public void write(final int bty) {
+        try {
+            wrappedBuffer.put((byte) bty);
+        } catch (final BufferOverflowException ex) {
+            if (autoEnlarge) {
+                final int newBufferSize = wrappedBuffer.capacity() * 2;
+                growTo(newBufferSize);
+                write(bty);
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    @Override
+    public void write(final byte[] bytes) {
+        int oldPosition = 0;
+        try {
+            oldPosition = wrappedBuffer.position();
+            wrappedBuffer.put(bytes);
+        } catch (final BufferOverflowException ex) {
+            if (autoEnlarge) {
+                final int newBufferSize
+                        = Math.max(wrappedBuffer.capacity() * 2, oldPosition + bytes.length);
+                growTo(newBufferSize);
+                write(bytes);
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    @Override
+    public void write(final byte[] bytes, final int off, final int len) {
+        int oldPosition = 0;
+        try {
+            oldPosition = wrappedBuffer.position();
+            wrappedBuffer.put(bytes, off, len);
+        } catch (final BufferOverflowException ex) {
+            if (autoEnlarge) {
+                final int newBufferSize
+                        = Math.max(wrappedBuffer.capacity() * 2, oldPosition + len);
+                growTo(newBufferSize);
+                write(bytes, off, len);
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    public void position(int i) {
+        if (i >= wrappedBuffer.capacity()) {
+            if (autoEnlarge) {
+                this.growTo(i);
+            } else {
+                throw new BufferOverflowException();
+            }
+        }
+
+        wrappedBuffer.position(i);
+    }
+
+    public int position() {
+        return wrappedBuffer.position();
+    }
+
+    public void write(ByteBuffer input) {
+        wrappedBuffer.put(input);
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/Cache.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/Cache.java
@@ -154,11 +154,13 @@ public class Cache<K, V> implements Map<K, V> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public V get(final Object key) {
-        return getIfPresent(key);
+        return getIfPresent((K) key);
     }
 
-    public V getIfPresent(final Object key) {
+    public V getIfPresent(final K key) {
+        timeOutMap.put(key, Instant.now());
         return dataCache.getOrDefault(key, null);
     }
 
@@ -194,6 +196,14 @@ public class Cache<K, V> implements Map<K, V> {
 
     @Override
     public V put(final K key, final V value) {
+        checkSize();
+        final V val = dataCache.put(key, value);
+        timeOutMap.put(key, Instant.now());
+        return val;
+    }
+
+    @Override
+    public V putIfAbsent(final K key, final V value) {
         checkSize();
         final V val = dataCache.putIfAbsent(key, value);
         timeOutMap.putIfAbsent(key, Instant.now());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/CacheCollection.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/CacheCollection.java
@@ -1,0 +1,148 @@
+package de.gsi.dataset.utils;
+
+import java.lang.ref.Reference;
+import java.lang.ref.SoftReference;
+import java.util.AbstractCollection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Implements collection of cache-able objects that can be used to store recurring storage container.
+ * <p>
+ * N.B. this implements only the backing cache of adding, removing, etc. elements. The cache object retrieval should be implemented in the derived class.
+ * See for example {@link de.gsi.dataset.utils.ByteArrayCache}. 
+ * 
+ * @author rstein
+ *
+ * @param <T> generic for object type to be cahced.
+ */
+public class CacheCollection<T> extends AbstractCollection<T> {
+    protected final List<Reference<T>> contents = Collections.synchronizedList(new LinkedList<>());
+
+    @Override
+    public boolean add(T recoveredObject) {
+        if (recoveredObject != null) {
+            synchronized (contents) {
+                if (contains(recoveredObject)) {
+                    return false;
+                }
+                // N.B. here: specific choice of using 'SoftReferene'
+                // derived classes may overwrite this function and replace this with e.g. WeakReferene or simialr
+                return contents.add(new SoftReference<T>(recoveredObject));
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        synchronized (contents) {
+            contents.clear();
+        }
+    }
+
+    @Override
+    public boolean contains(Object object) {
+        if (object != null) {
+            synchronized (contents) {
+                for (Reference<T> weakReference : contents) {
+                    if (object.equals(weakReference.get()))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        synchronized (contents) {
+            return new CacheCollectionIterator<>(contents.iterator());
+        }
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (o == null) {
+            return false;
+        }
+        synchronized (contents) {
+            Iterator<Reference<T>> iter = contents.iterator();
+            while (iter.hasNext()) {
+                final Reference<T> candidate = iter.next();
+                final T test = candidate.get();
+                if (test == null) {
+                    iter.remove();
+                    continue;
+                }
+                if (o.equals(test)) {
+                    iter.remove();
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int size() {
+        synchronized (contents) {
+            cleanup();
+            return contents.size();
+        }
+    }
+
+    protected void cleanup() {
+        synchronized (contents) {
+            List<Reference<T>> toRemove = new LinkedList<>();
+            for (Reference<T> weakReference : contents) {
+                if (weakReference.get() == null) {
+                    toRemove.add(weakReference);
+                }
+            }
+            contents.removeAll(toRemove);
+        }
+    }
+
+    private static class CacheCollectionIterator<T> implements Iterator<T> {
+        private final Iterator<Reference<T>> iterator;
+        private T next;
+
+        private CacheCollectionIterator(Iterator<Reference<T>> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (next != null) {
+                return true;
+            }
+            while (iterator.hasNext()) {
+                T t = iterator.next().get();
+                if (t != null) {
+                    // to ensure next() can't throw after hasNext() returned true, we need to dereference this
+                    next = t;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public T next() {
+            T result = next;
+            next = null;
+            while (result == null) {
+                result = iterator.next().get();
+            }
+            return result;
+        }
+
+        @Override
+        public void remove() {
+            iterator.remove();
+        }
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/CachedDaemonThreadFactory.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/CachedDaemonThreadFactory.java
@@ -7,10 +7,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public final class CachedDaemonThreadFactory implements ThreadFactory {
     private static final int MAX_THREADS = Math.max(4, Runtime.getRuntime().availableProcessors());
-    private static final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+    private static final ThreadFactory DEFAULT_FACTORY = Executors.defaultThreadFactory();
     private static final CachedDaemonThreadFactory SELF = new CachedDaemonThreadFactory();
     private static final ExecutorService COMMON_POOL = Executors.newFixedThreadPool(2 * MAX_THREADS, SELF);
-    private static final AtomicInteger threadCounter = new AtomicInteger();
+    private static final AtomicInteger TREAD_COUNTER = new AtomicInteger();
 
     private CachedDaemonThreadFactory() {
         // helper class
@@ -18,9 +18,9 @@ public final class CachedDaemonThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread thread = defaultFactory.newThread(r);
-        threadCounter.incrementAndGet();
-        thread.setName("daemonised_chartfx_thread_#" + threadCounter.intValue());
+        Thread thread = DEFAULT_FACTORY.newThread(r);
+        TREAD_COUNTER.incrementAndGet();
+        thread.setName("daemonised_chartfx_thread_#" + TREAD_COUNTER.intValue());
         thread.setDaemon(true);
         return thread;
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/SoftHashMap.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/SoftHashMap.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package de.gsi.dataset.utils;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A memory-constrained <code>SoftHashMap</code> that stores its <em>values</em> in {@link SoftReference}s.
+ *
+ * <p>
+ * N.B. JDK's {@link WeakHashMap}, which uses {@link java.lang.ref.WeakReference}s for 
+ * its <em>keys</em> rather than for its values. See {@link SoftKeyHashMap}
+ * for a {@link WeakHashMap}-similar implementation using SoftReference-ed keys.
+ *
+ * <p>
+ * Having the values wrapped by soft references allows the cache to automatically reduce its size based on memory
+ * limitations and garbage collection.  This ensures that the cache will not cause memory leaks by holding strong
+ * references to all of its values.
+ * <p>
+ * This implementation is thread-safe and usable in concurrent environments.
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ *
+ * @author Heinz Kabutz, original author <a href="http://www.javaspecialists.eu/archive/Issue015.html">public version</a>
+ * @author rstein, adapted to use within de.gsi.dataset
+ *
+ * @see SoftKeyHashMap
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public class SoftHashMap<K, V> implements Map<K, V> {
+    /**
+     * The default value of the RETENTION_SIZE attribute, equal to 100.
+     */
+    private static final int DEFAULT_RETENTION_SIZE = 100;
+
+    /**
+     * The internal HashMap that will hold the SoftReference.
+     */
+    private final Map<K, SoftValue<V, K>> map;
+
+    /**
+     * The number of strong references to hold internally, that is, the number of instances to prevent
+     * from being garbage collected automatically (unlike other soft references).
+     */
+    private final int retentionSize;
+
+    /**
+     * The FIFO list of strong references (not to be garbage collected), order of last access.
+     */
+    private final Queue<V> strongReferences; //guarded by 'strongReferencesLock'
+    private final ReentrantLock strongReferencesLock;
+
+    /**
+     * Reference queue for cleared SoftReference objects.
+     */
+    private final ReferenceQueue<? super V> queue;
+
+    /**
+     * Creates a new SoftHashMap with a default retention size size of
+     * {@link #DEFAULT_RETENTION_SIZE DEFAULT_RETENTION_SIZE} (100 entries).
+     *
+     * @see #SoftHashMap(int)
+     */
+    public SoftHashMap() {
+        this(DEFAULT_RETENTION_SIZE);
+    }
+
+    /**
+     * Creates a new SoftHashMap with the specified retention size.
+     * <p>
+     * The retention size (n) is the total number of most recent entries in the map that will be strongly referenced
+     * (ie 'retained') to prevent them from being eagerly garbage collected.  That is, the point of a SoftHashMap is to
+     * allow the garbage collector to remove as many entries from this map as it desires, but there will always be (n)
+     * elements retained after a GC due to the strong references.
+     * <p>
+     * Note that in a highly concurrent environments the exact total number of strong references may differ slightly
+     * than the actual <code>retentionSize</code> value.  This number is intended to be a best-effort retention low
+     * water mark.
+     *
+     * @param retentionSize the total number of most recent entries in the map that will be strongly referenced
+     *                      (retained), preventing them from being eagerly garbage collected by the JVM.
+     */
+    public SoftHashMap(final int retentionSize) {
+        super();
+        this.retentionSize = Math.max(0, retentionSize);
+        queue = new ReferenceQueue<>();
+        strongReferencesLock = new ReentrantLock();
+        map = new ConcurrentHashMap<>();
+        strongReferences = new ConcurrentLinkedQueue<>();
+    }
+
+    /**
+     * Creates a {@code SoftHashMap} backed by the specified {@code source}, with a default retention
+     * size of {@link #DEFAULT_RETENTION_SIZE} (100 entries).
+     *
+     * @param source the backing map to populate this {@code SoftHashMap}
+     * @see #SoftHashMap(Map,int)
+     */
+    public SoftHashMap(final Map<K, V> source) {
+        this(DEFAULT_RETENTION_SIZE);
+        putAll(source); // NOPMD - OK during class construction
+    }
+
+    /**
+     * Creates a {@code SoftHashMap} backed by the specified {@code source}, with the specified retention size.
+     * <p>
+     * The retention size (n) is the total number of most recent entries in the map that will be strongly referenced
+     * (ie 'retained') to prevent them from being eagerly garbage collected.  That is, the point of a SoftHashMap is to
+     * allow the garbage collector to remove as many entries from this map as it desires, but there will always be (n)
+     * elements retained after a GC due to the strong references.
+     * <p>
+     * Note that in a highly concurrent environments the exact total number of strong references may differ slightly
+     * than the actual <code>retentionSize</code> value.  This number is intended to be a best-effort retention low
+     * water mark.
+     *
+     * @param source        the backing map to populate this {@code SoftHashMap}
+     * @param retentionSize the total number of most recent entries in the map that will be strongly referenced
+     *                      (retained), preventing them from being eagerly garbage collected by the JVM.
+     */
+    public SoftHashMap(final Map<K, V> source, final int retentionSize) {
+        this(retentionSize);
+        putAll(source); // NOPMD - OK during class construction
+    }
+
+    @Override
+    public void clear() {
+        strongReferencesLock.lock();
+        try {
+            strongReferences.clear();
+        } finally {
+            strongReferencesLock.unlock();
+        }
+        processQueue(); // throw out garbage collected values
+        map.clear();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        processQueue();
+        return map.containsKey(key);
+    }
+
+    //Guarded by the strongReferencesLock in the addToStrongReferences method
+
+    @Override
+    public boolean containsValue(final Object value) {
+        processQueue();
+        final Collection<V> values = values();
+        return values != null && values.contains(value);
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        processQueue(); // throw out garbage collected values first
+        final Collection<K> keys = map.keySet();
+        if (keys.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Map<K, V> kvPairs = new ConcurrentHashMap<>(keys.size());
+        for (final K key : keys) {
+            final V v = get(key);
+            if (v != null) {
+                kvPairs.put(key, v);
+            }
+        }
+        return kvPairs.entrySet();
+    }
+
+    @Override
+    public V get(final Object key) {
+        processQueue();
+
+        V result = null;
+        final SoftValue<V, K> value = map.get(key);
+
+        if (value != null) {
+            //unwrap the 'real' value from the SoftReference
+            result = value.get();
+            if (result == null) {
+                //The wrapped value was garbage collected, so remove this entry from the backing map:
+                map.remove(key);
+            } else {
+                //Add this value to the beginning of the strong reference queue (FIFO).
+                addToStrongReferences(result);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        processQueue();
+        return map.isEmpty();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        processQueue();
+        return map.keySet();
+    }
+
+    /**
+     * Creates a new entry, but wraps the value in a SoftValue instance to enable auto garbage collection.
+     * @param key key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @return the previous value associated with {@code key}, or
+     *         {@code null} if there was no mapping for {@code key}.
+     *         (A {@code null} return can also indicate that the map
+     *         previously associated {@code null} with {@code key},
+     *         if the implementation supports {@code null} values.)
+     */
+    @Override
+    public V put(final K key, final V value) {
+        processQueue(); // throw out garbage collected values first
+        final SoftValue<V, K> sv = new SoftValue<>(value, key, queue);
+        final SoftValue<V, K> previous = map.put(key, sv);
+        addToStrongReferences(value);
+        return previous == null ? null : previous.get();
+    }
+
+    @Override
+    public void putAll(final Map<? extends K, ? extends V> m) {
+        if (m == null || m.isEmpty()) {
+            processQueue();
+            return;
+        }
+        for (final Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public V remove(final Object key) {
+        processQueue(); // throw out garbage collected values first
+        final SoftValue<V, K> raw = map.remove(key);
+        return raw == null ? null : raw.get();
+    }
+
+    @Override
+    public int size() {
+        processQueue(); // throw out garbage collected values first
+        return map.size();
+    }
+
+    @Override
+    public Collection<V> values() {
+        processQueue();
+        final Collection<K> keys = map.keySet();
+        if (keys.isEmpty()) {
+            return Collections.emptySet();
+        }
+        final Collection<V> values = new ArrayList<>(keys.size());
+        for (final K key : keys) {
+            final V v = get(key);
+            if (v != null) {
+                values.add(v);
+            }
+        }
+        return values;
+    }
+
+    private void addToStrongReferences(final V result) {
+        strongReferencesLock.lock();
+        try {
+            strongReferences.add(result);
+            trimStrongReferencesIfNecessary();
+        } finally {
+            strongReferencesLock.unlock();
+        }
+    }
+
+    /**
+     * Traverses the ReferenceQueue and removes garbage-collected SoftValue objects from the backing map
+     * by looking them up using the SoftValue.key data member.
+     */
+    @SuppressWarnings("unchecked")
+    private void processQueue() {
+        SoftValue<V, K> sv;
+        while ((sv = (SoftValue<V, K>) queue.poll()) != null) {
+            map.remove(sv.key); // we can access private data!
+        }
+    }
+
+    private void trimStrongReferencesIfNecessary() {
+        //trim the strong ref queue if necessary:
+        while (strongReferences.size() > retentionSize) {
+            strongReferences.poll();
+        }
+    }
+
+    /**
+     * We define our own subclass of SoftReference which contains
+     * not only the value but also the key to make it easier to find
+     * the entry in the HashMap after it's been garbage collected.
+     * @param <V> generics for value
+     * @param <K> generics for key
+     */
+    private static class SoftValue<V, K> extends SoftReference<V> {
+        private final K key;
+
+        /**
+         * Constructs a new instance, wrapping the value, key, and queue, as
+         * required by the superclass.
+         *
+         * @param value the map value
+         * @param key   the map key
+         * @param queue the soft reference queue to poll to determine if the entry had been reaped by the GC.
+         */
+        private SoftValue(final V value, final K key, final ReferenceQueue<? super V> queue) {
+            super(value, queue);
+            this.key = key;
+        }
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/SoftKeyHashMap.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/SoftKeyHashMap.java
@@ -1,0 +1,1349 @@
+/*
+ * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package de.gsi.dataset.utils;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * Hash table based implementation of the {@code Map} interface, with
+ * <em>weak (SoftReference) keys</em>.
+ * An entry in a {@code SoftHashMap} will automatically be removed when
+ * its key is no longer in ordinary use.  More precisely, the presence of a
+ * mapping for a given key will not prevent the key from being discarded by the
+ * garbage collector, that is, made finalizable, finalized, and then reclaimed.
+ * When a key has been discarded its entry is effectively removed from the map,
+ * so this class behaves somewhat differently from other {@code Map}
+ * implementations.
+ *
+ * <p> Both null values and the null key are supported. This class has
+ * performance characteristics similar to those of the {@code HashMap}
+ * class, and has the same efficiency parameters of <em>initial capacity</em>
+ * and <em>load factor</em>.
+ *
+ * <p> Like most collection classes, this class is not synchronized.
+ * A synchronized {@code SoftHashMap} may be constructed using the
+ * {@link java.util.Collections#synchronizedMap Collections.synchronizedMap}
+ * method.
+ *
+ * <p> This class is intended primarily for use with key objects whose
+ * {@code equals} methods test for object identity using the
+ * {@code ==} operator.  Once such a key is discarded it can never be
+ * recreated, so it is impossible to do a lookup of that key in a
+ * {@code SoftHashMap} at some later time and be surprised that its entry
+ * has been removed.  This class will work perfectly well with key objects
+ * whose {@code equals} methods are not based upon object identity, such
+ * as {@code String} instances.  With such recreatable key objects,
+ * however, the automatic removal of {@code SoftHashMap} entries whose
+ * keys have been discarded may prove to be confusing.
+ *
+ * <p> The behavior of the {@code SoftHashMap} class depends in part upon
+ * the actions of the garbage collector, so several familiar (though not
+ * required) {@code Map} invariants do not hold for this class.  Because
+ * the garbage collector may discard keys at any time, a
+ * {@code SoftHashMap} may behave as though an unknown thread is silently
+ * removing entries.  In particular, even if you synchronize on a
+ * {@code SoftHashMap} instance and invoke none of its mutator methods, it
+ * is possible for the {@code size} method to return smaller values over
+ * time, for the {@code isEmpty} method to return {@code false} and
+ * then {@code true}, for the {@code containsKey} method to return
+ * {@code true} and later {@code false} for a given key, for the
+ * {@code get} method to return a value for a given key but later return
+ * {@code null}, for the {@code put} method to return
+ * {@code null} and the {@code remove} method to return
+ * {@code false} for a key that previously appeared to be in the map, and
+ * for successive examinations of the key set, the value collection, and
+ * the entry set to yield successively smaller numbers of elements.
+ *
+ * <p> Each key object in a {@code SoftHashMap} is stored indirectly as
+ * the referent of a soft reference.  Therefore a key will automatically be
+ * removed only after the soft references to it, both inside and outside of the
+ * map, have been cleared by the garbage collector.
+ *
+ * <p> <strong>Implementation note:</strong> The value objects in a
+ * {@code SoftHashMap} are held by ordinary strong references.  Thus care
+ * should be taken to ensure that value objects do not strongly refer to their
+ * own keys, either directly or indirectly, since that will prevent the keys
+ * from being discarded.  Note that a value object may refer indirectly to its
+ * key via the {@code SoftHashMap} itself; that is, a value object may
+ * strongly refer to some other key object whose associated value object, in
+ * turn, strongly refers to the key of the first value object.  If the values
+ * in the map do not rely on the map holding strong references to them, one way
+ * to deal with this is to wrap values themselves within
+ * {@code SoftReferences} before
+ * inserting, as in: {@code m.put(key, new SoftReference(value))},
+ * and then unwrapping upon each {@code get}.
+ *
+ * <p>The iterators returned by the {@code iterator} method of the collections
+ * returned by all of this class's "collection view methods" are
+ * <i>fail-fast</i>: if the map is structurally modified at any time after the
+ * iterator is created, in any way except through the iterator's own
+ * {@code remove} method, the iterator will throw a {@link
+ * ConcurrentModificationException}.  Thus, in the face of concurrent
+ * modification, the iterator fails quickly and cleanly, rather than risking
+ * arbitrary, non-deterministic behavior at an undetermined time in the future.
+ *
+ * <p>Note that the fail-fast behavior of an iterator cannot be guaranteed
+ * as it is, generally speaking, impossible to make any hard guarantees in the
+ * presence of unsynchronized concurrent modification.  Fail-fast iterators
+ * throw {@code ConcurrentModificationException} on a best-effort basis.
+ * Therefore, it would be wrong to write a program that depended on this
+ * exception for its correctness:  <i>the fail-fast behavior of iterators
+ * should be used only to detect bugs.</i>
+ *
+ * <p>This class is a member of the
+ * <a href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
+ * Java Collections Framework</a>.
+ * @author Oracle,
+ * @author rstein, adapted to use within chart-fx
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ *
+ * @author      Doug Lea
+ * @author      Josh Bloch
+ * @author      Mark Reinhold
+ * @since       1.2
+ * @see         java.util.HashMap
+ * @see         java.lang.ref.SoftReference
+ */
+@SuppressWarnings("PMD")
+public class SoftKeyHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
+    /**
+     * The default initial capacity -- MUST be a power of two.
+     */
+    private static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+    /**
+     * The maximum capacity, used if a higher value is implicitly specified
+     * by either of the constructors with arguments.
+     * MUST be a power of two <= 1<<30.
+     */
+    private static final int MAXIMUM_CAPACITY = 1 << 30;
+
+    /**
+     * The load factor used when none specified in constructor.
+     */
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    /**
+     * Value representing null keys inside tables.
+     */
+    private static final Object NULL_KEY = new Object();
+
+    /**
+     * The table, resized as necessary. Length MUST Always be a power of two.
+     */
+    Entry<K, V>[] table;
+
+    /**
+     * The number of key-value mappings contained in this soft hash map.
+     */
+    private int size;
+
+    /**
+     * The next size value at which to resize (capacity * load factor).
+     */
+    private int threshold;
+
+    /**
+     * The load factor for the hash table.
+     */
+    private final float loadFactor;
+
+    /**
+     * Reference queue for cleared WeakEntries
+     */
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+
+    /**
+     * The number of times this SoftHashMap has been structurally modified.
+     * Structural modifications are those that change the number of
+     * mappings in the map or otherwise modify its internal structure
+     * (e.g., rehash).  This field is used to make iterators on
+     * Collection-views of the map fail-fast.
+     *
+     * @see ConcurrentModificationException
+     */
+    int modCount;
+
+    private transient Set<Map.Entry<K, V>> entrySet;
+
+    /**
+     * Constructs a new, empty {@code SoftHashMap} with the default initial
+     * capacity (16) and load factor (0.75).
+     */
+    public SoftKeyHashMap() {
+        this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Constructs a new, empty {@code SoftHashMap} with the given initial
+     * capacity and the default load factor (0.75).
+     *
+     * @param  initialCapacity The initial capacity of the {@code SoftHashMap}
+     * @throws IllegalArgumentException if the initial capacity is negative
+     */
+    public SoftKeyHashMap(final int initialCapacity) {
+        this(initialCapacity, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Constructs a new, empty {@code SoftHashMap} with the given initial
+     * capacity and the given load factor.
+     *
+     * @param  initialCapacity The initial capacity of the {@code SoftHashMap}
+     * @param  loadFactor      The load factor of the {@code SoftHashMap}
+     * @throws IllegalArgumentException if the initial capacity is negative,
+     *         or if the load factor is nonpositive.
+     */
+    public SoftKeyHashMap(int initialCapacity, final float loadFactor) {
+        if (initialCapacity < 0) {
+            throw new IllegalArgumentException("Illegal Initial Capacity: " + initialCapacity);
+        }
+        if (initialCapacity > MAXIMUM_CAPACITY) {
+            initialCapacity = MAXIMUM_CAPACITY;
+        }
+
+        if (loadFactor <= 0 || Float.isNaN(loadFactor)) {
+            throw new IllegalArgumentException("Illegal Load factor: " + loadFactor);
+        }
+        int capacity = 1;
+        while (capacity < initialCapacity) {
+            capacity <<= 1;
+        }
+        table = newTable(capacity);
+        this.loadFactor = loadFactor;
+        threshold = (int) (capacity * loadFactor);
+    }
+
+    // internal utilities
+
+    /**
+     * Constructs a new {@code SoftHashMap} with the same mappings as the
+     * specified map.  The {@code SoftHashMap} is created with the default
+     * load factor (0.75) and an initial capacity sufficient to hold the
+     * mappings in the specified map.
+     *
+     * @param   m the map whose mappings are to be placed in this map
+     * @throws  NullPointerException if the specified map is null
+     * @since   1.3
+     */
+    public SoftKeyHashMap(final Map<? extends K, ? extends V> m) {
+        this(Math.max((int) (m.size() / DEFAULT_LOAD_FACTOR) + 1,
+                     DEFAULT_INITIAL_CAPACITY),
+                DEFAULT_LOAD_FACTOR);
+        putAll(m);
+    }
+
+    /**
+     * Removes all of the mappings from this map.
+     * The map will be empty after this call returns.
+     */
+    @Override
+    public void clear() {
+        // clear out ref queue. We don't need to expunge entries
+        // since table is getting cleared.
+        while (queue.poll() != null) {
+            // nothing to do
+        }
+
+        modCount++;
+        Arrays.fill(table, null);
+        size = 0;
+
+        // Allocation of array may have caused GC, which may have caused
+        // additional entries to go stale.  Removing these entries from the
+        // reference queue will make them eligible for reclamation.
+        while (queue.poll() != null) {
+            // nothing to do
+        }
+    }
+
+    /**
+     * Returns {@code true} if this map contains a mapping for the
+     * specified key.
+     *
+     * @param  key   The key whose presence in this map is to be tested
+     * @return {@code true} if there is a mapping for {@code key};
+     *         {@code false} otherwise
+     */
+    @Override
+    public boolean containsKey(final Object key) {
+        return getEntry(key) != null;
+    }
+
+    /**
+     * Returns {@code true} if this map maps one or more keys to the
+     * specified value.
+     *
+     * @param value value whose presence in this map is to be tested
+     * @return {@code true} if this map maps one or more keys to the
+     *         specified value
+     */
+    @Override
+    public boolean containsValue(final Object value) {
+        if (value == null) {
+            return containsNullValue();
+        }
+
+        final Entry<K, V>[] tab = getTable();
+        for (int i = tab.length; i-- > 0;) {
+            for (Entry<K, V> e = tab[i]; e != null; e = e.next) {
+                if (value.equals(e.value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns a {@link Set} view of the mappings contained in this map.
+     * The set is backed by the map, so changes to the map are
+     * reflected in the set, and vice-versa.  If the map is modified
+     * while an iteration over the set is in progress (except through
+     * the iterator's own {@code remove} operation, or through the
+     * {@code setValue} operation on a map entry returned by the
+     * iterator) the results of the iteration are undefined.  The set
+     * supports element removal, which removes the corresponding
+     * mapping from the map, via the {@code Iterator.remove},
+     * {@code Set.remove}, {@code removeAll}, {@code retainAll} and
+     * {@code clear} operations.  It does not support the
+     * {@code add} or {@code addAll} operations.
+     */
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        final Set<Map.Entry<K, V>> es = entrySet;
+        return es != null ? es : (entrySet = new EntrySet());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void forEach(final BiConsumer<? super K, ? super V> action) {
+        Objects.requireNonNull(action);
+        final int expectedModCount = modCount;
+
+        final Entry<K, V>[] tab = getTable();
+        for (Entry<K, V> entry : tab) {
+            while (entry != null) {
+                final Object key = entry.get();
+                if (key != null) {
+                    action.accept((K) SoftKeyHashMap.unmaskNull(key), entry.value);
+                }
+                entry = entry.next;
+
+                if (expectedModCount != modCount) {
+                    throw new ConcurrentModificationException();
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the value to which the specified key is mapped,
+     * or {@code null} if this map contains no mapping for the key.
+     *
+     * <p>More formally, if this map contains a mapping from a key
+     * {@code k} to a value {@code v} such that
+     * {@code Objects.equals(key, k)},
+     * then this method returns {@code v}; otherwise
+     * it returns {@code null}.  (There can be at most one such mapping.)
+     *
+     * <p>A return value of {@code null} does not <i>necessarily</i>
+     * indicate that the map contains no mapping for the key; it's also
+     * possible that the map explicitly maps the key to {@code null}.
+     * The {@link #containsKey containsKey} operation may be used to
+     * distinguish these two cases.
+     *
+     * @see #put(Object, Object)
+     */
+    @Override
+    public V get(final Object key) {
+        final Object k = maskNull(key);
+        final int h = hash(k);
+        final Entry<K, V>[] tab = getTable();
+        final int index = indexFor(h, tab.length);
+        Entry<K, V> e = tab[index];
+        while (e != null) {
+            if (e.hash == h && eq(k, e.get())) {
+                return e.value;
+            }
+            e = e.next;
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if this map contains no key-value mappings.
+     * This result is a snapshot, and may not reflect unprocessed
+     * entries that will be removed before next attempted access
+     * because they are no longer referenced.
+     */
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * Associates the specified value with the specified key in this map.
+     * If the map previously contained a mapping for this key, the old
+     * value is replaced.
+     *
+     * @param key key with which the specified value is to be associated.
+     * @param value value to be associated with the specified key.
+     * @return the previous value associated with {@code key}, or
+     *         {@code null} if there was no mapping for {@code key}.
+     *         (A {@code null} return can also indicate that the map
+     *         previously associated {@code null} with {@code key}.)
+     */
+    @Override
+    public V put(final K key, final V value) {
+        if (key == null || value == null)
+            throw new NullPointerException();
+        final Object k = maskNull(key);
+        final int h = hash(k);
+        final Entry<K, V>[] tab = getTable();
+        final int i = indexFor(h, tab.length);
+
+        for (Entry<K, V> e = tab[i]; e != null; e = e.next) {
+            if (h == e.hash && eq(k, e.get())) {
+                final V oldValue = e.value;
+                if (value != oldValue) {
+                    e.value = value;
+                }
+                return oldValue;
+            }
+        }
+
+        modCount++;
+        final Entry<K, V> e = tab[i];
+        tab[i] = new Entry<>(k, value, queue, h, e);
+        if (++size >= threshold) {
+            resize(tab.length * 2);
+        }
+        return null;
+    }
+
+    /**
+     * Copies all of the mappings from the specified map to this map.
+     * These mappings will replace any mappings that this map had for any
+     * of the keys currently in the specified map.
+     *
+     * @param m mappings to be stored in this map.
+     * @throws  NullPointerException if the specified map is null.
+     */
+    @Override
+    public void putAll(final Map<? extends K, ? extends V> m) {
+        if (m == null) {
+            return;
+        }
+        final int numKeysToBeAdded = m.size();
+        if (numKeysToBeAdded == 0) {
+            return;
+        }
+
+        /*
+         * Expand the map if the map if the number of mappings to be added
+         * is greater than or equal to threshold.  This is conservative; the
+         * obvious condition is (m.size() + size) >= threshold, but this
+         * condition could result in a map with twice the appropriate capacity,
+         * if the keys to be added overlap with the keys already in this map.
+         * By using the conservative calculation, we subject ourself
+         * to at most one extra resize.
+         */
+        if (numKeysToBeAdded > threshold) {
+            int targetCapacity = (int) (numKeysToBeAdded / loadFactor + 1);
+            if (targetCapacity > MAXIMUM_CAPACITY) {
+                targetCapacity = MAXIMUM_CAPACITY;
+            }
+            int newCapacity = table.length;
+            while (newCapacity < targetCapacity) {
+                newCapacity <<= 1;
+            }
+            if (newCapacity > table.length) {
+                resize(newCapacity);
+            }
+        }
+
+        for (final Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+            put(e.getKey(), e.getValue());
+        }
+    }
+
+    /**
+     * Removes the mapping for a key from this soft hash map if it is present.
+     * More formally, if this map contains a mapping from key {@code k} to
+     * value {@code v} such that <code>(key==null ?  k==null :
+     * key.equals(k))</code>, that mapping is removed.  (The map can contain
+     * at most one such mapping.)
+     *
+     * <p>Returns the value to which this map previously associated the key,
+     * or {@code null} if the map contained no mapping for the key.  A
+     * return value of {@code null} does not <i>necessarily</i> indicate
+     * that the map contained no mapping for the key; it's also possible
+     * that the map explicitly mapped the key to {@code null}.
+     *
+     * <p>The map will not contain a mapping for the specified key once the
+     * call returns.
+     *
+     * @param key key whose mapping is to be removed from the map
+     * @return the previous value associated with {@code key}, or
+     *         {@code null} if there was no mapping for {@code key}
+     */
+    @Override
+    public V remove(final Object key) {
+        final Object k = maskNull(key);
+        final int h = hash(k);
+        final Entry<K, V>[] tab = getTable();
+        final int i = indexFor(h, tab.length);
+        Entry<K, V> prev = tab[i];
+        Entry<K, V> e = prev;
+
+        while (e != null) {
+            final Entry<K, V> next = e.next;
+            if (h == e.hash && eq(k, e.get())) {
+                modCount++;
+                size--;
+                if (prev == e) {
+                    tab[i] = next;
+                } else {
+                    prev.next = next;
+                }
+                return e.value;
+            }
+            prev = e;
+            e = next;
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void replaceAll(final BiFunction<? super K, ? super V, ? extends V> function) {
+        Objects.requireNonNull(function);
+        final int expectedModCount = modCount;
+
+        final Entry<K, V>[] tab = getTable();
+
+        for (Entry<K, V> entry : tab) {
+            while (entry != null) {
+                final Object key = entry.get();
+                if (key != null) {
+                    entry.value = function.apply((K) SoftKeyHashMap.unmaskNull(key), entry.value);
+                }
+                entry = entry.next;
+
+                if (expectedModCount != modCount) {
+                    throw new ConcurrentModificationException();
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the number of key-value mappings in this map.
+     * This result is a snapshot, and may not reflect unprocessed
+     * entries that will be removed before next attempted access
+     * because they are no longer referenced.
+     */
+    @Override
+    public int size() {
+        if (size == 0) {
+            return 0;
+        }
+        expungeStaleEntries();
+        return size;
+    }
+
+    /**
+     * @return true for containsValue with (to be evicted) null argument
+     */
+    private boolean containsNullValue() {
+        final Entry<K, V>[] tab = getTable();
+        for (int i = tab.length; i-- > 0;) {
+            for (Entry<K, V> e = tab[i]; e != null; e = e.next) {
+                if (e.value == null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Expunges stale entries from the table.
+     */
+    private void expungeStaleEntries() {
+        for (Object x; (x = queue.poll()) != null;) {
+            synchronized (queue) {
+                @SuppressWarnings("unchecked")
+                final Entry<K, V> e = (Entry<K, V>) x;
+                final int i = indexFor(e.hash, table.length);
+
+                Entry<K, V> prev = table[i];
+                Entry<K, V> p = prev;
+                while (p != null) {
+                    final Entry<K, V> next = p.next;
+                    if (p == e) {
+                        if (prev == e) {
+                            table[i] = next;
+                        } else {
+                            prev.next = next;
+                        }
+                        // Must not null out e.next;
+                        // stale entries may be in use by a HashIterator
+                        e.value = null; // Help GC
+                        size--;
+                        break;
+                    }
+                    prev = p;
+                    p = next;
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the table after first expunging stale entries.
+     * @return internal reference table
+     */
+    private Entry<K, V>[] getTable() {
+        expungeStaleEntries();
+        return table;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Entry<K, V>[] newTable(final int n) {
+        return (Entry<K, V>[]) new Entry<?, ?>[n];
+    }
+
+    /** Transfers all entries from src to dest tables
+     * @param src source entry
+     * @param dest destination entry
+     */
+    private void transfer(final Entry<K, V>[] src, final Entry<K, V>[] dest) {
+        for (int j = 0; j < src.length; ++j) {
+            Entry<K, V> e = src[j];
+            src[j] = null;
+            while (e != null) {
+                final Entry<K, V> next = e.next;
+                final Object key = e.get();
+                if (key == null) {
+                    e.next = null; // Help GC
+                    e.value = null; //  "   "
+                    size--;
+                } else {
+                    final int i = indexFor(e.hash, dest.length);
+                    e.next = dest[i];
+                    dest[i] = e;
+                }
+                e = next;
+            }
+        }
+    }
+
+    /**
+     * Returns the entry associated with the specified key in this map.
+     * Returns null if the map contains no mapping for this key.
+     * @param key the key
+     * @return entry for the given key
+     */
+    Entry<K, V> getEntry(final Object key) {
+        final Object k = maskNull(key);
+        final int h = hash(k);
+        final Entry<K, V>[] tab = getTable();
+        final int index = indexFor(h, tab.length);
+        Entry<K, V> e = tab[index];
+        while (e != null && (e.hash != h || !eq(k, e.get()))) {
+            e = e.next;
+        }
+        return e;
+    }
+
+    /**
+     * Retrieve object hash code and applies a supplemental hash function to the
+     * result hash, which defends against poor quality hash functions.  This is
+     * critical because HashMap uses power-of-two length hash tables, that
+     * otherwise encounter collisions for hashCodes that do not differ
+     * in lower bits.
+     * @param k key
+     * @return hash code for given key
+     */
+    final int hash(final Object k) {
+        int h = k.hashCode();
+
+        // This function ensures that hashCodes that differ only by
+        // constant multiples at each bit position have a bounded
+        // number of collisions (approximately 8 at default load factor).
+        h ^= h >>> 20 ^ h >>> 12;
+        return h ^ h >>> 7 ^ h >>> 4;
+    }
+
+    /* Special version of remove needed by Entry set */
+    boolean removeMapping(final Object o) {
+        if (!(o instanceof Map.Entry)) {
+            return false;
+        }
+        final Entry<K, V>[] tab = getTable();
+        final Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
+        final Object k = maskNull(entry.getKey());
+        final int h = hash(k);
+        final int i = indexFor(h, tab.length);
+        Entry<K, V> prev = tab[i];
+        Entry<K, V> e = prev;
+
+        while (e != null) {
+            final Entry<K, V> next = e.next;
+            if (h == e.hash && e.equals(entry)) {
+                modCount++;
+                size--;
+                if (prev == e) {
+                    tab[i] = next;
+                } else {
+                    prev.next = next;
+                }
+                return true;
+            }
+            prev = e;
+            e = next;
+        }
+
+        return false;
+    }
+
+    /**
+     * Rehashes the contents of this map into a new array with a
+     * larger capacity.  This method is called automatically when the
+     * number of keys in this map reaches its threshold.
+     *
+     * If current capacity is MAXIMUM_CAPACITY, this method does not
+     * resize the map, but sets threshold to Integer.MAX_VALUE.
+     * This has the effect of preventing future calls.
+     *
+     * @param newCapacity the new capacity, MUST be a power of two;
+     *        must be greater than current capacity unless current
+     *        capacity is MAXIMUM_CAPACITY (in which case value
+     *        is irrelevant).
+     */
+    void resize(final int newCapacity) {
+        final Entry<K, V>[] oldTable = getTable();
+        final int oldCapacity = oldTable.length;
+        if (oldCapacity == MAXIMUM_CAPACITY) {
+            threshold = Integer.MAX_VALUE;
+            return;
+        }
+
+        final Entry<K, V>[] newTable = newTable(newCapacity);
+        transfer(oldTable, newTable);
+        table = newTable;
+
+        /*
+         * If ignoring null elements and processing ref queue caused massive
+         * shrinkage, then restore old table.  This should be rare, but avoids
+         * unbounded expansion of garbage-filled tables.
+         */
+        if (size >= threshold / 2) {
+            threshold = (int) (newCapacity * loadFactor);
+        } else {
+            expungeStaleEntries();
+            transfer(newTable, oldTable);
+            table = oldTable;
+        }
+    }
+
+    /*
+     * Checks for equality of non-null reference x and possibly-null y.  By
+     * default uses Object.equals.
+     */
+    private static boolean eq(final Object x, final Object y) {
+        return x == y || x.equals(y);
+    }
+
+    /*
+     * Returns index for hash code h.
+     */
+    private static int indexFor(final int h, final int length) {
+        return h & length - 1;
+    }
+
+    /*
+     * Use NULL_KEY for key if it is null.
+     */
+    private static Object maskNull(final Object key) {
+        return key == null ? NULL_KEY : key;
+    }
+
+    /*
+     * Returns internal representation of null key back to caller as null.
+     */
+    static Object unmaskNull(final Object key) {
+        return key == NULL_KEY ? null : key;
+    }
+
+    /*
+     * The entries in this hash table extend SoftReference, using its main ref
+     * field as the key.
+     */
+    private static class Entry<K, V> extends SoftReference<Object> implements Map.Entry<K, V> {
+        V value;
+        final int hash;
+        Entry<K, V> next;
+
+        /*
+         * Creates new entry.
+         */
+        Entry(final Object key, final V value, final ReferenceQueue<Object> queue, final int hash, final Entry<K, V> next) {
+            super(key, queue);
+            this.value = value;
+            this.hash = hash;
+            this.next = next;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            final Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+            final K k1 = getKey();
+            final Object k2 = e.getKey();
+            if (k1 == k2 || k1 != null && k1.equals(k2)) {
+                final V v1 = getValue();
+                final Object v2 = e.getValue();
+                if (v1 == v2 || v1 != null && v1.equals(v2)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public K getKey() {
+            return (K) SoftKeyHashMap.unmaskNull(get());
+        }
+
+        @Override
+        public V getValue() {
+            return value;
+        }
+
+        @Override
+        public int hashCode() {
+            final K k = getKey();
+            final V v = getValue();
+            return Objects.hashCode(k) ^ Objects.hashCode(v);
+        }
+
+        @Override
+        public V setValue(final V newValue) {
+            final V oldValue = value;
+            value = newValue;
+            return oldValue;
+        }
+
+        @Override
+        public String toString() {
+            return getKey() + "=" + getValue();
+        }
+    }
+
+    // Views
+
+    private class EntryIterator extends HashIterator<Map.Entry<K, V>> {
+        @Override
+        public Map.Entry<K, V> next() {
+            return nextEntry();
+        }
+    }
+
+    private class EntrySet extends AbstractSet<Map.Entry<K, V>> {
+        @Override
+        public void clear() {
+            SoftKeyHashMap.this.clear();
+        }
+
+        @Override
+        public boolean contains(final Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            final Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+            final Entry<K, V> candidate = getEntry(e.getKey());
+            return candidate != null && candidate.equals(e);
+        }
+
+        @Override
+        public Iterator<Map.Entry<K, V>> iterator() {
+            return new EntryIterator();
+        }
+
+        @Override
+        public boolean remove(final Object o) {
+            return removeMapping(o);
+        }
+
+        @Override
+        public int size() {
+            return SoftKeyHashMap.this.size();
+        }
+
+        @Override
+        public Spliterator<Map.Entry<K, V>> spliterator() {
+            return new EntrySpliterator<>(SoftKeyHashMap.this, 0, -1, 0, 0);
+        }
+
+        @Override
+        public Object[] toArray() {
+            return deepCopy().toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(final T[] a) {
+            return deepCopy().toArray(a);
+        }
+
+        private List<Map.Entry<K, V>> deepCopy() {
+            final List<Map.Entry<K, V>> list = new ArrayList<>(size());
+            this.forEach((final Map.Entry<K, V> e) -> list.add(new AbstractMap.SimpleEntry<>(e)));
+            return list;
+        }
+    }
+
+    private abstract class HashIterator<T> implements Iterator<T> {
+        private int index;
+        private Entry<K, V> entry;
+        private Entry<K, V> lastReturned;
+        private int expectedModCount = modCount;
+
+        /**
+         * Strong reference needed to avoid disappearance of key
+         * between hasNext and next
+         */
+        private Object nextKey;
+
+        /**
+         * Strong reference needed to avoid disappearance of key
+         * between nextEntry() and any use of the entry
+         */
+        private Object currentKey;
+
+        HashIterator() {
+            index = isEmpty() ? 0 : table.length;
+        }
+
+        @Override
+        public boolean hasNext() {
+            final Entry<K, V>[] t = table;
+
+            while (nextKey == null) {
+                Entry<K, V> e = entry;
+                int i = index;
+                while (e == null && i > 0) {
+                    e = t[--i];
+                }
+                entry = e;
+                index = i;
+                if (e == null) {
+                    currentKey = null;
+                    return false;
+                }
+                nextKey = e.get(); // hold on to key in strong ref
+                if (nextKey == null) {
+                    entry = entry.next;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void remove() {
+            if (lastReturned == null) {
+                throw new IllegalStateException();
+            }
+            if (modCount != expectedModCount) {
+                throw new ConcurrentModificationException();
+            }
+
+            SoftKeyHashMap.this.remove(currentKey);
+            expectedModCount = modCount;
+            lastReturned = null;
+            currentKey = null;
+        }
+
+        /** The common parts of next() across different types of iterators
+         * @return next entry if available
+         * @throws ConcurrentModificationException in case of concurrent modification
+         * @throws NoSuchElementException if there is no next elements (N.B. should be called only after {@link #hasNext()})
+         */
+        protected Entry<K, V> nextEntry() {
+            if (modCount != expectedModCount) {
+                throw new ConcurrentModificationException();
+            }
+            if (nextKey == null && !hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            lastReturned = entry;
+            entry = entry.next;
+            currentKey = nextKey;
+            nextKey = null;
+            return lastReturned;
+        }
+    }
+
+    static final class EntrySpliterator<K, V>
+            extends SoftHashMapSpliterator<K, V>
+            implements Spliterator<Map.Entry<K, V>> {
+        EntrySpliterator(final SoftKeyHashMap<K, V> m, final int origin, final int fence, final int est,
+                final int expectedModCount) {
+            super(m, origin, fence, est, expectedModCount);
+        }
+
+        @Override
+        public int characteristics() {
+            return Spliterator.DISTINCT;
+        }
+
+        @Override
+        public void forEachRemaining(final Consumer<? super Map.Entry<K, V>> action) {
+            int i;
+            int hi;
+            final int mc;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap<K, V> m = map;
+            final SoftKeyHashMap.Entry<K, V>[] tab = m.table;
+            if ((hi = fence) < 0) {
+                mc = expectedModCount = m.modCount;
+                hi = fence = tab.length;
+            } else {
+                mc = expectedModCount;
+            }
+            if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+                SoftKeyHashMap.Entry<K, V> p = current;
+                current = null; // exhaust
+                do {
+                    if (p == null) {
+                        p = tab[i++];
+                    } else {
+                        final Object x = p.get();
+                        final V v = p.value;
+                        p = p.next;
+                        if (x != null) {
+                            @SuppressWarnings("unchecked")
+                            final
+                                    K k
+                                    = (K) SoftKeyHashMap.unmaskNull(x);
+                            action.accept(new AbstractMap.SimpleImmutableEntry<>(k, v));
+                        }
+                    }
+                } while (p != null || i < hi);
+            }
+            if (m.modCount != mc) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super Map.Entry<K, V>> action) {
+            final int hi;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap.Entry<K, V>[] tab = map.table;
+            if (tab.length >= (hi = getFence()) && index >= 0) {
+                while (current != null || index < hi) {
+                    if (current == null) {
+                        current = tab[index++];
+                    } else {
+                        final Object x = current.get();
+                        final V v = current.value;
+                        current = current.next;
+                        if (x != null) {
+                            @SuppressWarnings("unchecked")
+                            final
+                                    K k
+                                    = (K) SoftKeyHashMap.unmaskNull(x);
+                            action.accept(new AbstractMap.SimpleImmutableEntry<>(k, v));
+                            if (map.modCount != expectedModCount) {
+                                throw new ConcurrentModificationException();
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public EntrySpliterator<K, V> trySplit() {
+            final int hi = getFence();
+            final int lo = index;
+            final int mid = lo + hi >>> 1;
+            return lo >= mid ? null : new EntrySpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+        }
+    }
+
+    static final class KeySpliterator<K, V>
+            extends SoftHashMapSpliterator<K, V>
+            implements Spliterator<K> {
+        KeySpliterator(final SoftKeyHashMap<K, V> m, final int origin, final int fence, final int est,
+                final int expectedModCount) {
+            super(m, origin, fence, est, expectedModCount);
+        }
+
+        @Override
+        public int characteristics() {
+            return Spliterator.DISTINCT;
+        }
+
+        @Override
+        public void forEachRemaining(final Consumer<? super K> action) {
+            int i;
+            int hi;
+            final int mc;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap<K, V> m = map;
+            final SoftKeyHashMap.Entry<K, V>[] tab = m.table;
+            if ((hi = fence) < 0) {
+                mc = expectedModCount = m.modCount;
+                hi = fence = tab.length;
+            } else {
+                mc = expectedModCount;
+            }
+            if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+                SoftKeyHashMap.Entry<K, V> p = current;
+                current = null; // exhaust
+                do {
+                    if (p == null) {
+                        p = tab[i++];
+                    } else {
+                        final Object x = p.get();
+                        p = p.next;
+                        if (x != null) {
+                            @SuppressWarnings("unchecked")
+                            final
+                                    K k
+                                    = (K) SoftKeyHashMap.unmaskNull(x);
+                            action.accept(k);
+                        }
+                    }
+                } while (p != null || i < hi);
+            }
+            if (m.modCount != mc) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super K> action) {
+            final int hi;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap.Entry<K, V>[] tab = map.table;
+            if (tab.length >= (hi = getFence()) && index >= 0) {
+                while (current != null || index < hi) {
+                    if (current == null) {
+                        current = tab[index++];
+                    } else {
+                        final Object x = current.get();
+                        current = current.next;
+                        if (x != null) {
+                            @SuppressWarnings("unchecked")
+                            final
+                                    K k
+                                    = (K) SoftKeyHashMap.unmaskNull(x);
+                            action.accept(k);
+                            if (map.modCount != expectedModCount) {
+                                throw new ConcurrentModificationException();
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public KeySpliterator<K, V> trySplit() {
+            final int hi = getFence();
+            final int lo = index;
+            final int mid = lo + hi >>> 1;
+            return lo >= mid ? null : new KeySpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+        }
+    }
+
+    /**
+     * Similar form as other hash Spliterators, but skips dead
+     * elements.
+     * @param <K> generics for key
+     * @param <V> generics for value
+     */
+    static class SoftHashMapSpliterator<K, V> {
+        final SoftKeyHashMap<K, V> map;
+        SoftKeyHashMap.Entry<K, V> current; // current node
+        int index; // current index, modified on advance/split
+        int fence; // -1 until first use; then one past last index
+        int est; // size estimate
+        int expectedModCount; // for comodification checks
+
+        SoftHashMapSpliterator(final SoftKeyHashMap<K, V> m, final int origin,
+                final int fence, final int est,
+                final int expectedModCount) {
+            this.map = m;
+            this.index = origin;
+            this.fence = fence;
+            this.est = est;
+            this.expectedModCount = expectedModCount;
+        }
+
+        public final long estimateSize() {
+            getFence(); // force init
+            return est;
+        }
+
+        final int getFence() { // initialize fence and size on first use
+            int hi;
+            if ((hi = fence) < 0) {
+                final SoftKeyHashMap<K, V> m = map;
+                est = m.size();
+                expectedModCount = m.modCount;
+                hi = fence = m.table.length;
+            }
+            return hi;
+        }
+    }
+
+    static final class ValueSpliterator<K, V>
+            extends SoftHashMapSpliterator<K, V>
+            implements Spliterator<V> {
+        ValueSpliterator(final SoftKeyHashMap<K, V> m, final int origin, final int fence, final int est,
+                final int expectedModCount) {
+            super(m, origin, fence, est, expectedModCount);
+        }
+
+        @Override
+        public int characteristics() {
+            return 0;
+        }
+
+        @Override
+        public void forEachRemaining(final Consumer<? super V> action) {
+            int i;
+            int hi;
+            final int mc;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap<K, V> m = map;
+            final SoftKeyHashMap.Entry<K, V>[] tab = m.table;
+            if ((hi = fence) < 0) {
+                mc = expectedModCount = m.modCount;
+                hi = fence = tab.length;
+            } else {
+                mc = expectedModCount;
+            }
+            if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+                SoftKeyHashMap.Entry<K, V> p = current;
+                current = null; // exhaust
+                do {
+                    if (p == null) {
+                        p = tab[i++];
+                    } else {
+                        final Object x = p.get();
+                        final V v = p.value;
+                        p = p.next;
+                        if (x != null) {
+                            action.accept(v);
+                        }
+                    }
+                } while (p != null || i < hi);
+            }
+            if (m.modCount != mc) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super V> action) {
+            final int hi;
+            if (action == null) {
+                throw new NullPointerException();
+            }
+            final SoftKeyHashMap.Entry<K, V>[] tab = map.table;
+            if (tab.length >= (hi = getFence()) && index >= 0) {
+                while (current != null || index < hi) {
+                    if (current == null) {
+                        current = tab[index++];
+                    } else {
+                        final Object x = current.get();
+                        final V v = current.value;
+                        current = current.next;
+                        if (x != null) {
+                            action.accept(v);
+                            if (map.modCount != expectedModCount) {
+                                throw new ConcurrentModificationException();
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public ValueSpliterator<K, V> trySplit() {
+            final int hi = getFence();
+            final int lo = index;
+            final int mid = lo + hi >>> 1;
+            return lo >= mid ? null : new ValueSpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+        }
+    }
+}

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/ByteArrayCacheTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/ByteArrayCacheTests.java
@@ -1,0 +1,173 @@
+package de.gsi.dataset.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * Tests implementation of {@link de.gsi.dataset.utils.ByteArrayCache} as well as implicitly {@link de.gsi.dataset.utils.CacheCollection}.
+ * 
+ * @author rstein
+ *
+ *         N.B. to run manually: javac ByteArrayCacheTests.java java -Xms256m
+ *         -Xmx256m ByteArrayCacheTests
+ */
+public class ByteArrayCacheTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ByteArrayCacheTests.class);
+    private static final int N_ITERATIONS = 1000;
+    private static final int N_INITIAL_CACHE_OBJECTS = 10;
+    private static final int N_CACHE_ARRAY_SIZE = 10_000_000;
+
+    @Test
+    public void testBasicFunction() {
+        final ByteArrayCache cache = new ByteArrayCache();
+        assertEquals(0, cache.size(), "initial cache size");
+
+        for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
+            cache.add(new byte[N_CACHE_ARRAY_SIZE]);
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
+
+        // force release of SoftReferences (should work fine starting with > JDK11, JDK
+        // < may need VM parameter: `-XX:SoftRefLRUPolicyMSPerMB=0`
+        forceMemoryShortage();
+        assertEquals(0, cache.size(), "zero-ing memory and SoftReferenes");
+
+        cache.add(new byte[N_CACHE_ARRAY_SIZE - 10]);
+        cache.add(new byte[N_CACHE_ARRAY_SIZE]);
+        cache.add(new byte[N_CACHE_ARRAY_SIZE + 10]);
+        cache.add(new byte[N_CACHE_ARRAY_SIZE + 5]);
+        assertEquals(4, cache.size());
+
+        assertEquals(N_CACHE_ARRAY_SIZE, cache.getArray(N_CACHE_ARRAY_SIZE).length);
+        assertEquals(3, cache.size());
+        assertEquals(N_CACHE_ARRAY_SIZE + 5, cache.getArray(N_CACHE_ARRAY_SIZE).length);
+        assertEquals(2, cache.size());
+
+        assertEquals(N_CACHE_ARRAY_SIZE, cache.getArrayExact(N_CACHE_ARRAY_SIZE).length);
+        assertEquals(2, cache.size());
+
+        cache.clear();
+        assertEquals(0, cache.size());
+
+        // prevent adding twice
+        final byte[] array = new byte[1000];
+        assertFalse(cache.contains(array));
+        assertTrue(cache.add(array));
+        assertTrue(cache.contains(array));
+        assertFalse(cache.add(array));
+
+        // check null safe-guard
+        assertFalse(cache.add(null));
+        assertFalse(cache.contains(null));
+        assertFalse(cache.remove(null));
+
+        // remove non-existent byte array
+        assertFalse(cache.remove(new byte[1]));
+    }
+
+    @Test
+    public void testIterators() {
+        final ByteArrayCache cache = new ByteArrayCache();
+        assertEquals(0, cache.size(), "initial cache size");
+
+        for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
+            cache.add(new byte[1000]);
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
+
+        final java.util.Iterator<byte[]> iter = cache.iterator();
+        int count = 0;
+        while (iter.hasNext()) {
+            final byte[] element = iter.next();
+            if (count == 0 || element == null) {
+                iter.remove();
+            }
+            count++;
+        }
+        assertEquals(N_INITIAL_CACHE_OBJECTS, count);
+    }
+
+    private static void forceMemoryShortage() {
+        boolean run = true;
+        List<byte[]> strongReference = Collections.synchronizedList(new ArrayList<>(100000));
+
+        while (run) {
+            try {
+                strongReference.add(new byte[10_000_000]);
+            } catch (final OutOfMemoryError e) {
+                run = false;
+            }
+        }
+
+        // to be garbage collected
+        strongReference = null;
+        Runtime.getRuntime().gc();
+        Runtime.getRuntime().gc();
+    }
+
+    private static double performanceCheckCached() {
+        final ByteArrayCache cache = new ByteArrayCache();
+        cache.add(new byte[N_CACHE_ARRAY_SIZE]);
+
+        final long start = System.nanoTime();
+        for (int i = 0; i < N_ITERATIONS; i++) {
+            byte[] array = cache.getArray(N_CACHE_ARRAY_SIZE);
+
+            // simple check to minimise JIT optimisations
+            if (array[0] != 0.0 || array.length != N_CACHE_ARRAY_SIZE) {
+                throw new IllegalStateException("should not occur");
+            }
+
+            cache.add(array);
+            array = null;
+        }
+
+        final long stop = System.nanoTime();
+
+        return (stop - start) / (double) N_ITERATIONS;
+    }
+
+    private static double performanceCheckClassic() {
+        final long start = System.nanoTime();
+        for (int i = 0; i < N_ITERATIONS; i++) {
+            byte[] array = new byte[N_CACHE_ARRAY_SIZE];
+
+            // simple check to minimise JIT optimisations
+            if (array[0] != 0.0 || array.length != N_CACHE_ARRAY_SIZE) {
+                throw new IllegalStateException("should not occur");
+            }
+
+            array = null;
+        }
+
+        final long stop = System.nanoTime();
+
+        return (stop - start) / (double) N_ITERATIONS;
+    }
+
+    public static void main(String[] args) {
+        final ByteArrayCacheTests test = new ByteArrayCacheTests();
+
+        test.testBasicFunction();
+        final double mem1 = Runtime.getRuntime().totalMemory();
+        final double classic = performanceCheckClassic();
+        final double mem2 = Runtime.getRuntime().totalMemory();
+        final double cached = performanceCheckCached();
+        final double mem3 = Runtime.getRuntime().totalMemory();
+        LOGGER.atInfo().addArgument(classic).addArgument(cached).log("ByteArrayCache performance difference: {} ns (classic) vs. {} ns (cached)");
+        LOGGER.atInfo().addArgument(classic / cached * 100.0).log("ByteArrayCache performance difference: {}& (classic/cached)");
+        LOGGER.atInfo().addArgument(mem1).log("memory before: {} Bytes");
+        LOGGER.atInfo().addArgument(mem2).log("after classic: {} Bytes");
+        LOGGER.atInfo().addArgument(mem3).log("after cached:  {} Bytes");
+    }
+}

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/ByteBufferOutputStreamTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/ByteBufferOutputStreamTests.java
@@ -1,0 +1,102 @@
+package de.gsi.dataset.utils;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ByteBufferOutputStreamTests {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testExpandByteBufferOnPositionIncrease(final boolean directBuffer) throws Exception {
+        final ByteBuffer initialBuffer = directBuffer ? ByteBuffer.allocateDirect(16) : ByteBuffer.allocate(16);
+        ByteBufferOutputStream output = new ByteBufferOutputStream(initialBuffer, true);
+        output.write("hello".getBytes());
+        output.position(32);
+        assertEquals(32, output.position());
+        assertEquals(5, initialBuffer.position());
+
+        ByteBuffer buffer = output.buffer();
+        assertEquals(32, buffer.limit());
+        buffer.position(0);
+        buffer.limit(5);
+        byte[] bytes = new byte[5];
+        buffer.get(bytes);
+        assertArrayEquals("hello".getBytes(), bytes);
+        output.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testExpandByteBufferOnWrite(final boolean directBuffer) throws Exception {
+        final ByteBuffer initialBuffer = directBuffer ? ByteBuffer.allocateDirect(16) : ByteBuffer.allocate(16);
+        ByteBufferOutputStream output = new ByteBufferOutputStream(initialBuffer, true);
+        output.write("Hello".getBytes());
+        output.write(new byte[27]);
+        assertEquals(32, output.position());
+        assertEquals(5, initialBuffer.position());
+
+        ByteBuffer buffer = output.buffer();
+        assertEquals(32, buffer.limit());
+        buffer.position(0);
+        buffer.limit(5);
+        byte[] bytes = new byte[5];
+        buffer.get(bytes);
+        assertArrayEquals("Hello".getBytes(), bytes);
+
+        buffer.rewind();
+        output.close();
+    }
+
+    @Test
+    public void testWriteByte() throws IOException {
+        ByteBufferOutputStream output = new ByteBufferOutputStream(ByteBuffer.allocate(1), true);
+        final byte[] secondMsg = "Hello World!".getBytes();
+        for (int byt : secondMsg) {
+            output.write(byt);
+        }
+        output.buffer().position(0);
+        output.buffer().limit(12);
+
+        // read result
+        byte[] bytes = new byte[12];
+        output.buffer().get(bytes);
+        assertArrayEquals(secondMsg, bytes);
+        output.buffer().rewind();
+
+        output.write(secondMsg, 0, secondMsg.length);
+        output.write(secondMsg, 0, secondMsg.length);
+
+        output.buffer().position(0);
+        output.buffer().limit(24);
+
+        // read result
+        output.buffer().get(bytes);
+        assertArrayEquals(secondMsg, bytes);
+        output.buffer().get(bytes);
+        assertArrayEquals(secondMsg, bytes);
+
+        output.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testWriteByteBuffer(final boolean directBuffer) throws Exception {
+        final ByteBuffer initialBuffer = directBuffer ? ByteBuffer.allocateDirect(16) : ByteBuffer.allocate(16);
+        long value = 234239230L;
+        initialBuffer.putLong(value);
+        initialBuffer.flip();
+
+        ByteBufferOutputStream output = new ByteBufferOutputStream(ByteBuffer.allocate(32));
+        output.write(initialBuffer);
+        assertEquals(8, initialBuffer.position());
+        assertEquals(8, output.position());
+        assertEquals(value, output.buffer().getLong(0));
+        output.close();
+    }
+}

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/CacheTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/CacheTests.java
@@ -2,6 +2,7 @@ package de.gsi.dataset.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,33 +61,6 @@ public class CacheTests {
         assertFalse(isCached(cache, name1), "check after 500 ms");
         assertTrue(preListenerCalled.get());
         assertTrue(postListenerCalled.get());
-    }
-
-    private boolean isCached(Cache cache, final String KEY) {
-        return cache.getOptional(KEY).isPresent();
-    }
-
-    @Test
-    public void testHelperMethods() {
-        // TimeUnit to ChronoUnit conversions
-        for (TimeUnit timeUnit : TimeUnit.values()) {
-            ChronoUnit chronoUnit = Cache.convertToChronoUnit(timeUnit);
-            // timeUnit.toChronoUnit() would be faster but exists only since Java 9
-
-            long nanoTimeUnit = timeUnit.toNanos(1);
-            long nanoChrono = chronoUnit.getDuration().getNano() + 1000000000 * chronoUnit.getDuration().getSeconds();
-            assertEquals(nanoTimeUnit, nanoChrono, "ChronoUnit =" + chronoUnit);
-        }
-
-        // test clamp(int ... ) routine
-        assertEquals(1, Cache.clamp(1, 3, 0));
-        assertEquals(2, Cache.clamp(1, 3, 2));
-        assertEquals(3, Cache.clamp(1, 3, 4));
-
-        // test clamp(long ... ) routine
-        assertEquals(1l, Cache.clamp(1l, 3l, 0l));
-        assertEquals(2l, Cache.clamp(1l, 3l, 2l));
-        assertEquals(3l, Cache.clamp(1l, 3l, 4l));
     }
 
     @Test
@@ -207,5 +181,44 @@ public class CacheTests {
         });
 
         // Cache cache4 = Cache.builder().withLimit(20).withTimeout(100, TimeUnit.MILLISECONDS).build();
+    }
+
+    @Test
+    public void testHelperMethods() {
+        // TimeUnit to ChronoUnit conversions
+        for (TimeUnit timeUnit : TimeUnit.values()) {
+            ChronoUnit chronoUnit = Cache.convertToChronoUnit(timeUnit);
+            // timeUnit.toChronoUnit() would be faster but exists only since Java 9
+
+            long nanoTimeUnit = timeUnit.toNanos(1);
+            long nanoChrono = chronoUnit.getDuration().getNano() + 1000000000 * chronoUnit.getDuration().getSeconds();
+            assertEquals(nanoTimeUnit, nanoChrono, "ChronoUnit =" + chronoUnit);
+        }
+
+        // test clamp(int ... ) routine
+        assertEquals(1, Cache.clamp(1, 3, 0));
+        assertEquals(2, Cache.clamp(1, 3, 2));
+        assertEquals(3, Cache.clamp(1, 3, 4));
+
+        // test clamp(long ... ) routine
+        assertEquals(1l, Cache.clamp(1l, 3l, 0l));
+        assertEquals(2l, Cache.clamp(1l, 3l, 2l));
+        assertEquals(3l, Cache.clamp(1l, 3l, 4l));
+    }
+
+    @Test
+    public void testPutVariants() {
+        Cache<String, Integer> cache = Cache.<String, Integer>builder().withLimit(3).build();
+
+        assertNull(cache.put("key", 2));
+        assertEquals(2, cache.put("key", 3));
+        assertEquals(3, cache.putIfAbsent("key", 4));
+        cache.clear();
+        assertNull(cache.putIfAbsent("key", 4));
+        assertEquals(4, cache.putIfAbsent("key", 5));
+    }
+
+    private boolean isCached(Cache cache, final String KEY) {
+        return cache.getOptional(KEY).isPresent();
     }
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/SoftHashMapTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/SoftHashMapTests.java
@@ -1,0 +1,210 @@
+package de.gsi.dataset.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Contains usage illustrations and tests for {@link SoftHashMap} and {@link SoftKeyHashMap}
+ *
+ * @author rstein
+ */
+public class SoftHashMapTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SoftHashMapTests.class);
+    private static final int N_ENTRIES = 100;
+    private static final int DEFAULT_ARRAY_SIZE = 10_000;
+
+    // @Test // N.B. also covered by other tests
+    public void basicTests() {
+        testMap(new HashMap<String, byte[]>(2));
+        testMap(new WeakHashMap<String, byte[]>(2));
+        testMap(new SoftHashMap<String, byte[]>(2));
+        testMap(new SoftKeyHashMap<String, byte[]>(2));
+    }
+
+    @Test
+    public void constructorTests() {
+        final HashMap<String, byte[]> test = new HashMap<>();
+        initMap(test, 2);
+
+        assertDoesNotThrow(() -> new SoftHashMap<>());
+        assertDoesNotThrow(() -> new SoftHashMap<>(2));
+        assertDoesNotThrow(() -> new SoftHashMap<>(test));
+        assertDoesNotThrow(() -> new SoftHashMap<>(test, 3));
+
+        assertDoesNotThrow(() -> new SoftKeyHashMap<>());
+        assertDoesNotThrow(() -> new SoftKeyHashMap<>(2));
+        assertDoesNotThrow(() -> new SoftKeyHashMap<>(2, 0.9f));
+    }
+
+    /**
+     * this test probably best illustrates the differen Map implementations
+     */
+    @Test
+    public void dataRetentionTests() {
+        final int retentionDepth = 10;
+        final Map<String, byte[]> hashMap = new HashMap<>();
+        final Map<String, byte[]> weakMap = new WeakHashMap<>(retentionDepth);
+        final Map<String, byte[]> softMap = new SoftHashMap<>(retentionDepth);
+        final Map<String, byte[]> softKeyMap = new SoftKeyHashMap<>(retentionDepth);
+
+        initMap(hashMap, N_ENTRIES);
+        initMap(weakMap, N_ENTRIES);
+        initMap(softMap, N_ENTRIES);
+        initMap(softKeyMap, N_ENTRIES);
+        // assert that all maps have initially the same state
+        assertEquals(N_ENTRIES, hashMap.size());
+        assertEquals(N_ENTRIES, weakMap.size());
+        assertEquals(N_ENTRIES, softMap.size());
+        assertEquals(N_ENTRIES, softKeyMap.size());
+
+        // force garbage collection (N.B. not an out-of-memory situation)
+        forceGC();
+        assertEquals(N_ENTRIES, hashMap.size());
+        assertEquals(0, countNonNullEntries(weakMap)); // only  WeakHashMap drops its entries
+        // assertEquals(0, weakMap.size()); // disabled: possible bug in JDK's WeakHashMap
+        initMap(weakMap, N_ENTRIES); // re-fill weakMap
+        assertEquals(N_ENTRIES, softMap.size());
+        assertEquals(N_ENTRIES, softKeyMap.size());
+
+        // force memory shortage (out-of-memory situation)
+        forceMemoryShortage();
+        assertEquals(N_ENTRIES, hashMap.size()); // the only Map that keeps all data due to its strong references
+        assertEquals(0, countNonNullEntries(weakMap));
+        // assertEquals(0, weakMap.size()); // disabled: possible bug in JDK's WeakHashMap
+        assertEquals(retentionDepth, softMap.size());
+        assertEquals(retentionDepth, countNonNullEntries(softMap));
+        assertEquals(0, softKeyMap.size());
+        assertEquals(0, countNonNullEntries(softKeyMap));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = { SoftHashMap.class, SoftKeyHashMap.class })
+    public void extendedTests(final Class<?> testClass) throws Exception {
+        if (!Map.class.isAssignableFrom(testClass)) {
+            // config error: testClass is not derived from Map
+            throw new IllegalArgumentException("testClass " + testClass.getCanonicalName() + " is not derived from " + Map.class.getCanonicalName());
+        }
+        @SuppressWarnings("unchecked")
+        final Map<String, byte[]> map = (Map<String, byte[]>) testClass.getDeclaredConstructor().newInstance();
+
+        assertTrue(map.isEmpty());
+        assertThrows(NullPointerException.class, () -> map.put(null, new byte[0]));
+        assertThrows(NullPointerException.class, () -> map.put("key", null));
+        assertDoesNotThrow(() -> map.put("key", new byte[0]));
+        assertDoesNotThrow(() -> map.remove("key"));
+        assertDoesNotThrow(() -> map.putAll(null));
+        assertDoesNotThrow(() -> map.putAll(Collections.emptyMap()));
+        assertDoesNotThrow(() -> map.clear());
+        assertEquals(0, map.keySet().size());
+        assertEquals(0, map.values().size());
+        assertEquals(0, map.entrySet().size());
+        initMap(map, 10);
+        assertEquals(10, map.size());
+        assertEquals(10, countNonNullEntries(map));
+
+        final Set<String> keySet = map.keySet();
+        for (String key : keySet) {
+            assertTrue(map.containsKey(key));
+        }
+        final Collection<byte[]> values = map.values();
+        for (byte[] value : values) {
+            assertTrue(map.containsValue(value));
+        }
+
+        for (final Entry<String, byte[]> entry : map.entrySet()) {
+            assertTrue(keySet.contains(entry.getKey()));
+            assertTrue(values.contains(entry.getValue()));
+        }
+    }
+
+    /**
+     * This method guarantees that garbage collection is
+     * done unlike <code>{@link System#gc()}</code>
+     */
+    public static void forceGC() {
+        Object obj = new Object();
+        final WeakReference<Object> ref = new WeakReference<>(obj);
+        obj = null;
+        while (ref.get() != null) {
+            System.gc();
+        }
+    }
+
+    public static void initMap(final Map<String, byte[]> map, final int nEntries) {
+        for (int i = 0; i < nEntries; i++) {
+            map.put("key#" + i, new byte[DEFAULT_ARRAY_SIZE + i]);
+        }
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final SoftHashMapTests test = new SoftHashMapTests();
+        test.basicTests();
+    }
+
+    private static int countNonNullEntries(final Map<String, byte[]> map) {
+        int nonNullEntries = 0;
+        for (int i = 0; i < N_ENTRIES; i++) {
+            if (map.get("key#" + i) != null) {
+                nonNullEntries++;
+            }
+        }
+        return nonNullEntries;
+    }
+
+    private static void forceMemoryShortage() {
+        boolean run = true;
+        List<byte[]> strongReference = Collections.synchronizedList(new ArrayList<>(10_000_000));
+
+        while (run) {
+            try {
+                strongReference.add(new byte[DEFAULT_ARRAY_SIZE]);
+            } catch (final OutOfMemoryError e) {
+                run = false;
+            }
+        }
+        // to be garbage collected
+        strongReference = null;
+    }
+
+    private static void testMap(final Map<String, byte[]> map) {
+        LOGGER.atInfo().addArgument(map.getClass().getCanonicalName()).addArgument(N_ENTRIES).log("Test Map implementation: {} - #entries = {}");
+        initMap(map, N_ENTRIES);
+        assertEquals(N_ENTRIES, map.size());
+        assertEquals(map.size(), countNonNullEntries(map));
+
+        LOGGER.atInfo().addArgument(countNonNullEntries(map)).log("initial state     : {} entries");
+
+        forceGC();
+        LOGGER.atInfo().addArgument(countNonNullEntries(map)).log("after forced gc   : {} entries");
+
+        forceMemoryShortage();
+        LOGGER.atInfo().addArgument(countNonNullEntries(map)).log("after mem shortage: {} entries");
+
+        map.clear();
+        assertEquals(0, map.size());
+        assertEquals(map.size(), countNonNullEntries(map));
+
+        LOGGER.atInfo().addArgument(countNonNullEntries(map)).log("after clear()     : {} entries");
+
+        LOGGER.atInfo().addArgument(map.getClass()).log("done\n");
+    }
+}


### PR DESCRIPTION
* changed PNG encoder to PNGJ with near-complete RFC implementation

* added clone() helper method to WriteFxImage

* added runAndWait methods for Runnable, Supplier and Function to FXUtils plus some unit-testing. This allows more easily and safely to pass arguments and return values to and from lambdas executed within the JavaFX UI thread. Enjoy!

* fixed put -> putIfAbsent mapping in Cache and refresh timer on get access
N.B. subtle but important to fix since put-> putIfAbsent prevented to override values for an existing key (otherwise would have worked only for immutable values)

* new CacheCollections, ByteArrayCache & WritableImageCache classes
N.B. Implements cache collection to minimise memory re-allocation and in turn garbage collection for short-lived data storage objects. Other data storage contained can be similarly derived from CacheCollections. See ByteArrayCache for inspiration

* added pre- and post-listener to Cache<K> implementation

* added SoftHashMap and SoftKeyHashMap implementations:
  * SoftHashMap is a simple drop-in-replacements for simple caching applications. Values are freed if an OutOfMemory condition is expected.
  * SoftKeyHashMap is equivalent to WeakHashMap with the difference that
the keys are referenced by SoftReference instead of WeakReference.
