### PR TITLE
Fixes for Timo

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/DataSetMeasurements.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/DataSetMeasurements.java
@@ -6,6 +6,7 @@ import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementC
 import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementCategory.FOURIER;
 import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementCategory.MATH;
 import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementCategory.MATH_FUNCTION;
+import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementCategory.PROJECTION;
 import static de.gsi.chart.plugins.measurements.DataSetMeasurements.MeasurementCategory.TRENDING;
 
 import java.time.OffsetDateTime;
@@ -67,6 +68,7 @@ import de.gsi.math.DataSetMath.Filter;
 import de.gsi.math.DataSetMath.MathOp;
 import de.gsi.math.MathDataSet;
 import de.gsi.math.MathDataSet.DataSetsFunction;
+import de.gsi.math.MultiDimDataSetMath;
 
 public class DataSetMeasurements extends AbstractChartMeasurement {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSetMeasurements.class);
@@ -618,6 +620,88 @@ public class DataSetMeasurements extends AbstractChartMeasurement {
                 outputDataSet.set(DataSetMath.iirLowPassFilterFunction(firstDataSet, functionValue));
                 break;
 
+            // DataSet projections
+            case DATASET_SLICE_X:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_X)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeSlice(firstDataSet, outputDataSet, DataSet.DIM_X, newValueMarker1);
+                break;
+            case DATASET_SLICE_Y:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeSlice(firstDataSet, outputDataSet, DataSet.DIM_Y, newValueMarker1);
+                break;
+            case DATASET_MEAN_X:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMean(firstDataSet, outputDataSet, DataSet.DIM_X, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_MEAN_Y:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMean(firstDataSet, outputDataSet, DataSet.DIM_Y, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_MIN_X:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMin(firstDataSet, outputDataSet, DataSet.DIM_X, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_MIN_Y:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMin(firstDataSet, outputDataSet, DataSet.DIM_Y, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_MAX_X:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMax(firstDataSet, outputDataSet, DataSet.DIM_X, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_MAX_Y:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeMax(firstDataSet, outputDataSet, DataSet.DIM_Y, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_INTEGRAL_X:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeIntegral(firstDataSet, outputDataSet, DataSet.DIM_X, newValueMarker1, newValueMarker2);
+                break;
+            case DATASET_INTEGRAL_Y:
+                if (firstDataSet.getDimension() <= 2) {
+                    break;
+                }
+                FXUtils.runFX(() -> xAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Y)));
+                FXUtils.runFX(() -> yAxis.set(firstDataSet.getAxisDescription(DataSet.DIM_Z)));
+                MultiDimDataSetMath.computeIntegral(firstDataSet, outputDataSet, DataSet.DIM_Y, newValueMarker1, newValueMarker2);
+                break;
+
             // Fourier transforms
             case FFT_DB:
                 FXUtils.runFX(() -> xAxis.set(FREQUENCY, "Hz"));
@@ -710,6 +794,7 @@ public class DataSetMeasurements extends AbstractChartMeasurement {
         MATH("Math - Basic"),
         MATH_FUNCTION("Math - Functions"),
         FILTER("DataSet Filtering"),
+        PROJECTION("DataSet Projections"),
         FOURIER("Spectral Transforms"),
         TRENDING("Trending");
 
@@ -760,6 +845,18 @@ public class DataSetMeasurements extends AbstractChartMeasurement {
         FILTER_RMS(true, FILTER, "RMS", 0, 1, FILTER_CONSTANT_VARIABLE),
         FILTER_GEOMMEAN(true, FILTER, "GeometricMean", 0, 1, FILTER_CONSTANT_VARIABLE),
         FILTER_LOWPASS_IIR(true, FILTER, "low-pass (IIR)", 0, 1, FILTER_CONSTANT_VARIABLE),
+
+        // DataSet projections
+        DATASET_SLICE_X(false, PROJECTION, "hor. Slice", 1, 1),
+        DATASET_SLICE_Y(true, PROJECTION, "ver. Slice", 1, 1),
+        DATASET_MEAN_X(false, PROJECTION, "hor. Mean-Projection", 2, 1),
+        DATASET_MEAN_Y(true, PROJECTION, "ver. Mean-Projection", 2, 1),
+        DATASET_MIN_X(false, PROJECTION, "hor. Min-Projection", 2, 1),
+        DATASET_MIN_Y(true, PROJECTION, "ver. Min-Projection", 2, 1),
+        DATASET_MAX_X(false, PROJECTION, "hor. Max-Projection", 2, 1),
+        DATASET_MAX_Y(true, PROJECTION, "ver. Max-Projection", 2, 1),
+        DATASET_INTEGRAL_X(false, PROJECTION, "hor. Integral-Projection", 2, 1),
+        DATASET_INTEGRAL_Y(true, PROJECTION, "ver. Integral-Projection", 2, 1),
 
         // Fourier transforms
         FFT_DB(true, FOURIER, "FFT [dB]", 0, 1),

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/CachedDataPoints.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/CachedDataPoints.java
@@ -20,6 +20,7 @@ import de.gsi.dataset.DataSetError;
 import de.gsi.dataset.DataSetError.ErrorType;
 import de.gsi.dataset.utils.ArrayCache;
 import de.gsi.dataset.utils.CachedDaemonThreadFactory;
+import de.gsi.dataset.utils.DoubleArrayCache;
 import de.gsi.dataset.utils.ProcessingProfiler;
 import de.gsi.math.ArrayUtils;
 
@@ -33,12 +34,6 @@ import de.gsi.math.ArrayUtils;
 class CachedDataPoints {
     private static final String STYLES2 = "styles";
     private static final String SELECTED2 = "selected";
-    private static final String ERROR_X_POS = "errorXPos";
-    private static final String ERROR_X_NEG = "errorXNeg";
-    private static final String ERROR_Y_POS = "errorYPos";
-    private static final String ERROR_Y_NEG = "errorYNeg";
-    private static final String Y_VALUES = "yValues";
-    private static final String X_VALUES = "xValues";
     private static final double DEG_TO_RAD = Math.PI / 180.0;
 
     protected double[] xValues;
@@ -71,21 +66,20 @@ class CachedDataPoints {
     protected double yRange;
     protected double maxRadius;
     protected int maxDataCount;
-    protected int actualDataCount; // number of data points that remain
-            // after data reduction
+    protected int actualDataCount; // number of data points that remain after data reduction
 
     public CachedDataPoints(final int indexMin, final int indexMax, final int dataLength, final boolean full) {
         maxDataCount = dataLength;
-        xValues = ArrayCache.getCachedDoubleArray(X_VALUES, maxDataCount);
-        yValues = ArrayCache.getCachedDoubleArray(Y_VALUES, maxDataCount);
+        xValues = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+        yValues = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
         styles = ArrayCache.getCachedStringArray(STYLES2, dataLength);
         this.indexMin = indexMin;
         this.indexMax = indexMax;
-        errorYNeg = ArrayCache.getCachedDoubleArray(ERROR_Y_NEG, maxDataCount);
-        errorYPos = ArrayCache.getCachedDoubleArray(ERROR_Y_POS, maxDataCount);
+        errorYNeg = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+        errorYPos = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
         if (full) {
-            errorXNeg = ArrayCache.getCachedDoubleArray(ERROR_X_NEG, maxDataCount);
-            errorXPos = ArrayCache.getCachedDoubleArray(ERROR_X_POS, maxDataCount);
+            errorXNeg = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
+            errorXPos = DoubleArrayCache.getInstance().getArrayExact(maxDataCount);
         }
         selected = ArrayCache.getCachedBooleanArray(SELECTED2, dataLength);
         ArrayUtils.fillArray(styles, null);
@@ -529,12 +523,12 @@ class CachedDataPoints {
     }
 
     public void release() {
-        ArrayCache.release(X_VALUES, xValues);
-        ArrayCache.release(Y_VALUES, yValues);
-        ArrayCache.release(ERROR_Y_NEG, errorYNeg);
-        ArrayCache.release(ERROR_Y_POS, errorYPos);
-        ArrayCache.release(ERROR_X_NEG, errorXNeg);
-        ArrayCache.release(ERROR_X_POS, errorXPos);
+        DoubleArrayCache.getInstance().add(xValues);
+        DoubleArrayCache.getInstance().add(yValues);
+        DoubleArrayCache.getInstance().add(errorYNeg);
+        DoubleArrayCache.getInstance().add(errorYPos);
+        DoubleArrayCache.getInstance().add(errorXNeg);
+        DoubleArrayCache.getInstance().add(errorXPos);
         ArrayCache.release(SELECTED2, selected);
         ArrayCache.release(STYLES2, styles);
     }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -32,7 +32,7 @@ import de.gsi.chart.utils.StyleParser;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSetError.ErrorType;
 import de.gsi.dataset.spi.utils.Triple;
-import de.gsi.dataset.utils.ArrayCache;
+import de.gsi.dataset.utils.DoubleArrayCache;
 import de.gsi.dataset.utils.ProcessingProfiler;
 
 /**
@@ -51,18 +51,6 @@ import de.gsi.dataset.utils.ProcessingProfiler;
 public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<ErrorDataSetRenderer>
         implements Renderer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorDataSetRenderer.class);
-    private static final String Y_BEZIER_SECOND_CONTROL_POINT = "yBezierSecondControlPoint";
-    private static final String X_BEZIER_SECOND_CONTROL_POINT = "xBezierSecondControlPoint";
-    private static final String Y_BEZIER_FIRST_CONTROL_POINT = "yBezierFirstControlPoint";
-    private static final String X_BEZIER_FIRST_CONTROL_POINT = "xBezierFirstControlPoint";
-    private static final String Y_DRAW_POLY_LINE_STAIR_CASE = "yDrawPolyLineStairCase";
-    private static final String X_DRAW_POLY_LINE_STAIR_CASE = "xDrawPolyLineStairCase";
-    private static final String Y_DRAW_POLY_LINE_AREA = "yDrawPolyLineArea";
-    private static final String X_DRAW_POLY_LINE_AREA = "xDrawPolyLineArea";
-    private static final String Y_VALUES_SURFACE = "yValuesSurface";
-    private static final String X_VALUES_SURFACE = "xValuesSurface";
-    private static final String Y_DRAW_POLY_LINE_HISTOGRAM = "yDrawPolyLineHistogram";
-    private static final String X_DRAW_POLY_LINE_HISTOGRAM = "xDrawPolyLineHistogram";
     private Marker marker = DefaultMarker.RECTANGLE; // default: rectangle
     private long stopStamp;
 
@@ -495,8 +483,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
 
         final int nDataCount = localCachedPoints.actualDataCount;
         final int nPolygoneEdges = 2 * nDataCount;
-        final double[] xValuesSurface = ArrayCache.getCachedDoubleArray(X_VALUES_SURFACE, nPolygoneEdges);
-        final double[] yValuesSurface = ArrayCache.getCachedDoubleArray(Y_VALUES_SURFACE, nPolygoneEdges);
+        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
+        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
 
         final int xend = nPolygoneEdges - 1;
         for (int i = 0; i < nDataCount; i++) {
@@ -520,8 +508,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         drawMarker(gc, localCachedPoints);
         drawBubbles(gc, localCachedPoints);
 
-        ArrayCache.release(X_VALUES_SURFACE, xValuesSurface);
-        ArrayCache.release(Y_VALUES_SURFACE, yValuesSurface);
+        DoubleArrayCache.getInstance().add(xValuesSurface);
+        DoubleArrayCache.getInstance().add(yValuesSurface);
 
         ProcessingProfiler.getTimeDiff(start);
     }
@@ -542,8 +530,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
 
         final int nDataCount = localCachedPoints.actualDataCount;
         final int nPolygoneEdges = 2 * nDataCount;
-        final double[] xValuesSurface = ArrayCache.getCachedDoubleArray(X_VALUES_SURFACE, nPolygoneEdges);
-        final double[] yValuesSurface = ArrayCache.getCachedDoubleArray(Y_VALUES_SURFACE, nPolygoneEdges);
+        final double[] xValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
+        final double[] yValuesSurface = DoubleArrayCache.getInstance().getArrayExact(nPolygoneEdges);
 
         final int xend = nPolygoneEdges - 1;
         int count = 0;
@@ -586,8 +574,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         drawMarker(gc, localCachedPoints);
         drawBubbles(gc, localCachedPoints);
 
-        ArrayCache.release(X_VALUES_SURFACE, xValuesSurface);
-        ArrayCache.release(Y_VALUES_SURFACE, yValuesSurface);
+        DoubleArrayCache.getInstance().add(xValuesSurface);
+        DoubleArrayCache.getInstance().add(yValuesSurface);
 
         ProcessingProfiler.getTimeDiff(start);
     }
@@ -764,8 +752,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = ArrayCache.getCachedDoubleArray(X_DRAW_POLY_LINE_AREA, n + 2);
-        final double[] newY = ArrayCache.getCachedDoubleArray(Y_DRAW_POLY_LINE_AREA, n + 2);
+        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(n + 2);
+        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(n + 2);
 
         final double zero = localCachedPoints.yZero;
         System.arraycopy(localCachedPoints.xValues, 0, newX, 0, n);
@@ -785,8 +773,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         gc.restore();
 
         // release arrays to cache
-        ArrayCache.release(X_DRAW_POLY_LINE_AREA, newX);
-        ArrayCache.release(Y_DRAW_POLY_LINE_AREA, newY);
+        DoubleArrayCache.getInstance().add(newX);
+        DoubleArrayCache.getInstance().add(newY);
     }
 
     protected static void drawPolyLineHistogram(final GraphicsContext gc, final CachedDataPoints localCachedPoints) {
@@ -796,8 +784,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = ArrayCache.getCachedDoubleArray(X_DRAW_POLY_LINE_HISTOGRAM, 2 * (n + 1));
-        final double[] newY = ArrayCache.getCachedDoubleArray(Y_DRAW_POLY_LINE_HISTOGRAM, 2 * (n + 1));
+        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
+        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
 
         final double xRange = localCachedPoints.xMax - localCachedPoints.xMin;
         double diffLeft;
@@ -836,8 +824,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         gc.restore();
 
         // release arrays to cache
-        ArrayCache.release(X_DRAW_POLY_LINE_HISTOGRAM, newX);
-        ArrayCache.release(Y_DRAW_POLY_LINE_HISTOGRAM, newY);
+        DoubleArrayCache.getInstance().add(newX);
+        DoubleArrayCache.getInstance().add(newY);
     }
 
     protected static void drawPolyLineHistogramBezier(final GraphicsContext gc,
@@ -849,10 +837,10 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] xCp1 = ArrayCache.getCachedDoubleArray(X_BEZIER_FIRST_CONTROL_POINT, n);
-        final double[] yCp1 = ArrayCache.getCachedDoubleArray(Y_BEZIER_FIRST_CONTROL_POINT, n);
-        final double[] xCp2 = ArrayCache.getCachedDoubleArray(X_BEZIER_SECOND_CONTROL_POINT, n);
-        final double[] yCp2 = ArrayCache.getCachedDoubleArray(Y_BEZIER_SECOND_CONTROL_POINT, n);
+        final double[] xCp1 = DoubleArrayCache.getInstance().getArrayExact(n);
+        final double[] yCp1 = DoubleArrayCache.getInstance().getArrayExact(n);
+        final double[] xCp2 = DoubleArrayCache.getInstance().getArrayExact(n);
+        final double[] yCp2 = DoubleArrayCache.getInstance().getArrayExact(n);
 
         BezierCurve.calcCurveControlPoints(localCachedPoints.xValues, localCachedPoints.yValues, xCp1, yCp1, xCp2, yCp2,
                 localCachedPoints.actualDataCount);
@@ -886,10 +874,10 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         gc.restore();
 
         // release arrays to Cache
-        ArrayCache.release(X_BEZIER_FIRST_CONTROL_POINT, xCp1);
-        ArrayCache.release(Y_BEZIER_FIRST_CONTROL_POINT, yCp1);
-        ArrayCache.release(X_BEZIER_SECOND_CONTROL_POINT, xCp2);
-        ArrayCache.release(Y_BEZIER_SECOND_CONTROL_POINT, yCp2);
+        DoubleArrayCache.getInstance().add(xCp1);
+        DoubleArrayCache.getInstance().add(yCp1);
+        DoubleArrayCache.getInstance().add(xCp2);
+        DoubleArrayCache.getInstance().add(yCp2);
     }
 
     protected static void drawPolyLineHistogramFilled(final GraphicsContext gc,
@@ -900,8 +888,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = ArrayCache.getCachedDoubleArray(X_DRAW_POLY_LINE_HISTOGRAM, 2 * (n + 1));
-        final double[] newY = ArrayCache.getCachedDoubleArray(Y_DRAW_POLY_LINE_HISTOGRAM, 2 * (n + 1));
+        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
+        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * (n + 1));
 
         final double xRange = localCachedPoints.xMax - localCachedPoints.xMin;
         double diffLeft;
@@ -934,8 +922,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         gc.restore();
 
         // release arrays to cache
-        ArrayCache.release(X_DRAW_POLY_LINE_HISTOGRAM, newX);
-        ArrayCache.release(Y_DRAW_POLY_LINE_HISTOGRAM, newY);
+        DoubleArrayCache.getInstance().add(newX);
+        DoubleArrayCache.getInstance().add(newY);
     }
 
     protected static void drawPolyLineLine(final GraphicsContext gc, final CachedDataPoints localCachedPoints) {
@@ -994,8 +982,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         }
 
         // need to allocate new array :-(
-        final double[] newX = ArrayCache.getCachedDoubleArray(X_DRAW_POLY_LINE_STAIR_CASE, 2 * n);
-        final double[] newY = ArrayCache.getCachedDoubleArray(Y_DRAW_POLY_LINE_STAIR_CASE, 2 * n);
+        final double[] newX = DoubleArrayCache.getInstance().getArrayExact(2 * n);
+        final double[] newY = DoubleArrayCache.getInstance().getArrayExact(2 * n);
 
         for (int i = 0; i < n - 1; i++) {
             newX[2 * i] = localCachedPoints.xValues[i];
@@ -1025,8 +1013,8 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         gc.restore();
 
         // release arrays to cache
-        ArrayCache.release(X_DRAW_POLY_LINE_STAIR_CASE, newX);
-        ArrayCache.release(Y_DRAW_POLY_LINE_STAIR_CASE, newY);
+        DoubleArrayCache.getInstance().add(newX);
+        DoubleArrayCache.getInstance().add(newY);
     }
 
     private static void compactVector(final double[] input, final int stopIndex) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -22,10 +22,6 @@ import de.gsi.chart.renderer.ErrorStyle;
 import de.gsi.chart.renderer.Renderer;
 import de.gsi.dataset.AxisDescription;
 import de.gsi.dataset.DataSet;
-import de.gsi.dataset.DataSet2D;
-import de.gsi.dataset.DataSet3D;
-import de.gsi.dataset.DataSetError;
-import de.gsi.dataset.event.AxisRangeChangeEvent;
 import de.gsi.dataset.event.EventListener;
 import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
@@ -37,14 +33,13 @@ import de.gsi.dataset.utils.ProcessingProfiler;
  * @author rstein
  */
 public class MountainRangeRenderer extends ErrorDataSetRenderer implements Renderer {
+    private static final int MIN_DIM = 3;
     protected DoubleProperty mountainRangeOffset = new SimpleDoubleProperty(this, "mountainRangeOffset", 0.5);
     private final ObservableList<ErrorDataSetRenderer> renderers = FXCollections.observableArrayList();
     private final ObservableList<DataSet> empty = FXCollections.observableArrayList();
     private final WeakHashMap<Double, Integer> xWeakIndexMap = new WeakHashMap<>();
     private final WeakHashMap<Double, Integer> yWeakIndexMap = new WeakHashMap<>();
-    private double zRangeMin = +Double.MAX_VALUE;
-    private double zRangeMax = -Double.MAX_VALUE;
-    private double mountainRaingeExtra = 0.0;
+    private double mountainRaingeExtra;
 
     public MountainRangeRenderer() {
         super();
@@ -58,32 +53,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
     public MountainRangeRenderer(final double mountainRangeOffset) {
         this();
         setMountainRangeOffset(mountainRangeOffset);
-    }
-
-    private void checkAndRecreateRenderer(final int nRenderer) {
-        if (renderers.size() == nRenderer) {
-            // all OK
-            return;
-        }
-
-        if (nRenderer > renderers.size()) {
-            for (int i = renderers.size(); i < nRenderer; i++) {
-                final ErrorDataSetRenderer newRenderer = new ErrorDataSetRenderer();
-                newRenderer.bind(this);
-                // do not show history sets in legend (single exception to
-                // binding)
-                newRenderer.showInLegendProperty().unbind();
-                newRenderer.setShowInLegend(false);
-                renderers.add(newRenderer);
-            }
-            return;
-        }
-
-        // require less renderer -> remove first until we have the right number
-        // needed
-        while (nRenderer < renderers.size()) {
-            renderers.remove(0);
-        }
     }
 
     /**
@@ -102,12 +71,11 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
     @Override
     public void render(final GraphicsContext gc, final Chart chart, final int dataSetOffset,
             final ObservableList<DataSet> datasets) {
-        final long start = ProcessingProfiler.getTimeStamp();
         if (!(chart instanceof XYChart)) {
             throw new InvalidParameterException(
                     "must be derivative of XYChart for renderer - " + this.getClass().getSimpleName());
         }
-
+        final long start = ProcessingProfiler.getTimeStamp(); // NOPMD - time keeping needs to be defined here
         final XYChart xyChart = (XYChart) chart;
 
         if (!(xyChart.getYAxis() instanceof Axis)) {
@@ -119,44 +87,50 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         final List<DataSet> localDataSetList = new ArrayList<>(datasets);
         localDataSetList.addAll(getDatasets());
 
-        zRangeMin = +Double.MAX_VALUE;
-        zRangeMax = -Double.MAX_VALUE;
+        final double zRangeMin = localDataSetList.stream().mapToDouble(ds -> ds.getAxisDescription(DIM_Z).getMin()).min().orElse(-1.0);
+        final double zRangeMax = localDataSetList.stream().mapToDouble(ds -> ds.getAxisDescription(DIM_Z).getMax()).max().orElse(+1.0);
 
         // render in reverse order
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
 
-            // detect and fish-out DataSet3D, ignore others
-            if (dataSet instanceof DataSet3D) {
-                dataSet.lock().readLockGuardOptimistic(() -> {
-                    final DataSet3D mData = (DataSet3D) dataSet;
-                    xWeakIndexMap.clear();
-                    yWeakIndexMap.clear();
-                    zRangeMin = Math.min(zRangeMin, mData.getAxisDescription(DIM_Z).getMin());
-                    zRangeMax = Math.max(zRangeMin, mData.getAxisDescription(DIM_Z).getMax());
-                    mountainRaingeExtra = MountainRangeRenderer.this.getMountainRangeOffset();
-
-                    final double min = zRangeMin;
-                    final double max = zRangeMax * (1.0 + mountainRaingeExtra);
-                    final boolean autoRange = yAxis.isAutoRanging();
-                    if (autoRange && (min != yAxis.getMin() || max != yAxis.getMax())) {
-                        yAxis.setAutoRanging(false);
-                        yAxis.setMin(min);
-                        yAxis.setMax(max);
-                        yAxis.setTickUnit(Math.abs(max - min) / 10.0);
-                        yAxis.forceRedraw();
-                    }
-                    yAxis.setAutoRanging(autoRange);
-
-                    final int yCountMax = mData.getDataCount(DataSet.DIM_Y);
-                    checkAndRecreateRenderer(yCountMax);
-
-                    for (int index = yCountMax - 1; index >= 0; index--) {
-                        renderers.get(index).getDatasets().setAll(new Demux3dTo2dDataSet(mData, index));
-                        renderers.get(index).render(gc, chart, 0, empty);
-                    }
-                });
+            // detect and fish-out 3D DataSet, ignore others
+            if (dataSet.getDimension() < MIN_DIM) {
+                continue;
             }
+            final int nx = dataSet.getDataCount(DataSet.DIM_X);
+            final int ny = dataSet.getDataCount(DataSet.DIM_Y);
+            final int nz = dataSet.getDataCount(DIM_Z);
+            if (nz != nx * ny) {
+                // this renderer can handle only DataSets that are equidistantly-rastered
+                continue;
+            }
+
+            dataSet.lock().readLockGuardOptimistic(() -> {
+                xWeakIndexMap.clear();
+                yWeakIndexMap.clear();
+                mountainRaingeExtra = getMountainRangeOffset();
+
+                final double min = zRangeMin;
+                final double max = zRangeMax * (1.0 + mountainRaingeExtra);
+                final boolean autoRange = yAxis.isAutoRanging();
+                if (autoRange && (min != yAxis.getMin() || max != yAxis.getMax())) {
+                    yAxis.setAutoRanging(false);
+                    yAxis.setMin(min);
+                    yAxis.setMax(max);
+                    yAxis.setTickUnit(Math.abs(max - min) / 10.0);
+                    yAxis.forceRedraw();
+                }
+                yAxis.setAutoRanging(autoRange);
+
+                final int yCountMax = dataSet.getDataCount(DataSet.DIM_Y);
+                checkAndRecreateRenderer(yCountMax);
+
+                for (int index = yCountMax - 1; index >= 0; index--) {
+                    renderers.get(index).getDatasets().setAll(new Demux3dTo2dDataSet(dataSet, index, min, max)); // NOPMD -- new necessary here
+                    renderers.get(index).render(gc, chart, 0, empty);
+                }
+            });
         }
 
         ProcessingProfiler.getTimeDiff(start);
@@ -169,50 +143,82 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
      * @param mountainRangeOffset t<code>mountainRangeOffset</code>, i.e. vertical offset between subsequent data sets
      * @return itself (fluent design)
      */
-    public final MountainRangeRenderer setMountainRangeOffset(final double mountainRangeOffset) {
+    public MountainRangeRenderer setMountainRangeOffset(final double mountainRangeOffset) { // NOPMD -- fluent design setter returns class
         AssertUtils.gtEqThanZero("mountainRangeOffset", mountainRangeOffset);
         this.mountainRangeOffset.setValue(mountainRangeOffset);
         return this;
     }
 
-    private class Demux3dTo2dDataSet implements DataSet2D, DataSetError {
+    private void checkAndRecreateRenderer(final int nRenderer) {
+        if (renderers.size() == nRenderer) {
+            // all OK
+            return;
+        }
+
+        if (nRenderer > renderers.size()) {
+            for (int i = renderers.size(); i < nRenderer; i++) {
+                final ErrorDataSetRenderer newRenderer = new ErrorDataSetRenderer(); // NOPMD -- 'new' needed in this context
+                newRenderer.bind(this);
+                // do not show history sets in legend (single exception to
+                // binding)
+                newRenderer.showInLegendProperty().unbind();
+                newRenderer.setShowInLegend(false);
+                renderers.add(newRenderer);
+            }
+            return;
+        }
+
+        // require less renderer -> remove first until we have the right number
+        // needed
+        while (nRenderer < renderers.size()) {
+            renderers.remove(0);
+        }
+    }
+
+    private class Demux3dTo2dDataSet implements DataSet {
         private static final long serialVersionUID = 3914728138839091421L;
-        private final transient DataSetLock<DataSet> lock = new DefaultDataSetLock<>(Demux3dTo2dDataSet.this);
-        private final AtomicBoolean autoNotification = new AtomicBoolean(true);
-        private final DataSet3D dataSet;
+        private final transient DataSetLock<DataSet> localLock = new DefaultDataSetLock<>(this);
+        private final transient AtomicBoolean autoNotify = new AtomicBoolean(true);
+        private final DataSet dataSet;
+        private final int nx;
+        private final int ny;
         private final int yIndex;
         private final int yMax;
-        private double yShift;
+        private final double zMin;
+        private final double zMax;
+        private final double yShift;
         private final transient List<EventListener> updateListener = new ArrayList<>();
         private final transient List<AxisDescription> axesDescriptions = new ArrayList<>(Arrays.asList( //
                 new DefaultAxisDescription("x-Axis", "a.u."), //
                 new DefaultAxisDescription("y-Axis", "a.u.")));
 
-        public Demux3dTo2dDataSet(final DataSet3D sourceDataSet, final int selectedYIndex) {
+        public Demux3dTo2dDataSet(final DataSet sourceDataSet, final int selectedYIndex, final double zMin, final double zMax) {
             super();
             dataSet = sourceDataSet;
+            nx = sourceDataSet.getDataCount(DIM_X);
+            ny = sourceDataSet.getDataCount(DIM_Y);
             yIndex = selectedYIndex;
-            yMax = dataSet.getDataCount(DataSet.DIM_Y);
-            yShift = 0.0; // just temporarily, will be recomputed
-
-            // listener on axis
-            final AxisDescription xAxis = dataSet.getAxisDescription(DIM_X);
-            dataSet.addListener(evt -> {
-                Demux3dTo2dDataSet.this.getAxisDescription(DIM_X).set(xAxis.getName(), xAxis.getUnit(), xAxis.getMin(),
-                        xAxis.getMax());
-                setYMax(dataSet.getAxisDescription(2));
-            });
-            setYMax(dataSet.getAxisDescription(DIM_Z)); // #NOPMD needed for init, cannot be overwritten by user
+            yMax = dataSet.getDataCount(DIM_Y);
+            this.zMin = zMin;
+            this.zMax = zMax;
+            yShift = mountainRaingeExtra * dataSet.getAxisDescription(DIM_Z).getMax() * yIndex / yMax;
         }
 
         @Override
         public AtomicBoolean autoNotification() {
-            return autoNotification;
+            return autoNotify;
         }
 
         @Override
         public double get(final int dimIndex, final int i) {
-            return dimIndex == DIM_Y ? this.getY(i) : dataSet.get(dimIndex, i);
+            switch (dimIndex) {
+            case DIM_X:
+                return dataSet.get(dimIndex, i);
+            case DIM_Y:
+                return dataSet.get(DIM_Z, yIndex * nx + i) + yShift;
+            default:
+                throw new IllegalArgumentException("dinIndex " + dimIndex + " not defined");
+            }
         }
 
         @Override
@@ -221,13 +227,15 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         }
 
         @Override
-        public int getDataCount() {
-            return dataSet.getDataCount(DataSet.DIM_X);
-        }
-
-        @Override
         public int getDataCount(int dimIndex) {
-            return this.getDataCount();
+            switch (dimIndex) {
+            case DIM_X:
+                return nx;
+            case DIM_Y:
+                return ny;
+            default:
+                throw new IndexOutOfBoundsException("dimIndex=" + dimIndex + " out of range");
+            }
         }
 
         @Override
@@ -236,24 +244,31 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         }
 
         @Override
-        public double getErrorNegative(final int dimIndex, final int index) {
-            return 0;
+        public int getDimension() {
+            return 2;
         }
 
         @Override
-        public double getErrorPositive(final int dimIndex, final int index) {
-            return 0;
-        }
-
-        @Override
-        public ErrorType getErrorType(final int dimIndex) {
+        public int getIndex(int dimIndex, double value) {
             switch (dimIndex) {
             case DIM_X:
-                return ErrorType.NO_ERROR;
+                // added computation of hash since this is recomputed quite often
+                // (and the same) for each slice
+                return xWeakIndexMap.computeIfAbsent(value, key -> {
+                    final int ret = dataSet.getIndex(DIM_X, value);
+                    xWeakIndexMap.put(value, ret);
+                    return ret;
+                });
             case DIM_Y:
-                return ErrorType.SYMMETRIC;
+                // added computation of hash since this is recomputed quite often
+                // (and the same) for each slice
+                return yWeakIndexMap.computeIfAbsent(value, key -> {
+                    final int ret = dataSet.getIndex(DIM_Y, value);
+                    yWeakIndexMap.put(value, ret);
+                    return ret;
+                });
             default:
-                throw new IndexOutOfBoundsException("DataSet only 2-dimensional");
+                throw new IndexOutOfBoundsException("dimIndex=" + dimIndex + " out of range");
             }
         }
 
@@ -273,31 +288,26 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         }
 
         @Override
-        public double getX(final int i) {
-            return dataSet.get(DIM_X, i);
-        }
-
-        @Override
-        public double getY(final int i) {
-            return dataSet.getZ(i, yIndex) + yShift;
+        public double getValue(int dimIndex, double x) {
+            return 0;
         }
 
         @Override
         public boolean isAutoNotification() {
-            return autoNotification.get();
+            return autoNotify.get();
         }
 
         @Override
         public DataSetLock<DataSet> lock() {
             // empty implementation since the superordinate DataSet3D lock is
             // being held/protecting this data set
-            return lock;
+            return localLock;
         }
 
         @Override
         public DataSet recomputeLimits(int dimension) {
-            this.setYMax(dataSet.getAxisDescription(DIM_Z));
-            notifyRangeChange();
+            this.getAxisDescription(DIM_X).set(dataSet.getAxisDescription(DIM_X));
+            this.getAxisDescription(DIM_Y).set(zMin, zMax);
             return this;
         }
 
@@ -306,50 +316,9 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
             return dataSet.setStyle(style);
         }
 
-        private final void setYMax(AxisDescription zAxis) {
-            yShift = mountainRaingeExtra * zAxis.getMax() * yIndex / yMax;
-
-            Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).set(zAxis.getName(), zAxis.getUnit(), zAxis.getMin(),
-                    zRangeMax * (1 + mountainRaingeExtra));
-        }
-
-        private final void notifyRangeChange() {
-            if (dataSet == null || !dataSet.autoNotification().get()) {
-                return;
-            }
-            final String name = Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).getName();
-            final String unit = Demux3dTo2dDataSet.this.getAxisDescription(DIM_Y).getUnit();
-            dataSet.invokeListener(
-                    new AxisRangeChangeEvent(dataSet, "updated axis range for '" + name + "' '[" + unit + "]'", -1));
-        }
-
         @Override
         public List<EventListener> updateEventListener() {
             return updateListener;
-        }
-
-        @Override
-        public int getIndex(int dimIndex, double value) {
-            switch (dimIndex) {
-            case DIM_X:
-                // added computation of hash since this is recomputed quite often
-                // (and the same) for each slice
-                return xWeakIndexMap.computeIfAbsent(value, key -> {
-                    Integer ret = dataSet.getXIndex(value);
-                    xWeakIndexMap.put(value, ret);
-                    return ret;
-                });
-            case DIM_Y:
-                // added computation of hash since this is recomputed quite often
-                // (and the same) for each slice
-                return yWeakIndexMap.computeIfAbsent(value, key -> {
-                    Integer ret = dataSet.getYIndex(value);
-                    yWeakIndexMap.put(value, ret);
-                    return ret;
-                });
-            default:
-                throw new IndexOutOfBoundsException("dimIndex=" + dimIndex + " out of range");
-            }
         }
     }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/utils/ColorGradient.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/utils/ColorGradient.java
@@ -19,9 +19,17 @@ import javafx.scene.paint.Stop;
  */
 public class ColorGradient {
     /**
-     * Rainbow colors gradient: violet, indigo, blue, green, yellow, orange and red.
+     * Rainbow colors gradient: violet, indigo, blue, green, yellow, orange and red with transparent limits for data outside ]0, 1[
      */
     public static final ColorGradient RAINBOW = new ColorGradient("RAINBOW", new Stop(0.0, Color.TRANSPARENT),
+            new Stop(Double.MIN_VALUE, Color.VIOLET), new Stop(0.17, Color.INDIGO), new Stop(0.34, Color.BLUE),
+            new Stop(0.51, Color.GREEN), new Stop(0.68, Color.YELLOW), new Stop(0.85, Color.ORANGE),
+            new Stop(1.0, Color.RED));
+
+    /**
+     * Rainbow colors gradient: violet, indigo, blue, green, yellow, orange and red with opaque limits for data outside ]0, 1[
+     */
+    public static final ColorGradient RAINBOW_OPAQUE = new ColorGradient("RAINBOW_OPAQUE", new Stop(0.0, Color.DODGERBLUE),
             new Stop(Double.MIN_VALUE, Color.VIOLET), new Stop(0.17, Color.INDIGO), new Stop(0.34, Color.BLUE),
             new Stop(0.51, Color.GREEN), new Stop(0.68, Color.YELLOW), new Stop(0.85, Color.ORANGE),
             new Stop(1.0, Color.RED));
@@ -102,8 +110,8 @@ public class ColorGradient {
     public static final ColorGradient DEFAULT = RAINBOW;
     private final List<Stop> stops;
     private final String name;
-    private transient final WeakHashMap<Double, Color> colorMap = new WeakHashMap<>();
-    private transient final WeakHashMap<Double, int[]> colorMapBytes = new WeakHashMap<>();
+    private final WeakHashMap<Double, Color> colorMap = new WeakHashMap<>();
+    private final WeakHashMap<Double, int[]> colorMapBytes = new WeakHashMap<>();
 
     /**
      * Creates a new instance of ColorGradient.**
@@ -242,7 +250,7 @@ public class ColorGradient {
     }
 
     public static List<ColorGradient> colorGradients() {
-        return Arrays.asList(ColorGradient.RAINBOW, ColorGradient.JET, ColorGradient.TOPO, ColorGradient.TOPO_EXT,
+        return Arrays.asList(ColorGradient.RAINBOW, ColorGradient.RAINBOW_OPAQUE, ColorGradient.JET, ColorGradient.TOPO, ColorGradient.TOPO_EXT,
                 ColorGradient.WHITE_BLACK, ColorGradient.BLACK_WHITE, ColorGradient.HOT, ColorGradient.SUNRISE,
                 ColorGradient.VIRIDIS, ColorGradient.BLUERED, ColorGradient.PINK, ColorGradient.RAINBOW_EQ);
     }

--- a/chartfx-chart/src/main/java/de/gsi/chart/utils/WritableImageCache.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/utils/WritableImageCache.java
@@ -39,6 +39,8 @@ import de.gsi.dataset.utils.CacheCollection;
  *
  */
 public class WritableImageCache extends CacheCollection<WritableImage> {
+    private static final WritableImageCache SELF = new WritableImageCache();
+
     public WritableImage getImage(final int requiredWidth, final int requiredHeight) {
         synchronized (contents) {
             WritableImage bestFit = null;
@@ -66,5 +68,9 @@ public class WritableImageCache extends CacheCollection<WritableImage> {
             remove(bestFit);
             return bestFit;
         }
+    }
+
+    public static WritableImageCache getInstance() {
+        return SELF;
     }
 }

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/AbstractContourDataSetRendererParameterTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/AbstractContourDataSetRendererParameterTests.java
@@ -1,0 +1,89 @@
+package de.gsi.chart.renderer.spi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.collections.ObservableList;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+
+import org.junit.jupiter.api.Test;
+
+import de.gsi.chart.Chart;
+import de.gsi.chart.renderer.ContourType;
+import de.gsi.chart.renderer.datareduction.ReductionType;
+import de.gsi.chart.renderer.spi.utils.ColorGradient;
+import de.gsi.dataset.DataSet;
+
+/**
+ * Basic getter/setter tests for {@link de.gsi.chart.renderer.spi.AbstractContourDataSetRendererParameter}
+ * @author rstein
+ */
+public class AbstractContourDataSetRendererParameterTests {
+    @Test
+    public void basicGetterSetterTests() {
+        assertDoesNotThrow(() -> new TestContourDataSetRendererParameter());
+
+        final TestContourDataSetRendererParameter renderer = new TestContourDataSetRendererParameter();
+
+        renderer.setAltImplementation(true);
+        assertTrue(renderer.isAltImplementation());
+        renderer.setAltImplementation(false);
+        assertFalse(renderer.isAltImplementation());
+
+        renderer.setColorGradient(ColorGradient.BLUERED);
+        assertEquals(ColorGradient.BLUERED, renderer.getColorGradient());
+
+        renderer.setComputeLocalRange(true);
+        assertTrue(renderer.computeLocalRange());
+        renderer.setComputeLocalRange(false);
+        assertFalse(renderer.computeLocalRange());
+
+        renderer.setContourType(ContourType.CONTOUR_HEXAGON);
+        assertEquals(ContourType.CONTOUR_HEXAGON, renderer.getContourType());
+
+        renderer.setMaxContourSegments(42);
+        assertEquals(42, renderer.getMaxContourSegments());
+
+        renderer.setMinHexTileSizeProperty(101);
+        assertEquals(101, renderer.getMinHexTileSizeProperty());
+
+        renderer.setNumberQuantisationLevels(3);
+        assertEquals(3, renderer.getNumberQuantisationLevels());
+
+        renderer.setReductionFactorX(4);
+        assertEquals(4, renderer.getReductionFactorX());
+        renderer.setReductionFactorY(3);
+        assertEquals(3, renderer.getReductionFactorY());
+
+        renderer.setReductionType(ReductionType.AVERAGE);
+        assertEquals(ReductionType.AVERAGE, renderer.getReductionType());
+
+        renderer.setSmooth(true);
+        assertTrue(renderer.isSmooth());
+        renderer.setSmooth(false);
+        assertFalse(renderer.isSmooth());
+    }
+
+    /**
+     * basic test class, only supports limited getter/setter/property functions
+     */
+    public class TestContourDataSetRendererParameter extends AbstractContourDataSetRendererParameter<TestContourDataSetRendererParameter> {
+        @Override
+        public Canvas drawLegendSymbol(DataSet dataSet, int dsIndex, int width, int height) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void render(GraphicsContext gc, Chart chart, int dataSetOffset, ObservableList<DataSet> datasets) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected TestContourDataSetRendererParameter getThis() {
+            return this;
+        }
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameterTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameterTests.java
@@ -1,0 +1,135 @@
+package de.gsi.chart.renderer.spi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.collections.ObservableList;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+
+import org.junit.jupiter.api.Test;
+
+import de.gsi.chart.Chart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.renderer.ErrorStyle;
+import de.gsi.chart.renderer.LineStyle;
+import de.gsi.chart.renderer.datareduction.DefaultDataReducer;
+import de.gsi.chart.renderer.datareduction.MaxDataReducer;
+import de.gsi.dataset.DataSet;
+
+/**
+ * Basic getter/setter tests for {@link de.gsi.chart.renderer.spi.AbstractErrorDataSetRendererParameter}
+ * @author rstein
+ */
+public class AbstractErrorDataSetRendererParameterTests {
+    @Test
+    public void basicGetterSetterTests() {
+        assertDoesNotThrow(() -> new TestErrorDataSetRendererParameter());
+
+        final TestErrorDataSetRendererParameter renderer = new TestErrorDataSetRendererParameter();
+
+        renderer.setAllowNaNs(true);
+        assertTrue(renderer.isallowNaNs());
+        renderer.setAllowNaNs(false);
+        assertFalse(renderer.isallowNaNs());
+
+        renderer.setBarWidth(13);
+        assertEquals(13, renderer.getBarWidth());
+
+        renderer.setBarWidthPercentage(42);
+        assertEquals(42, renderer.getBarWidthPercentage());
+
+        renderer.setDashSize(7);
+        assertEquals(7, renderer.getDashSize());
+
+        renderer.setDrawBars(true);
+        assertTrue(renderer.isDrawBars());
+        renderer.setDrawBars(false);
+        assertFalse(renderer.isDrawBars());
+
+        renderer.setDrawBubbles(true);
+        assertTrue(renderer.isDrawBubbles());
+        renderer.setDrawBubbles(false);
+        assertFalse(renderer.isDrawBubbles());
+
+        renderer.setDrawChartDataSets(true);
+        assertTrue(renderer.isDrawChartDataSets());
+        renderer.setDrawChartDataSets(false);
+        assertFalse(renderer.isDrawChartDataSets());
+
+        renderer.setDrawMarker(true);
+        assertTrue(renderer.isDrawMarker());
+        renderer.setDrawMarker(false);
+        assertFalse(renderer.isDrawMarker());
+
+        renderer.setDynamicBarWidth(true);
+        assertTrue(renderer.isDynamicBarWidth());
+        renderer.setDynamicBarWidth(false);
+        assertFalse(renderer.isDynamicBarWidth());
+
+        for (ErrorStyle eStyle : ErrorStyle.values()) {
+            renderer.setErrorType(eStyle);
+            assertEquals(eStyle, renderer.getErrorType());
+        }
+        renderer.setIntensityFading(0.85);
+        assertEquals(0.85, renderer.getIntensityFading());
+
+        renderer.setMarkerSize(4);
+        assertEquals(4, renderer.getMarkerSize());
+
+        for (LineStyle eStyle : LineStyle.values()) {
+            renderer.setPolyLineStyle(eStyle);
+            assertEquals(eStyle, renderer.getPolyLineStyle());
+        }
+
+        assertEquals(DefaultDataReducer.class, renderer.getRendererDataReducer().getClass());
+        renderer.setRendererDataReducer(new MaxDataReducer());
+        assertEquals(MaxDataReducer.class, renderer.getRendererDataReducer().getClass());
+        renderer.setRendererDataReducer(null);
+        assertEquals(DefaultDataReducer.class, renderer.getRendererDataReducer().getClass());
+
+        renderer.setShiftBar(true);
+        assertTrue(renderer.isShiftBar());
+        renderer.setShiftBar(false);
+        assertFalse(renderer.isShiftBar());
+
+        renderer.setshiftBarOffset(5);
+        assertEquals(5, renderer.getShiftBarOffset());
+    }
+
+    @Test
+    public void testBindings() {
+        final TestErrorDataSetRendererParameter renderer1 = new TestErrorDataSetRendererParameter();
+        final TestErrorDataSetRendererParameter renderer2 = new TestErrorDataSetRendererParameter();
+
+        assertDoesNotThrow(() -> renderer1.bind(renderer2));
+
+        DefaultNumericAxis test = new DefaultNumericAxis("test axis");
+        renderer2.getAxes().add(test);
+        assertEquals(test, renderer2.getAxes().get(0));
+
+        assertDoesNotThrow(() -> renderer2.unbind());
+    }
+
+    /**
+     * basic test class, only supports limited getter/setter/property functions
+     */
+    public class TestErrorDataSetRendererParameter extends AbstractErrorDataSetRendererParameter<TestErrorDataSetRendererParameter> {
+        @Override
+        public Canvas drawLegendSymbol(DataSet dataSet, int dsIndex, int width, int height) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void render(GraphicsContext gc, Chart chart, int dataSetOffset, ObservableList<DataSet> datasets) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected TestErrorDataSetRendererParameter getThis() {
+            return this;
+        }
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ContourDataSetCacheTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ContourDataSetCacheTests.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import de.gsi.chart.axes.AxisTransform;
-import de.gsi.chart.renderer.spi.utils.ColorGradient;
 import de.gsi.dataset.spi.AbstractDataSet3D;
 import de.gsi.dataset.spi.DataRange;
 import de.gsi.math.ArrayUtils;
@@ -159,7 +158,7 @@ public class ContourDataSetCacheTests {
     }
 
     @Test
-    public void testDataTransform() {
+    public void testDataTransform() throws Exception {
         TestDataSet dataSet = new TestDataSet();
 
         assertEquals(TEST_DATA_X.length, dataSet.getDataCount(DIM_X), "data vector x length");
@@ -209,10 +208,12 @@ public class ContourDataSetCacheTests {
         ContourDataSetCache.copySubFrame(dataSet, dataBuffer, true, false, 0, 2, false, 0, 3);
         assertArrayEquals(TEST_DATA_Z, dataBuffer, "data buffer content - parallel copySubFrame");
 
-        assertDoesNotThrow(() -> ContourDataSetCache.convertDataArrayToImage(TEST_DATA_Z, TEST_DATA_X.length, TEST_DATA_Y.length, ColorGradient.DEFAULT), "data to colour image conversion");
+        // requires FX to be tested, now in ContourDataSetRendererTests
+        // final ContourDataSetCache cache = FXUtils.runAndWait(() -> new ContourDataSetCache(new XYChart(), new ContourDataSetRenderer(), dataSet));
+        // assertDoesNotThrow(() -> cache.convertDataArrayToImage(TEST_DATA_Z, TEST_DATA_X.length, TEST_DATA_Y.length, ColorGradient.DEFAULT), "data to colour image conversion");
     }
 
-    private class TestDataSet extends AbstractDataSet3D<TestDataSet> {
+    public class TestDataSet extends AbstractDataSet3D<TestDataSet> {
         private static final long serialVersionUID = 4176996086927034332L;
 
         public TestDataSet() {

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ContourDataSetRendererTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ContourDataSetRendererTests.java
@@ -1,0 +1,137 @@
+package de.gsi.chart.renderer.spi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.compareAndWriteReference;
+import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.writeTestImage;
+
+import java.io.IOException;
+
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.renderer.ContourType;
+import de.gsi.chart.renderer.spi.utils.ColorGradient;
+import de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+import de.gsi.chart.ui.utils.TestFx;
+import de.gsi.chart.utils.FXUtils;
+import de.gsi.dataset.DataSet3D;
+
+/**
+ * Tests {@link de.gsi.chart.renderer.spi.ContourDataSetRenderer }
+ *
+ * @author rstein
+ *
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class ContourDataSetRendererTests {
+    private static final Class<?> clazz = ContourDataSetRendererTests.class;
+    private static final Logger LOGGER = LoggerFactory.getLogger(clazz);
+    private static final String className = clazz.getSimpleName();
+    private static final String referenceFileName = "./Reference_" + className;
+    private static final String referenceFileExtension = ".png";
+    private static final double[] TEST_DATA_X = { 1, 2, 3 };
+    private static final double[] TEST_DATA_Y = { 1, 2, 3, 4 };
+    private static final double[] TEST_DATA_Z = { //
+        1, 2, 3, //
+        4, 5, 6, //
+        7, 8, 9, //
+        10, 11, 12
+    };
+    private static final int MAX_TIMEOUT_MILLIS = 1000;
+    private static final int WAIT_N_FX_PULSES = 3;
+    private static final double IMAGE_CMP_THRESHOLD = 0.99; // 1.0 is perfect identity
+    private static final int WIDTH = 300;
+    private static final int HEIGHT = 200;
+    private XYChart chart;
+    private ContourDataSetRenderer renderer;
+    private Image testImage;
+
+    @Start
+    public void start(Stage stage) {
+        assertDoesNotThrow(() -> new ContourDataSetRenderer());
+        renderer = new ContourDataSetRenderer();
+        renderer.getDatasets().add(getTestDataSet());
+        chart = new XYChart(new DefaultNumericAxis(), new DefaultNumericAxis());
+        chart.getRenderers().set(0, renderer);
+        chart.legendVisibleProperty().set(true);
+
+        stage.setScene(new Scene(chart, WIDTH, HEIGHT));
+        stage.show();
+    }
+
+    @ParameterizedTest
+    @EnumSource(ContourType.class)
+    public void testRendererNominal(final ContourType contourType) throws IOException, Exception {
+        testRenderer(contourType, false);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ContourType.class)
+    public void testRendererAlt(final ContourType contourType) throws IOException, Exception {
+        testRenderer(contourType, true);
+    }
+
+    private void testRenderer(final ContourType contourType, final boolean altImplementation) throws IOException, Exception {
+        renderer.setAltImplementation(altImplementation);
+        renderer.setContourType(contourType);
+        final String contourTypeString = renderer.getContourType().toString();
+        final String referenceImage = referenceFileName + contourTypeString + (altImplementation ? "_ALT" : "") + referenceFileExtension;
+        FXUtils.runAndWait(() -> chart.requestLayout());
+        assertTrue(FXUtils.waitForFxTicks(chart.getScene(), WAIT_N_FX_PULSES, MAX_TIMEOUT_MILLIS));
+
+        FXUtils.runAndWait(() -> testImage = chart.snapshot(null, null));
+        final double tresholdIdentity = compareAndWriteReference(clazz, referenceImage, testImage);
+        if (IMAGE_CMP_THRESHOLD < tresholdIdentity) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.atInfo().addArgument(tresholdIdentity).log("image identity - threshold = {}");
+            }
+        } else {
+            // write image to report repository
+            writeTestImage(clazz, "Test_" + clazz.getSimpleName() + "_identity.png", testImage);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.atWarn().addArgument(tresholdIdentity).log("image identity - threshold exceeded = {}");
+            }
+        }
+
+        FXUtils.runAndWait(() -> chart.requestLayout());
+        assertTrue(FXUtils.waitForFxTicks(chart.getScene(), WAIT_N_FX_PULSES, MAX_TIMEOUT_MILLIS));
+
+        FXUtils.runAndWait(() -> testImage = chart.snapshot(null, null));
+        final double tresholdNonIdentity = compareAndWriteReference(clazz, referenceImage, testImage);
+        if (IMAGE_CMP_THRESHOLD > tresholdNonIdentity) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.atInfo().addArgument(tresholdNonIdentity).log("image non-identity - threshold = {}");
+            }
+        } else {
+            // write image to report repository
+            writeTestImage(clazz, "Test_" + clazz.getSimpleName() + "_nonidentity.png", testImage);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.atWarn().addArgument(tresholdNonIdentity).log("image non-identity - threshold exceeded = {}");
+            }
+        }
+    }
+
+    @TestFx
+    public void test() {
+        final ContourDataSetCache cache = new ContourDataSetCache(new XYChart(), new ContourDataSetRenderer(), getTestDataSet());
+        assertDoesNotThrow(() -> cache.convertDataArrayToImage(TEST_DATA_Z, TEST_DATA_X.length, TEST_DATA_Y.length, ColorGradient.DEFAULT), "data to colour image conversion");
+    }
+
+    private DataSet3D getTestDataSet() {
+        return new ContourDataSetCacheTests().new TestDataSet();
+    }
+}

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ErrorDataSetRendererTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/ErrorDataSetRendererTests.java
@@ -1,0 +1,186 @@
+package de.gsi.chart.renderer.spi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.compareAndWriteReference;
+import static de.gsi.chart.ui.utils.FuzzyTestImageUtils.writeTestImage;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.renderer.ErrorStyle;
+import de.gsi.chart.renderer.LineStyle;
+import de.gsi.chart.ui.utils.JavaFXInterceptorUtils.SelectiveJavaFxInterceptor;
+import de.gsi.chart.utils.FXUtils;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.testdata.spi.SineFunction;
+import de.gsi.math.DataSetMath;
+
+/**
+ * Tests {@link de.gsi.chart.renderer.spi.ErrorDataSetRenderer }
+ *
+ * @author rstein
+ *
+ */
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(SelectiveJavaFxInterceptor.class)
+public class ErrorDataSetRendererTests {
+    private static final Class<?> clazz = ErrorDataSetRendererTests.class;
+    private static final Logger LOGGER = LoggerFactory.getLogger(clazz);
+    private static final String className = clazz.getSimpleName();
+    private static final String referenceFileName = "./Reference_" + className;
+    private static final String referenceFileExtension = ".png";
+    private static final int MAX_TIMEOUT_MILLIS = 1000;
+    private static final int WAIT_N_FX_PULSES = 3;
+    private static final double IMAGE_CMP_THRESHOLD = 0.5; // 1.0 is perfect identity
+    private static final int WIDTH = 600;
+    private static final int HEIGHT = 480;
+    private static final int N_SAMPLES = 10000;
+    private DefaultNumericAxis xAxis = new DefaultNumericAxis();
+    private DefaultNumericAxis yAxis = new DefaultNumericAxis();
+    private XYChart chart;
+    private ErrorDataSetRenderer renderer;
+    private Image testImage;
+
+    @Start
+    public void start(Stage stage) {
+        assertDoesNotThrow(() -> new ErrorDataSetRenderer());
+        renderer = new ErrorDataSetRenderer();
+        renderer.getDatasets().setAll(getTestDataSet());
+        chart = new XYChart(xAxis, yAxis);
+        chart.getRenderers().set(0, renderer);
+        chart.legendVisibleProperty().set(true);
+
+        stage.setScene(new Scene(chart, WIDTH, HEIGHT));
+        stage.show();
+    }
+
+    @ParameterizedTest
+    @EnumSource(LineStyle.class)
+    public void testRendererNominal(final LineStyle lineStyle) throws IOException, Exception {
+        for (ErrorStyle eStyle : ErrorStyle.values()) {
+            renderer.setErrorType(eStyle);
+            testRenderer(lineStyle);
+        }
+    }
+
+    @Test
+    public void testRendererSepcialCases() throws IOException, Exception {
+        final LineStyle lineStyle = LineStyle.NORMAL;
+
+        renderer.setPointReduction(false);
+        testRenderer(lineStyle);
+        renderer.setPointReduction(true);
+        testRenderer(lineStyle);
+        renderer.setDrawMarker(false);
+        testRenderer(lineStyle);
+        renderer.setDrawBubbles(true);
+        testRenderer(lineStyle);
+        renderer.setDrawBubbles(false);
+        renderer.setDrawBars(true);
+        testRenderer(lineStyle);
+        renderer.setShiftBar(true);
+        testRenderer(lineStyle);
+        renderer.setShiftBar(false);
+        renderer.setDrawBars(false);
+        chart.setPolarPlot(true);
+        testRenderer(lineStyle);
+        renderer.setDrawBars(true);
+        testRenderer(lineStyle);
+        renderer.setDrawBars(false);
+        FXUtils.runAndWait(() -> yAxis.setLogAxis(true));
+        testRenderer(lineStyle);
+        chart.setPolarPlot(false);
+        testRenderer(lineStyle);
+        FXUtils.runAndWait(() -> yAxis.setLogAxis(false));
+
+        // perform NaN only on JDK >= 11 on JDK8 this will crash JavaFX
+        final int jdkMajorVersion = Integer.parseInt(System.getProperty("java.version").split("\\.")[0]);
+        if (jdkMajorVersion >= 11) {
+            assertTrue(jdkMajorVersion >= 11);
+            renderer.setAllowNaNs(true);
+            testRenderer(lineStyle);
+            renderer.setAllowNaNs(false);
+        }
+    }
+
+    private void testRenderer(final LineStyle lineStyle) throws IOException, Exception {
+        renderer.setPolyLineStyle(lineStyle);
+        final String referenceImage = getReferenceImageFileName();
+        FXUtils.runAndWait(() -> renderer.getDatasets().setAll(getTestDataSet()));
+        FXUtils.runAndWait(() -> chart.getLegend().updateLegend(renderer.getDatasets(), Collections.singletonList(renderer), true));
+        FXUtils.runAndWait(() -> chart.requestLayout());
+        assertTrue(FXUtils.waitForFxTicks(chart.getScene(), WAIT_N_FX_PULSES, MAX_TIMEOUT_MILLIS));
+
+        FXUtils.runAndWait(() -> testImage = chart.snapshot(null, null));
+        final double tresholdIdentity = compareAndWriteReference(clazz, referenceImage, testImage);
+        if (IMAGE_CMP_THRESHOLD < tresholdIdentity) {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.atInfo().addArgument(tresholdIdentity).log("image identity - threshold = {}");
+            }
+        } else {
+            // write image to report repository
+            writeTestImage(clazz, "Test_" + clazz.getSimpleName() + "_identity.png", testImage);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.atWarn().addArgument(tresholdIdentity).log("image identity - threshold exceeded = {}");
+            }
+        }
+
+        FXUtils.runAndWait(() -> chart.requestLayout());
+        assertTrue(FXUtils.waitForFxTicks(chart.getScene(), WAIT_N_FX_PULSES, MAX_TIMEOUT_MILLIS));
+
+        FXUtils.runAndWait(() -> testImage = chart.snapshot(null, null));
+        final double tresholdNonIdentity = compareAndWriteReference(clazz, referenceImage, testImage);
+        if (IMAGE_CMP_THRESHOLD > tresholdNonIdentity) {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.atInfo().addArgument(tresholdNonIdentity).log("image non-identity - threshold = {}");
+            }
+        } else {
+            // write image to report repository
+            writeTestImage(clazz, "Test_" + clazz.getSimpleName() + "_nonidentity.png", testImage);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.atWarn().addArgument(tresholdNonIdentity).log("image non-identity - threshold exceeded = {}");
+            }
+        }
+    }
+
+    private String getReferenceImageFileName() {
+        final String contourTypeString = renderer.getPolyLineStyle().toString();
+        final String reduced = renderer.isReducePoints() ? "_REDUCED" : "";
+        final String errorStyle = "_" + renderer.getErrorType().toString();
+        final String bars = renderer.isDrawBars() ? (renderer.isShiftBar() ? "_SHIFTEDBARDS" : "_BARS") : "";
+        final String bubbles = renderer.isDrawBubbles() ? "_BUBBLES" : "";
+        final String marker = renderer.isDrawMarker() ? "_MARKER" : "";
+        final String nan = renderer.isallowNaNs() ? "_NANALLOWED" : "";
+        final String options = reduced + errorStyle + bars + bubbles + marker + nan;
+        final String referenceImage = referenceFileName + contourTypeString + options + referenceFileExtension;
+        return referenceImage;
+    }
+
+    private DataSet getTestDataSet() {
+        final DoubleErrorDataSet retVal = (DoubleErrorDataSet) DataSetMath.addFunction(new SineFunction("test-sine", N_SAMPLES), 5.0);
+        retVal.setStyle("strokeColor=red;");
+        for (int i = 10; i < 1000; i++) {
+            retVal.addDataLabel(i, "special point");
+            retVal.addDataStyle(i, "strokeColor=green; fillColor=green; markerColor=green;");
+        }
+        return retVal;
+    }
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -566,12 +566,14 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
      */
     @Override
     public D recomputeLimits(final int dimIndex) {
-        // Clear previous ranges
-        getAxisDescription(dimIndex).clear();
+        // first compute range (does not trigger notify events)
+        DataRange newRange = new DataRange();
         final int dataCount = getDataCount(dimIndex);
         for (int i = 0; i < dataCount; i++) {
-            getAxisDescription(dimIndex).add(get(dimIndex, i));
+            newRange.add(get(dimIndex, i));
         }
+        // set to new computed one and trigger notify event if different to old limits
+        getAxisDescription(dimIndex).set(newRange.getMin(), newRange.getMax());
         return getThis();
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
@@ -21,7 +21,6 @@ public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends 
      */
     public AbstractDataSet3D(final String name) {
         super(name, 3);
-        getAxisDescriptions().add(new DefaultAxisDescription(this, "z-Axis", "a.u."));
     }
 
     /**
@@ -31,49 +30,5 @@ public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends 
     @Override
     public int getDataCount() {
         return getDataCount(DataSet.DIM_X) * getDataCount(DataSet.DIM_Y);
-    }
-
-    // @Override
-    // public DataRange getZRange() {
-    // if (!zRange.isDefined()) {
-    // computeLimits();
-    // }
-    // return zRange;
-    // }
-
-    /**
-     * recompute data set limits
-     */
-    @Override
-    public D recomputeLimits(final int dimension) {
-        // Clear previous ranges
-        getAxisDescription(dimension).clear();
-
-        if (dimension == 0) {
-            // x-range
-            final int dataCount = getDataCount(DataSet.DIM_X);
-            AxisDescription axisRange = getAxisDescription(dimension);
-            for (int i = 0; i < dataCount; i++) {
-                axisRange.add(getX(i));
-            }
-        } else if (dimension == 1) {
-            // x-range
-            final int dataCount = getDataCount(DataSet.DIM_Y);
-            AxisDescription axisRange = getAxisDescription(dimension);
-            for (int i = 0; i < dataCount; i++) {
-                axisRange.add(getY(i));
-            }
-        } else {
-            // z-range
-            final int xDataCount = getDataCount(DataSet.DIM_X);
-            final int yDataCount = getDataCount(DataSet.DIM_Y);
-            AxisDescription axisRange = getAxisDescription(dimension);
-            for (int i = 0; i < xDataCount; i++) {
-                for (int j = 0; j < yDataCount; j++) {
-                    axisRange.add(getZ(i, j));
-                }
-            }
-        }
-        return getThis();
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet3D.java
@@ -1,6 +1,5 @@
 package de.gsi.dataset.spi;
 
-import de.gsi.dataset.AxisDescription;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSet3D;
 
@@ -10,8 +9,7 @@ import de.gsi.dataset.DataSet3D;
  * @author rstein
  * @param <D> java generics handling of DataSet for derived classes (needed for fluent design)
  */
-public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends AbstractDataSet<D>
-        implements DataSet3D {
+public abstract class AbstractDataSet3D<D extends AbstractDataSet3D<D>> extends AbstractDataSet<D> implements DataSet3D {
     private static final long serialVersionUID = 2766945109681463872L;
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractErrorDataSet.java
@@ -69,8 +69,8 @@ public abstract class AbstractErrorDataSet<D extends AbstractErrorDataSet<D>> ex
      */
     @Override
     public D recomputeLimits(final int dimIndex) {
-        // Clear previous ranges
-        getAxisDescription(dimIndex).clear();
+        // first compute range (does not trigger notify events)
+        DataRange newRange = new DataRange();
         final int dataCount = getDataCount(dimIndex);
         switch (getErrorType(dimIndex)) {
         case NO_ERROR:
@@ -81,18 +81,22 @@ public abstract class AbstractErrorDataSet<D extends AbstractErrorDataSet<D>> ex
                 final double value = get(dimIndex, i);
                 final double errorNeg = getErrorNegative(dimIndex, i);
                 final double errorPos = getErrorPositive(dimIndex, i);
-                getAxisDescription(dimIndex).add(value - errorNeg);
-                getAxisDescription(dimIndex).add(value + errorPos);
+                newRange.add(value - errorNeg);
+                newRange.add(value + errorPos);
             }
+            // set to new computed one and trigger notify event if different to old limits
+            getAxisDescription(dimIndex).set(newRange.getMin(), newRange.getMax());
             break;
         case SYMMETRIC:
         default:
             for (int i = 0; i < dataCount; i++) {
                 final double value = get(dimIndex, i);
                 final double error = getErrorPositive(dimIndex, i);
-                getAxisDescription(dimIndex).add(value - error);
-                getAxisDescription(dimIndex).add(value + error);
+                newRange.add(value - error);
+                newRange.add(value + error);
             }
+            // set to new computed one and trigger notify event if different to old limits
+            getAxisDescription(dimIndex).set(newRange.getMin(), newRange.getMax());
             break;
         }
         return getThis();

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DefaultAxisDescription.java
@@ -291,12 +291,13 @@ public class DefaultAxisDescription extends DataRange implements AxisDescription
 
     @Override
     public boolean set(final double min, final double max) {
-        if (super.set(min, max)) {
-            return false;
+        final boolean a = super.setMin(min);
+        final boolean b = super.setMax(max);
+        if (a || b) {
+            notifyRangeChange();
+            return true;
         }
-
-        notifyRangeChange();
-        return true;
+        return false;
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DoubleArrayCache.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DoubleArrayCache.java
@@ -3,14 +3,14 @@ package de.gsi.dataset.utils;
 import java.lang.ref.Reference;
 
 /**
- * Implements byte-array (byte[]) cache collection to minimise memory re-allocation.
+ * Implements double-array (double[]) cache collection to minimise memory re-allocation.
  *  
  * <p> 
  * N.B. This is useful to re-use short-lived data storage container to minimise the amount of garbage to be collected. This is used in situation replacing e.g.
  * <pre>
  *  {@code
  *      public returnValue frequentlyExecutedFunction(...) {
- *          final byte[] storage = new byte[10000]; // allocate new memory block (costly)
+ *          final double[] storage = new byte[10000]; // allocate new memory block (costly)
  *          // [...] do short-lived computation on storage
  *          // storage is implicitly finalised by garbage collector (costly)
  *      }
@@ -24,7 +24,7 @@ import java.lang.ref.Reference;
  *      // ...
  *      
  *      public returnValue frequentlyExecutedFunction(...) {
- *          final byte[] storage = cache.getArray(10000); // return previously allocated array (cheap) or allocated new if necessary 
+ *          final double[] storage = cache.getArray(10000); // return previously allocated array (cheap) or allocated new if necessary 
  *          // [...] do short-lived computation on storage
  *          cache.add(storage); // return object to cache
  *      }
@@ -34,24 +34,24 @@ import java.lang.ref.Reference;
  * @author rstein
  *
  */
-public class ByteArrayCache extends CacheCollection<byte[]> {
-    private static final ByteArrayCache SELF = new ByteArrayCache();
+public class DoubleArrayCache extends CacheCollection<double[]> {
+    private static final DoubleArrayCache SELF = new DoubleArrayCache();
 
-    public byte[] getArray(final int requiredSize) {
+    public double[] getArray(final int requiredSize) {
         return getArray(requiredSize, false);
     }
 
-    public byte[] getArrayExact(final int requiredSize) {
+    public double[] getArrayExact(final int requiredSize) {
         return getArray(requiredSize, true);
     }
 
-    private byte[] getArray(final int requiredSize, final boolean exact) {
+    private double[] getArray(final int requiredSize, final boolean exact) {
         synchronized (contents) {
-            byte[] bestFit = null;
+            double[] bestFit = null;
             int bestFitSize = Integer.MAX_VALUE;
 
-            for (final Reference<byte[]> candidate : contents) {
-                final byte[] localRef = candidate.get();
+            for (final Reference<double[]> candidate : contents) {
+                final double[] localRef = candidate.get();
                 if (localRef == null) {
                     continue;
                 }
@@ -69,8 +69,8 @@ public class ByteArrayCache extends CacheCollection<byte[]> {
             }
 
             if (bestFit == null) {
-                // could not find any cached, return new byte[]
-                bestFit = new byte[requiredSize];
+                // could not find any cached, return new double[]
+                bestFit = new double[requiredSize];
                 return bestFit;
             }
 
@@ -79,7 +79,7 @@ public class ByteArrayCache extends CacheCollection<byte[]> {
         }
     }
 
-    public static ByteArrayCache getInstance() {
+    public static DoubleArrayCache getInstance() {
         return SELF;
     }
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DoubleArrayCacheTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/utils/DoubleArrayCacheTests.java
@@ -15,26 +15,26 @@ import org.slf4j.LoggerFactory;
 
 /**
  * 
- * Tests implementation of {@link de.gsi.dataset.utils.ByteArrayCache} as well as implicitly {@link de.gsi.dataset.utils.CacheCollection}.
+ * Tests implementation of {@link de.gsi.dataset.utils.DoubleArrayCache} as well as implicitly {@link de.gsi.dataset.utils.CacheCollection}.
  * 
  * @author rstein
  *
- *         N.B. to run manually: javac ByteArrayCacheTests.java java -Xms256m
- *         -Xmx256m ByteArrayCacheTests
+ *         N.B. to run manually: javac DoubleArrayCacheTests.java java -Xms256m
+ *         -Xmx256m DoubleArrayCacheTests
  */
-public class ByteArrayCacheTests {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ByteArrayCacheTests.class);
+public class DoubleArrayCacheTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DoubleArrayCacheTests.class);
     private static final int N_ITERATIONS = 1000;
     private static final int N_INITIAL_CACHE_OBJECTS = 10;
     private static final int N_CACHE_ARRAY_SIZE = 10_000_000;
 
     @Test
     public void testBasicFunction() {
-        final ByteArrayCache cache = new ByteArrayCache();
+        final DoubleArrayCache cache = new DoubleArrayCache();
         assertEquals(0, cache.size(), "initial cache size");
 
         for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
-            cache.add(new byte[N_CACHE_ARRAY_SIZE]);
+            cache.add(new double[N_CACHE_ARRAY_SIZE]);
         }
         assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
 
@@ -43,10 +43,10 @@ public class ByteArrayCacheTests {
         forceMemoryShortage();
         assertEquals(0, cache.size(), "zero-ing memory and SoftReferenes");
 
-        cache.add(new byte[N_CACHE_ARRAY_SIZE - 10]);
-        cache.add(new byte[N_CACHE_ARRAY_SIZE]);
-        cache.add(new byte[N_CACHE_ARRAY_SIZE + 10]);
-        cache.add(new byte[N_CACHE_ARRAY_SIZE + 5]);
+        cache.add(new double[N_CACHE_ARRAY_SIZE - 10]);
+        cache.add(new double[N_CACHE_ARRAY_SIZE]);
+        cache.add(new double[N_CACHE_ARRAY_SIZE + 10]);
+        cache.add(new double[N_CACHE_ARRAY_SIZE + 5]);
         assertEquals(4, cache.size());
 
         assertEquals(N_CACHE_ARRAY_SIZE, cache.getArray(N_CACHE_ARRAY_SIZE).length);
@@ -61,7 +61,7 @@ public class ByteArrayCacheTests {
         assertEquals(0, cache.size());
 
         // prevent adding twice
-        final byte[] array = new byte[1000];
+        final double[] array = new double[1000];
         assertFalse(cache.contains(array));
         assertTrue(cache.add(array));
         assertTrue(cache.contains(array));
@@ -73,25 +73,25 @@ public class ByteArrayCacheTests {
         assertFalse(cache.remove(null));
 
         // remove non-existent byte array
-        assertFalse(cache.remove(new byte[1]));
+        assertFalse(cache.remove(new double[1]));
 
-        assertNotNull(ByteArrayCache.getInstance());
+        assertNotNull(DoubleArrayCache.getInstance());
     }
 
     @Test
     public void testIterators() {
-        final ByteArrayCache cache = new ByteArrayCache();
+        final DoubleArrayCache cache = new DoubleArrayCache();
         assertEquals(0, cache.size(), "initial cache size");
 
         for (int i = 0; i < N_INITIAL_CACHE_OBJECTS; i++) {
-            cache.add(new byte[1000]);
+            cache.add(new double[1000]);
         }
         assertEquals(N_INITIAL_CACHE_OBJECTS, cache.size(), "allocated dummy arrays -- N.B. if this fails the testing environment likely has not have enough memory");
 
-        final java.util.Iterator<byte[]> iter = cache.iterator();
+        final java.util.Iterator<double[]> iter = cache.iterator();
         int count = 0;
         while (iter.hasNext()) {
-            final byte[] element = iter.next();
+            final double[] element = iter.next();
             if (count == 0 || element == null) {
                 iter.remove();
             }
@@ -102,11 +102,11 @@ public class ByteArrayCacheTests {
 
     private static void forceMemoryShortage() {
         boolean run = true;
-        List<byte[]> strongReference = Collections.synchronizedList(new ArrayList<>(100000));
+        List<double[]> strongReference = Collections.synchronizedList(new ArrayList<>(100000));
 
         while (run) {
             try {
-                strongReference.add(new byte[10_000_000]);
+                strongReference.add(new double[10_000_000]);
             } catch (final OutOfMemoryError e) {
                 run = false;
             }
@@ -119,12 +119,12 @@ public class ByteArrayCacheTests {
     }
 
     private static double performanceCheckCached() {
-        final ByteArrayCache cache = new ByteArrayCache();
-        cache.add(new byte[N_CACHE_ARRAY_SIZE]);
+        final DoubleArrayCache cache = new DoubleArrayCache();
+        cache.add(new double[N_CACHE_ARRAY_SIZE]);
 
         final long start = System.nanoTime();
         for (int i = 0; i < N_ITERATIONS; i++) {
-            byte[] array = cache.getArray(N_CACHE_ARRAY_SIZE);
+            double[] array = cache.getArray(N_CACHE_ARRAY_SIZE);
 
             // simple check to minimise JIT optimisations
             if (array[0] != 0.0 || array.length != N_CACHE_ARRAY_SIZE) {
@@ -143,7 +143,7 @@ public class ByteArrayCacheTests {
     private static double performanceCheckClassic() {
         final long start = System.nanoTime();
         for (int i = 0; i < N_ITERATIONS; i++) {
-            byte[] array = new byte[N_CACHE_ARRAY_SIZE];
+            double[] array = new double[N_CACHE_ARRAY_SIZE];
 
             // simple check to minimise JIT optimisations
             if (array[0] != 0.0 || array.length != N_CACHE_ARRAY_SIZE) {
@@ -159,7 +159,7 @@ public class ByteArrayCacheTests {
     }
 
     public static void main(String[] args) {
-        final ByteArrayCacheTests test = new ByteArrayCacheTests();
+        final DoubleArrayCacheTests test = new DoubleArrayCacheTests();
 
         test.testBasicFunction();
         final double mem1 = Runtime.getRuntime().totalMemory();
@@ -167,8 +167,8 @@ public class ByteArrayCacheTests {
         final double mem2 = Runtime.getRuntime().totalMemory();
         final double cached = performanceCheckCached();
         final double mem3 = Runtime.getRuntime().totalMemory();
-        LOGGER.atInfo().addArgument(classic).addArgument(cached).log("ByteArrayCache performance difference: {} ns (classic) vs. {} ns (cached)");
-        LOGGER.atInfo().addArgument(classic / cached * 100.0).log("ByteArrayCache performance difference: {}& (classic/cached)");
+        LOGGER.atInfo().addArgument(classic).addArgument(cached).log("DoubleArrayCache performance difference: {} ns (classic) vs. {} ns (cached)");
+        LOGGER.atInfo().addArgument(classic / cached * 100.0).log("DoubleArrayCache performance difference: {}& (classic/cached)");
         LOGGER.atInfo().addArgument(mem1).log("memory before: {} Bytes");
         LOGGER.atInfo().addArgument(mem2).log("after classic: {} Bytes");
         LOGGER.atInfo().addArgument(mem3).log("after cached:  {} Bytes");

--- a/chartfx-dataset/src/test/resources/junit-platform.properties
+++ b/chartfx-dataset/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
-junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.enabled=false
 junit.jupiter.execution.parallel.mode.default = same_thread
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
 junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/chartfx-math/src/main/java/de/gsi/math/MultiDimDataSetMath.java
+++ b/chartfx-math/src/main/java/de/gsi/math/MultiDimDataSetMath.java
@@ -1,0 +1,227 @@
+package de.gsi.math;
+
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+import static de.gsi.dataset.DataSet.DIM_Z;
+
+import java.util.Arrays;
+
+import de.gsi.dataset.AxisDescription;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.utils.DoubleArrayCache;
+
+/**
+ * Some math operation on multi-dimensional DataSets (nDim larger than 2)
+ *
+ * @author rstein
+ */
+public final class MultiDimDataSetMath { // NOPMD -- nomen est omen
+
+    private MultiDimDataSetMath() {
+        // this is a utility class
+    }
+
+    public static void computeIntegral(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax) {
+        computeMeanIntegral(source, output, dimIndex, xMin, xMax, false);
+    }
+
+    public static void computeMax(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax) {
+        computeMinMax(source, output, dimIndex, xMin, xMax, false);
+    }
+
+    public static void computeMean(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax) {
+        computeMeanIntegral(source, output, dimIndex, xMin, xMax, true);
+    }
+
+    public static void computeMin(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax) {
+        computeMinMax(source, output, dimIndex, xMin, xMax, true);
+    }
+
+    public static void computeSlice(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin) {
+        checkMultiDimDataSetCompatibility(source);
+        checkOutputDataSetCompatibility(output);
+        final double[] xValues = output.getValues(DIM_X);
+        final double[] yValues = output.getValues(DIM_Y);
+        final double[] yErrorNeg = output.getErrorsNegative(DIM_Y);
+        final double[] yErrorPos = output.getErrorsPositive(DIM_Y);
+
+        if (source.getDataCount(dimIndex) == output.getDataCount(DIM_X)) {
+            final int nsize = source.getDataCount(dimIndex);
+            System.arraycopy(source.getValues(dimIndex), 0, xValues, 0, nsize);
+            final double[] ret = MultiDimDataSetMath.getSliceArray(source, dimIndex, xMin, yValues);
+            output.set(xValues, ret, yErrorNeg, yErrorPos, false);
+        } else {
+            final int nsize = source.getDataCount(dimIndex);
+            final double[] ret = MultiDimDataSetMath.getSliceArray(source, dimIndex, xMin, yValues);
+            output.set(Arrays.copyOf(source.getValues(dimIndex), nsize), ret, new double[nsize], new double[nsize], false);
+        }
+
+        output.setName("slice(" + source.getName() + ")@" + xMin + " " + source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_X).set(source.getAxisDescription(dimIndex).getName(), source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_Y).set(source.getAxisDescription(DIM_Z).getName(), source.getAxisDescription(DIM_Z).getUnit());
+        output.getAxisDescriptions().stream().forEach(AxisDescription::clear);
+    }
+
+    public static double[] getMeanIntegralArray(final DataSet source, final int dimIndex, final double xMin, final double xMax, final double[] buffer, final boolean isMean) {
+        checkMultiDimDataSetCompatibility(source);
+        final double[] ret = getSanitizedBuffer(source, dimIndex, buffer);
+
+        final int minIndex = source.getIndex(dimIndex == DIM_X ? DIM_Y : DIM_X, xMin);
+        final int maxIndex = source.getIndex(dimIndex == DIM_X ? DIM_Y : DIM_X, xMax);
+        final int min = Math.min(minIndex, maxIndex);
+        final int max = Math.max(Math.max(minIndex, maxIndex), min + 1);
+
+        final int nDataCount = source.getDataCount(dimIndex);
+        final int rowSize = source.getDataCount(DIM_X);
+        if (dimIndex == DIM_Y) {
+            for (int index = 0; index < nDataCount; index++) {
+                double integral = 0.0;
+                int nSlices = 0;
+                for (int i = min; i <= Math.min(max, nDataCount - 1); i++) {
+                    integral += source.get(DIM_Z, i + index * rowSize);
+                    nSlices += 1;
+                }
+                ret[index] = isMean ? nSlices == 0 ? Double.NaN : integral / nSlices : integral;
+            }
+        } else {
+            for (int index = 0; index < nDataCount; index++) {
+                double integral = 0.0;
+                int nSlices = 0;
+                for (int i = min; i <= Math.min(max, nDataCount - 1); i++) {
+                    integral += source.get(DIM_Z, index + i * rowSize);
+                    nSlices += 1;
+                }
+                ret[index] = isMean ? nSlices == 0 ? Double.NaN : integral / nSlices : integral;
+            }
+        }
+        return ret;
+    }
+
+    public static double[] getMinMaxArray(final DataSet source, final int dimIndex, final double xMin, final double xMax, final double[] buffer, final boolean isMin) {
+        checkMultiDimDataSetCompatibility(source);
+        final double[] ret = getSanitizedBuffer(source, dimIndex, buffer);
+
+        final int minIndex = source.getIndex(dimIndex == DIM_X ? DIM_Y : DIM_X, xMin);
+        final int maxIndex = source.getIndex(dimIndex == DIM_X ? DIM_Y : DIM_X, xMax);
+
+        final int min = Math.min(minIndex, maxIndex);
+        final int max = Math.max(Math.max(minIndex, maxIndex), min + 1);
+
+        final int nDataCount = source.getDataCount(dimIndex);
+        final int rowSize = source.getDataCount(DIM_X);
+        if (dimIndex == DIM_Y) {
+            for (int index = 0; index < nDataCount; index++) {
+                double extreme = source.get(DIM_Z, min + index * rowSize);
+                for (int i = min + 1; i <= Math.min(max, nDataCount - 1); i++) {
+                    final double val = source.get(DIM_Z, i + index * rowSize);
+                    extreme = isMin ? Math.min(val, extreme) : Math.max(val, extreme);
+                }
+                ret[index] = extreme;
+            }
+        } else {
+            for (int index = 0; index < nDataCount; index++) {
+                double extreme = source.get(DIM_Z, index + min * rowSize);
+                for (int i = min + 1; i <= Math.min(max, nDataCount - 1); i++) {
+                    final double val = source.get(DIM_Z, index + i * rowSize);
+                    extreme = isMin ? Math.min(val, extreme) : Math.max(val, extreme);
+                }
+                ret[index] = extreme;
+            }
+        }
+
+        return ret;
+    }
+
+    public static double[] getSliceArray(final DataSet source, final int dimIndex, final double xMin, final double[] buffer) {
+        checkMultiDimDataSetCompatibility(source);
+        final double[] ret = getSanitizedBuffer(source, dimIndex, buffer);
+
+        final int minIndex = source.getIndex(dimIndex == DIM_X ? DIM_Y : DIM_X, xMin);
+
+        final int nDataCount = source.getDataCount(dimIndex);
+        final int rowSize = source.getDataCount(DIM_X);
+        if (dimIndex == DIM_Y) {
+            for (int index = 0; index < nDataCount; index++) {
+                final double y = source.get(DIM_Z, minIndex + index * rowSize);
+                ret[index] = y;
+            }
+        } else {
+            for (int index = 0; index < nDataCount; index++) {
+                final double y = source.get(DIM_Z, index + minIndex * rowSize);
+                ret[index] = y;
+            }
+        }
+
+        return ret;
+    }
+
+    private static void checkMultiDimDataSetCompatibility(final DataSet source) {
+        if (source == null || source.getDimension() <= 2) {
+            throw new IllegalArgumentException("source is " + (source == null ? "null" : " has insufficient dimension = " + source.getDimension()));
+        }
+    }
+
+    private static void checkOutputDataSetCompatibility(final DataSet ouput) {
+        if (ouput == null || ouput.getDimension() != 2) {
+            throw new IllegalArgumentException("output is " + (ouput == null ? "null" : " has insufficient dimension = " + ouput.getDimension()));
+        }
+    }
+
+    private static void computeMeanIntegral(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax, final boolean isMean) {
+        checkMultiDimDataSetCompatibility(source);
+        checkOutputDataSetCompatibility(output);
+        final double[] xValues = output.getValues(DIM_X);
+        final double[] yValues = output.getValues(DIM_Y);
+        final double[] yErrorNeg = output.getErrorsNegative(DIM_Y);
+        final double[] yErrorPos = output.getErrorsPositive(DIM_Y);
+
+        if (source.getDataCount(dimIndex) == output.getDataCount(DIM_X)) {
+            final int nsize = source.getDataCount(dimIndex);
+            System.arraycopy(source.getValues(dimIndex), 0, xValues, 0, nsize);
+            final double[] ret = MultiDimDataSetMath.getMeanIntegralArray(source, dimIndex, xMin, xMax, yValues, isMean);
+            output.set(xValues, ret, yErrorNeg, yErrorPos, false);
+        } else {
+            final int nsize = source.getDataCount(dimIndex);
+            final double[] ret = MultiDimDataSetMath.getMeanIntegralArray(source, dimIndex, xMin, xMax, yValues, isMean);
+            output.set(Arrays.copyOf(source.getValues(dimIndex), nsize), ret, new double[nsize], new double[nsize], false);
+        }
+
+        output.setName((isMean ? "mean(" : "int(") + source.getName() + ")@" + xMin + " -> " + xMax + " " + source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_X).set(source.getAxisDescription(dimIndex).getName(), source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_Y).set(source.getAxisDescription(DIM_Z).getName(), source.getAxisDescription(DIM_Z).getUnit());
+        output.getAxisDescriptions().stream().forEach(AxisDescription::clear);
+    }
+
+    private static void computeMinMax(final DataSet source, final DoubleErrorDataSet output, final int dimIndex, final double xMin, final double xMax, final boolean isMin) {
+        checkMultiDimDataSetCompatibility(source);
+        checkOutputDataSetCompatibility(output);
+        final double[] xValues = output.getValues(DIM_X);
+        final double[] yValues = output.getValues(DIM_Y);
+        final double[] yErrorNeg = output.getErrorsNegative(DIM_Y);
+        final double[] yErrorPos = output.getErrorsPositive(DIM_Y);
+
+        if (source.getDataCount(dimIndex) == output.getDataCount(DIM_X)) {
+            final int nsize = source.getDataCount(dimIndex);
+            System.arraycopy(source.getValues(dimIndex), 0, xValues, 0, nsize);
+            final double[] ret = MultiDimDataSetMath.getMinMaxArray(source, dimIndex, xMin, xMax, yValues, isMin);
+            output.set(xValues, ret, yErrorNeg, yErrorPos, false);
+        } else {
+            final int nsize = source.getDataCount(dimIndex);
+            final double[] ret = MultiDimDataSetMath.getMinMaxArray(source, dimIndex, xMin, xMax, yValues, isMin);
+            output.set(Arrays.copyOf(source.getValues(dimIndex), nsize), ret, new double[nsize], new double[nsize], false);
+        }
+
+        output.setName((isMin ? "min(" : "max(") + source.getName() + ")@" + xMin + " -> " + xMax + " " + source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_X).set(source.getAxisDescription(dimIndex).getName(), source.getAxisDescription(dimIndex).getUnit());
+        output.getAxisDescription(DIM_Y).set(source.getAxisDescription(DIM_Z).getName(), source.getAxisDescription(DIM_Z).getUnit());
+        output.getAxisDescriptions().stream().forEach(AxisDescription::clear);
+    }
+
+    private static double[] getSanitizedBuffer(final DataSet source, final int dimIndex, final double[] buffer) {
+        final int size = source.getDataCount(dimIndex == DIM_X ? DIM_X : DIM_Y);
+        final boolean invalidBUffer = buffer == null || buffer.length < size;
+        final double[] ret = invalidBUffer ? DoubleArrayCache.getInstance().getArrayExact(size) : buffer;
+        return ret;
+    }
+}

--- a/chartfx-math/src/test/java/de/gsi/math/MultiDimDatasetMathTests.java
+++ b/chartfx-math/src/test/java/de/gsi/math/MultiDimDatasetMathTests.java
@@ -1,0 +1,246 @@
+package de.gsi.math;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.gsi.dataset.spi.DoubleDataSet3D;
+import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.dataset.spi.utils.MathUtils;
+
+/**
+ * Tests for the {@link de.gsi.math.MultiDimDataSetMath} -- Reduces 3D data to
+ * 2D DataSet either via slicing, min, mean, max or integration
+ *
+ * @author rstein
+ */
+public class MultiDimDatasetMathTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiDimDatasetMathTests.class);
+
+    @Test
+    public void testIntegralOptions() {
+        LOGGER.atDebug().log("testIntegralOptions");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DoubleErrorDataSet sliceDataSetX = new DoubleErrorDataSet("test_X");
+        DoubleErrorDataSet sliceDataSetY = new DoubleErrorDataSet("test_Y");
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeIntegral(null, sliceDataSetX, DIM_X, 0.0, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeIntegral(testData, null, DIM_X, 0.0, 4.0));
+
+        // integral over full array
+        final double[] integralX = new double[3];
+        final double[] integralY = new double[3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                integralX[j] += testData.getZ(j, i);
+                integralY[i] += testData.getZ(j, i);
+            }
+        }
+
+        for (int i = 0; i < 2; i++) {
+            if (i == 0) {
+                assertTrue(testData.getDataCount(DIM_X) != sliceDataSetX.getDataCount(DIM_X));
+                assertTrue(testData.getDataCount(DIM_Y) != sliceDataSetY.getDataCount(DIM_X));
+            } else {
+                // N.B. during the second iteration the sliceDataSets should have the same
+                // dimension as the source
+                assertEquals(testData.getDataCount(DIM_X), sliceDataSetX.getDataCount(DIM_X));
+                assertEquals(testData.getDataCount(DIM_Y), sliceDataSetY.getDataCount(DIM_X));
+            }
+            MultiDimDataSetMath.computeIntegral(testData, sliceDataSetX, DIM_X, 0, 9);
+            MultiDimDataSetMath.computeIntegral(testData, sliceDataSetY, DIM_Y, 0, 4);
+            assertArrayEquals(integralX, sliceDataSetX.getValues(DIM_Y), "x-integral");
+            assertArrayEquals(integralY, sliceDataSetY.getValues(DIM_Y), "y-integral");
+        }
+
+        LOGGER.atDebug().log("testIntegralOptions - done");
+    }
+
+    @Test
+    public void testMaxOptions() {
+        LOGGER.atDebug().log("testMaxOptions");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DoubleErrorDataSet sliceDataSetX = new DoubleErrorDataSet("test_X");
+        DoubleErrorDataSet sliceDataSetY = new DoubleErrorDataSet("test_Y");
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMax(null, sliceDataSetX, DIM_X, 0.0, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMax(testData, null, DIM_X, 0.0, 4.0));
+
+        // max over full array
+        final double[] maxY = new double[3];
+        final double[] maxX = new double[3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                maxX[j] = Math.max(testData.getZ(j, i), maxX[j]);
+                maxY[i] = Math.max(testData.getZ(j, i), maxY[i]);
+            }
+        }
+
+        for (int i = 0; i < 2; i++) {
+            if (i == 0) {
+                assertTrue(testData.getDataCount(DIM_X) != sliceDataSetX.getDataCount(DIM_X));
+                assertTrue(testData.getDataCount(DIM_Y) != sliceDataSetY.getDataCount(DIM_X));
+            } else {
+                // N.B. during the second iteration the sliceDataSets should have the same
+                // dimension as the source
+                assertEquals(testData.getDataCount(DIM_X), sliceDataSetX.getDataCount(DIM_X));
+                assertEquals(testData.getDataCount(DIM_Y), sliceDataSetY.getDataCount(DIM_X));
+            }
+            MultiDimDataSetMath.computeMax(testData, sliceDataSetX, DIM_X, 0, 10);
+            MultiDimDataSetMath.computeMax(testData, sliceDataSetY, DIM_Y, 0, 4);
+            assertArrayEquals(maxX, sliceDataSetX.getValues(DIM_Y), "x-max");
+            assertArrayEquals(maxY, sliceDataSetY.getValues(DIM_Y), "y-max");
+        }
+
+        LOGGER.atDebug().log("testMaxOptions - done");
+    }
+
+    @Test
+    public void testMeanOptions() {
+        LOGGER.atDebug().log("testMeanOptions");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DoubleErrorDataSet sliceDataSetX = new DoubleErrorDataSet("test_X");
+        DoubleErrorDataSet sliceDataSetY = new DoubleErrorDataSet("test_Y");
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMean(null, sliceDataSetX, DIM_X, 0.0, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMean(testData, null, DIM_X, 0.0, 4.0));
+
+        // mean over full array
+        final double[] meanX = new double[3];
+        final double[] meanY = new double[3];
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                meanX[j] += testData.getZ(j, i) / 3.0;
+                meanY[i] += testData.getZ(j, i) / 3.0;
+            }
+        }
+
+        for (int i = 0; i < 2; i++) {
+            if (i == 0) {
+                assertTrue(testData.getDataCount(DIM_X) != sliceDataSetX.getDataCount(DIM_X));
+                assertTrue(testData.getDataCount(DIM_Y) != sliceDataSetY.getDataCount(DIM_X));
+            } else {
+                // N.B. during the second iteration the sliceDataSets should have the same
+                // dimension as the source
+                assertEquals(testData.getDataCount(DIM_X), sliceDataSetX.getDataCount(DIM_X));
+                assertEquals(testData.getDataCount(DIM_Y), sliceDataSetY.getDataCount(DIM_X));
+            }
+            MultiDimDataSetMath.computeMean(testData, sliceDataSetX, DIM_X, 0, 10);
+            MultiDimDataSetMath.computeMean(testData, sliceDataSetY, DIM_Y, 0, 4);
+            for (int j = 0; j < 3; j++) {
+                assertTrue(MathUtils.nearlyEqual(meanX[j], sliceDataSetX.getValues(DIM_Y)[j]), "x-integral");
+                assertTrue(MathUtils.nearlyEqual(meanY[j], sliceDataSetY.getValues(DIM_Y)[j]), "y-integral");
+            }
+        }
+
+        LOGGER.atDebug().log("testMeanOptions - done");
+    }
+
+    @Test
+    public void testMinOptions() {
+        LOGGER.atDebug().log("testMinOptions");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DoubleErrorDataSet sliceDataSetX = new DoubleErrorDataSet("test_X");
+        DoubleErrorDataSet sliceDataSetY = new DoubleErrorDataSet("test_Y");
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMin(null, sliceDataSetX, DIM_X, 0.0, 10.0));
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeMin(testData, null, DIM_X, 0.0, 4.0));
+
+        // min over full array
+        final double[] minY = new double[] { Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE };
+        final double[] minX = new double[] { Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE };
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                minX[j] = Math.min(testData.getZ(j, i), minX[j]);
+                minY[i] = Math.min(testData.getZ(j, i), minY[i]);
+            }
+        }
+
+        for (int i = 0; i < 2; i++) {
+            if (i == 0) {
+                assertTrue(testData.getDataCount(DIM_X) != sliceDataSetX.getDataCount(DIM_X));
+                assertTrue(testData.getDataCount(DIM_Y) != sliceDataSetY.getDataCount(DIM_X));
+            } else {
+                // N.B. during the second iteration the sliceDataSets should have the same
+                // dimension as the source
+                assertEquals(testData.getDataCount(DIM_X), sliceDataSetX.getDataCount(DIM_X));
+                assertEquals(testData.getDataCount(DIM_Y), sliceDataSetY.getDataCount(DIM_X));
+            }
+            MultiDimDataSetMath.computeMin(testData, sliceDataSetX, DIM_X, 0, 10);
+            MultiDimDataSetMath.computeMin(testData, sliceDataSetY, DIM_Y, 0, 4);
+            assertArrayEquals(minX, sliceDataSetX.getValues(DIM_Y), "x-min");
+            assertArrayEquals(minY, sliceDataSetY.getValues(DIM_Y), "y-min");
+        }
+
+        LOGGER.atDebug().log("testMinOptions - done");
+    }
+
+    @Test
+    public void testSliceOptions() {
+        LOGGER.atDebug().log("testSliceOptions");
+        DoubleDataSet3D testData = new DoubleDataSet3D("test", //
+                new double[] { 1, 2, 3 }, // x-array
+                new double[] { 6, 7, 8 }, // y-array
+                new double[][] { // z-array
+                        new double[] { 1, 2, 3 }, //
+                        new double[] { 6, 5, 4 }, //
+                        new double[] { 9, 8, 7 } });
+
+        DoubleErrorDataSet sliceDataSetX = new DoubleErrorDataSet("test_X");
+        DoubleErrorDataSet sliceDataSetY = new DoubleErrorDataSet("test_Y");
+        MultiDimDataSetMath.computeSlice(testData, sliceDataSetX, DIM_X, 0.0);
+        MultiDimDataSetMath.computeSlice(testData, sliceDataSetY, DIM_Y, 0.0);
+
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeSlice(null, sliceDataSetX, DIM_X, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> MultiDimDataSetMath.computeSlice(testData, null, DIM_X, 0.0));
+
+        assertArrayEquals(testData.getValues(DIM_X), sliceDataSetX.getValues(DIM_X));
+        assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
+
+        assertArrayEquals(testData.getZValues()[0], sliceDataSetX.getValues(DIM_Y), "first row match");
+        assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
+
+        MultiDimDataSetMath.computeSlice(testData, sliceDataSetX, DIM_X, 7.0);
+
+        assertArrayEquals(testData.getZValues()[1], sliceDataSetX.getValues(DIM_Y), "second row match");
+        assertArrayEquals(testData.getValues(DIM_Y), sliceDataSetY.getValues(DIM_X));
+
+        assertArrayEquals(new double[] { 1, 6, 9 }, sliceDataSetY.getValues(DIM_Y), "first column match");
+        MultiDimDataSetMath.computeSlice(testData, sliceDataSetY, DIM_Y, 2.0);
+        assertArrayEquals(new double[] { 2, 5, 8 }, sliceDataSetY.getValues(DIM_Y), "second column match");
+
+        LOGGER.atDebug().log("testSliceOptions - done");
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/legacy/ChartPerformanceBenchmark.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/legacy/ChartPerformanceBenchmark.java
@@ -114,8 +114,7 @@ public class ChartPerformanceBenchmark extends AbstractTestApplication {
         subStage.show();
 
         final HBox headerBar = getHeaderBar(scene);
-        headerBar.getChildren().add(2, new VBox(startTestButton("Series@25Hz", testSamples25Hz, 40),
-                                               startTestButton("Series@2Hz", testSamples1Hz, 500)));
+        headerBar.getChildren().add(2, new VBox(startTestButton("Series@25Hz", testSamples25Hz, 40), startTestButton("Series@2Hz", testSamples1Hz, 500)));
         headerBar.getChildren().add(3, switchToTestCase("A", chartTestCase1, chart1));
         headerBar.getChildren().add(4, switchToTestCase("B", chartTestCase2, chart2));
         headerBar.getChildren().add(5, switchToTestCase("C", chartTestCase3, chart3));
@@ -162,6 +161,7 @@ public class ChartPerformanceBenchmark extends AbstractTestApplication {
                                 final TestThread t3 = new TestThread(3, compute[2] ? samples : 1000, chart3,
                                         chartTestCase3, results3, updatePeriod, wait);
 
+                                meter.resetAverages();
                                 if (compute[0]) {
                                     t1.start();
                                     t1.join();
@@ -194,7 +194,8 @@ public class ChartPerformanceBenchmark extends AbstractTestApplication {
                     }
                 };
                 timer.start();
-
+                LOGGER.atInfo().log("reset FPS averages");
+                meter.resetAverages();
             } else {
                 timer.interrupt();
                 timer = null;
@@ -216,6 +217,8 @@ public class ChartPerformanceBenchmark extends AbstractTestApplication {
             test = testCase;
             root.setCenter(chart);
             test.updateDataSet();
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
         return button;
     }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/legacy/utils/AbstractTestApplication.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/legacy/utils/AbstractTestApplication.java
@@ -17,9 +17,13 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.gsi.chart.utils.SimplePerformanceMeter;
 
 public abstract class AbstractTestApplication extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTestApplication.class);
     protected static final int MAX_DATA_POINTS_1K = 1000;
     protected static final int MAX_DATA_POINTS_10K = 10000;
     protected static final int MAX_DATA_POINTS_100K = 100000;
@@ -42,6 +46,8 @@ public abstract class AbstractTestApplication extends Application {
         newDataSet1k.setOnAction(evt -> {
             test.setNumberOfSamples(MAX_DATA_POINTS_1K);
             Platform.runLater(test::updateDataSet);
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         final Button newDataSet100k = new Button("100k");
@@ -50,6 +56,8 @@ public abstract class AbstractTestApplication extends Application {
         newDataSet100k.setOnAction(evt -> {
             test.setNumberOfSamples(MAX_DATA_POINTS_100K);
             Platform.runLater(test::updateDataSet);
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         final Button newDataSet10k = new Button("10k");
@@ -58,6 +66,8 @@ public abstract class AbstractTestApplication extends Application {
         newDataSet10k.setOnAction(evt -> {
             test.setNumberOfSamples(MAX_DATA_POINTS_10K);
             Platform.runLater(test::updateDataSet);
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         final Button newDataSet200k = new Button("200k");
@@ -66,6 +76,8 @@ public abstract class AbstractTestApplication extends Application {
         newDataSet200k.setOnAction(evt -> {
             test.setNumberOfSamples(MAX_DATA_POINTS_200K);
             Platform.runLater(test::updateDataSet);
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         final Button startTimer25Hz = new Button("T@25Hz");
@@ -84,6 +96,8 @@ public abstract class AbstractTestApplication extends Application {
                 timer.cancel();
                 timer = null;
             }
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         final Button startTimer1Hz = new Button("T@1Hz");
@@ -102,6 +116,8 @@ public abstract class AbstractTestApplication extends Application {
                 timer.cancel();
                 timer = null;
             }
+            LOGGER.atInfo().log("reset FPS averages");
+            meter.resetAverages();
         });
 
         // H-Spacer

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/utils/TestDataSetSource.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/utils/TestDataSetSource.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import de.gsi.dataset.event.AddedDataEvent;
 import de.gsi.dataset.spi.AbstractDataSet3D;
+import de.gsi.dataset.utils.ByteArrayCache;
 import de.gsi.dataset.utils.DoubleCircularBuffer;
 import de.gsi.math.ArrayUtils;
 import de.gsi.math.spectra.Apodization;
@@ -278,7 +279,7 @@ public class TestDataSetSource extends AbstractDataSet3D<TestDataSetSource> {
                 }
 
                 final int nAudioSamples = AUDIO_SAMPLING_RATE / 10;
-                final byte[] buffer = new byte[2 * nAudioSamples];
+                final byte[] buffer = ByteArrayCache.getInstance().getArrayExact(2 * nAudioSamples);
                 try (final AudioInputStream ais = new AudioInputStream(line)) {
                     int ret;
                     while ((ret = ais.read(buffer)) != 0 && running) {
@@ -298,6 +299,7 @@ public class TestDataSetSource extends AbstractDataSet3D<TestDataSetSource> {
                 } catch (final IOException e) {
                     LOGGER.atError().setCause(e).log("issue in audio IO loop");
                 }
+                ByteArrayCache.getInstance().add(buffer);
 
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.atDebug().log("stop recording...");


### PR DESCRIPTION
Based on user feedback by T. Milosic (Thanks Timo!!):

NEW FEATURES:
* added RAINBOW_OPAQUE colour palette with non-transparent boundaries
* recomputeLimits(..) and DefaultAxisDescription trigger now only one event on change
* removed superfluous code in AbstractDataSet3D already defined in its parent class
* new DoubleArrayCache impl. & getInstance() as global cache
  - added this to the ContourDataSetRenderer and ErrorDataSetRenderer
  - N.B. [Byte, Double]ArrayCache use internally SoftReference and are more suitable as Caching primitives than WeakHashmaps.
* added DimReduction functions to DataSetMeasurements & ParameterMeasurementPlugin
  - N.B. this is similar to the DimReductionDataSet. The latter is the stand-alone version.

FIXES:
* added missing readLockGuard to SimpleMeasurements computation
* upgraded EventSource::invokeListener() to non-blocking call
   N.B. solved threading issue for very high update rates and boosts overall performance
   - about 15% performance increase for DataSets with 10k or more DataPoints!
* disabled parallel testing (for testing): it seems that the parallel testing interferes with multiple tests that couple to each other via the GC and/or global thread-pools. tbc.

Added also several additional unit-tests to improve overall coverage.

Enjoy! 
