### PR TITLE
Fixes from testing the samples

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -128,7 +128,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
      * 
      * @param dataSet data set
      * @param searchedX x coordinate
-     * @return return neighouring data points
+     * @return return neighbouring data points
      */
     private Pair<DataPoint, DataPoint> findNeighborPoints(final DataSet dataSet, final double searchedX) {
         int prevIndex = -1;
@@ -137,15 +137,16 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         double nextX = Double.MAX_VALUE;
 
         final int nDataCount = dataSet.getDataCount(DataSet.DIM_X);
+        final int ny = dataSet.getDataCount(DataSet.DIM_Y); // ensure that the point is within data range. TODO: correctly handle 3D Data
         for (int i = 0, size = nDataCount; i < size; i++) {
             final double currentX = dataSet.get(DataSet.DIM_X, i);
 
             if (currentX < searchedX) {
-                if (prevX < currentX) {
+                if (prevX < currentX && i < ny) {
                     prevIndex = i;
                     prevX = currentX;
                 }
-            } else if (nextX > currentX) {
+            } else if (nextX > currentX && i < ny) {
                 nextIndex = i;
                 nextX = currentX;
             }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
@@ -566,9 +566,9 @@ public class ContourDataSetRenderer extends AbstractContourDataSetRendererParame
             break;
         case CONTOUR_HEXAGON:
             if (isAltImplementation()) {
-                drawHexagonMapContour(gc, localCache);
-            } else {
                 drawHexagonMapContourAlt(gc, axisTransform, localCache);
+            } else {
+                drawHexagonMapContour(gc, localCache);
             }
             break;
         case HEATMAP_HEXAGON:
@@ -614,6 +614,11 @@ public class ContourDataSetRenderer extends AbstractContourDataSetRendererParame
                 // minimum dimension criteria not met
                 continue;
             }
+            if (dataSet.getDataCount(DataSet.DIM_Z) != dataSet.getDataCount(DIM_X) * dataSet.getDataCount(DIM_Y)) {
+                // dataSet does not have grid Topology
+                continue;
+            }
+
             final boolean result = dataSet.lock().readLockGuard(() -> {
                 long stop = ProcessingProfiler.getTimeDiff(mid, "dataSet.lock()");
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
@@ -46,13 +46,8 @@ public class TransposedDataSet implements DataSet {
             permutation[0] = 1;
             permutation[1] = 0;
         }
-        // TODO: Evaluate if the data should be interpreted as on a grid, to be replaced by GridApi
-        for (int i = dataSet.getDimension() - 1; i >= 0; i--) {
-            if (dataSet.getDataCount(i) != dataSet.getDataCount()) {
-                grid = i + 1;
-                break;
-            }
-        }
+        evaluateGridType();
+        dataSet.addListener(event -> evaluateGridType());
     }
 
     private TransposedDataSet(final DataSet dataSet, final int[] permutation) {
@@ -73,6 +68,18 @@ public class TransposedDataSet implements DataSet {
         this.nDims = permutation.length;
         this.permutation = Arrays.copyOf(permutation, this.dataSet.getDimension());
         this.transposed = false;
+        evaluateGridType();
+        dataSet.addListener(event -> evaluateGridType());
+    }
+
+    private void evaluateGridType() {
+        // TODO: Evaluate if the data should be interpreted as on a grid, to be replaced by GridApi
+        for (int i = dataSet.getDimension() - 1; i >= 0; i--) {
+            if (dataSet.getDataCount(i) != dataSet.getDataCount()) {
+                grid = i + 1;
+                break;
+            }
+        }
     }
 
     @Override
@@ -192,13 +199,7 @@ public class TransposedDataSet implements DataSet {
 
     @Override
     public DataSet recomputeLimits(int dimension) {
-        // TODO: Evaluate if the data should be interpreted as on a grid, to be replaced by GridApi
-        for (int i = dataSet.getDimension() - 1; i >= 0; i--) {
-            if (dataSet.getDataCount(i) != dataSet.getDataCount()) {
-                grid = i + 1;
-                break;
-            }
-        }
+        evaluateGridType();
         return dataSet.recomputeLimits(permutation[dimension]);
     }
 

--- a/chartfx-math/src/main/java/de/gsi/math/spectra/wavelet/FastWaveletTransform.java
+++ b/chartfx-math/src/main/java/de/gsi/math/spectra/wavelet/FastWaveletTransform.java
@@ -1,5 +1,8 @@
 package de.gsi.math.spectra.wavelet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /************************
  * This is a very fast implementation of the Fast Wavelet Transform. It uses in-place computations for less memory
  * usage. Data length should be a power of 2 a be at least of length 8. Handles boundaries by assuming periodicity.
@@ -7,34 +10,33 @@ package de.gsi.math.spectra.wavelet;
  * 
  * @author Daniel Lemire
  *************************/
-public final class FastWaveletTransform {
-
+public final class FastWaveletTransform { // NOPMD - nomen est omen
+    private static final Logger LOGGER = LoggerFactory.getLogger(FastWaveletTransform.class);
     static final double[] scale = { 0.0322231006040782f, -0.0126039672622638f, -0.0992195435769564f, 0.297857795605605f,
-            0.803738751805386f, 0.497618667632563f, -0.0296355276459604f, -0.0757657147893567f };
+        0.803738751805386f, 0.497618667632563f, -0.0296355276459604f, -0.0757657147893567f };
+    static final double[] wavelet = { -scale[7], scale[6], -scale[5], scale[4], -scale[3], scale[2], -scale[1], scale[0] };
 
-    static final double[] wavelet = { -scale[7], scale[6], -scale[5], scale[4], -scale[3], scale[2], -scale[1],
-            scale[0] };
-
-    public FastWaveletTransform() {
+    private FastWaveletTransform() {
+        // utilityClass
     }
 
-    public void invTransform(final double[] v) {
+    public static void invTransform(final double[] v) {
         int last;
         for (last = 8; 2 * last <= v.length; last *= 2) {
             invTransform(v, last);
         }
         if (last != v.length) {
-            System.err.println("Careful! this should be a power of 2 : " + v.length);
+            LOGGER.atWarn().addArgument(v.length).log("Careful! this should be a power of 2 : {}");
         }
     }
 
-    public void transform(final double[] v) {
+    public static void transform(final double[] v) {
         int last;
         for (last = v.length; last > 8; last /= 2) {
             transform(v, last);
         }
         if (last != 8) {
-            System.err.println("Careful! this should be a power of 2 : " + v.length);
+            LOGGER.atWarn().addArgument(v.length).log("Careful! this should be a power of 2 : {}");
         }
     }
 
@@ -43,13 +45,12 @@ public final class FastWaveletTransform {
         final double[] ans = new double[ResultingLength];
         try {
             for (int k = 0; k < v.length / 2 - scale.length; k++) {
-                // System.err.println(" got " + k + " till " + (v.length/2 - scale.length));
                 for (int i = wavelet.length - 1; i >= 0; i--) {
                     ans[2 * k + i] += scale[i] * v[k] + wavelet[i] * v[k + n];
                 }
             }
         } catch (final IndexOutOfBoundsException e) {
-            System.err.println("exception " + n + "  message " + e.getLocalizedMessage());
+            LOGGER.atWarn().addArgument(n).setCause(e).log("exception {}  message:");
         }
 
         ans[ResultingLength - 6] += scale[0] * v[n - 3] + wavelet[0] * v[ResultingLength - 3];
@@ -85,9 +86,8 @@ public final class FastWaveletTransform {
     public static int mirror(final int i, final int n) {
         if (i < n) {
             return i;
-        } else {
-            return 2 * n - i;
         }
+        return 2 * n - i;
     }
 
     public static void transform(final double[] data, final int n) {
@@ -104,7 +104,7 @@ public final class FastWaveletTransform {
                 }
             }
         } catch (final IndexOutOfBoundsException e) {
-            System.err.println("exception " + n + "  message " + e.getLocalizedMessage());
+            LOGGER.atWarn().addArgument(n).setCause(e).log("exception {}  message:");
         }
 
         /*

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/CustomFragmentedRendererSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/CustomFragmentedRendererSample.java
@@ -1,7 +1,14 @@
 package de.gsi.chart.samples;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
 import de.gsi.chart.Chart;
 import de.gsi.chart.XYChart;
@@ -14,15 +21,6 @@ import de.gsi.dataset.DataSet;
 import de.gsi.dataset.spi.DoubleErrorDataSet;
 import de.gsi.dataset.spi.FragmentedDataSet;
 import de.gsi.dataset.testdata.spi.CosineFunction;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.scene.Scene;
-import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
 
 /**
  * Example illustrating the use of a custom renderer to plot graphs with gaps
@@ -30,7 +28,6 @@ import javafx.stage.Stage;
  * @author akrimm
  */
 public class CustomFragmentedRendererSample extends Application {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CustomFragmentedRendererSample.class);
     private static final int N_SAMPLES = 500; // default number of data points
     private static final int N_DATA_SETS_MAX = 3;
 
@@ -42,7 +39,7 @@ public class CustomFragmentedRendererSample extends Application {
         VBox.setVgrow(chart, Priority.ALWAYS);
         ErrorDataSetRenderer renderer = new ErrorDataSetRenderer() {
             @Override
-            public void render(final GraphicsContext gc, final Chart chart, final int dataSetOffset,
+            public void render(final GraphicsContext gc, final Chart renderChart, final int dataSetOffset,
                     final ObservableList<DataSet> datasets) {
                 ObservableList<DataSet> filteredDataSets = FXCollections.observableArrayList();
                 int dsIndex = 0;
@@ -59,7 +56,7 @@ public class CustomFragmentedRendererSample extends Application {
                     }
                     dsIndex++;
                 }
-                super.render(gc, chart, dataSetOffset, filteredDataSets);
+                super.render(gc, renderChart, dataSetOffset, filteredDataSets);
             }
         };
         chart.getRenderers().clear();

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/DimReductionDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/DimReductionDataSetSample.java
@@ -59,7 +59,7 @@ public class DimReductionDataSetSample extends Application {
         DimReductionDataSet horizontalRange = new DimReductionDataSet(waveletScalogram, DataSet.DIM_Y, Option.MEAN);
         XValueIndicator xRangeIndicatorMin = new XValueIndicator(waveletChart1.getXAxis(), 0.0);
         XValueIndicator xRangeIndicatorMax = new XValueIndicator(waveletChart1.getXAxis(), 0.0);
-        XRangeIndicator xRangeIndicator = new XRangeIndicator(waveletChart1.getXAxis(), 0.0, 0.0, "range-x");
+        XRangeIndicator xRangeIndicator = new XRangeIndicator(waveletChart1.getXAxis(), 0.0, 0.0, "range-y");
         xRangeIndicator.setLabelVerticalAnchor(VPos.TOP);
         xRangeIndicator.setLabelVerticalPosition(1.0);
         xRangeIndicator.lowerBoundProperty().bindBidirectional(xRangeIndicatorMin.valueProperty());
@@ -76,7 +76,7 @@ public class DimReductionDataSetSample extends Application {
 
         // reduce wavelet data set to 2D by using slices
         DimReductionDataSet verticalSlice = new DimReductionDataSet(waveletScalogram, DataSet.DIM_X, Option.SLICE);
-        YValueIndicator yValueIndicator = new YValueIndicator(waveletChart1.getYAxis(), 0.0, "slice-x");
+        YValueIndicator yValueIndicator = new YValueIndicator(waveletChart2.getYAxis(), 0.0, "slice-x");
         yValueIndicator.valueProperty().addListener((ch, o, n) -> verticalSlice.setMinValue(n.doubleValue()));
         yValueIndicator.setValue(0.26);
         verticalSlice.setMinValue(0.1);
@@ -84,9 +84,9 @@ public class DimReductionDataSetSample extends Application {
 
         // reduce wavelet data set to 2D by integrating over range
         DimReductionDataSet verticalRange = new DimReductionDataSet(waveletScalogram, DataSet.DIM_X, Option.MEAN);
-        YValueIndicator yRangeIndicatorMin = new YValueIndicator(waveletChart1.getYAxis(), 0.0);
-        YValueIndicator yRangeIndicatorMax = new YValueIndicator(waveletChart1.getYAxis(), 0.0);
-        YRangeIndicator yRangeIndicator = new YRangeIndicator(waveletChart1.getYAxis(), 0.0, 0.0, "range-y");
+        YValueIndicator yRangeIndicatorMin = new YValueIndicator(waveletChart2.getYAxis(), 0.0);
+        YValueIndicator yRangeIndicatorMax = new YValueIndicator(waveletChart2.getYAxis(), 0.0);
+        YRangeIndicator yRangeIndicator = new YRangeIndicator(waveletChart2.getYAxis(), 0.0, 0.0, "range-x");
         yRangeIndicator.setLabelHorizontalAnchor(HPos.RIGHT);
         yRangeIndicator.setLabelHorizontalPosition(1.0);
         yRangeIndicator.lowerBoundProperty().bindBidirectional(yRangeIndicatorMin.valueProperty());

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/EditDataSetSample.java
@@ -18,7 +18,6 @@ import de.gsi.chart.plugins.UpdateAxisLabels;
 import de.gsi.chart.plugins.Zoomer;
 import de.gsi.chart.renderer.Renderer;
 import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
-import de.gsi.dataset.DataSet;
 import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.spi.DoubleDataSet;
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/FxmlSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/FxmlSample.java
@@ -4,14 +4,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import de.gsi.chart.XYChart;
-import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
-import de.gsi.dataset.testdata.spi.CosineFunction;
-import de.gsi.dataset.testdata.spi.GaussFunction;
-import de.gsi.dataset.testdata.spi.RandomWalkFunction;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
@@ -23,14 +15,18 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.stage.Stage;
 
+import de.gsi.chart.XYChart;
+import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.dataset.testdata.spi.CosineFunction;
+import de.gsi.dataset.testdata.spi.GaussFunction;
+import de.gsi.dataset.testdata.spi.RandomWalkFunction;
+
 /**
  * Example on how to use chart-fx from fxml.
  * 
  * @author Alexander Krimm
  */
 public class FxmlSample extends Application implements Initializable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleChartSample.class);
-
     private static final int N_SAMPLES = 500;
 
     @FXML

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/HistoryDataSetRendererSample.java
@@ -38,12 +38,12 @@ public class HistoryDataSetRendererSample extends Application {
     private static final int UPDATE_PERIOD = 100; // [ms]
     private Timer timer;
     private double updateIteration;
+    private final DoubleErrorDataSet dataSet = new DoubleErrorDataSet("TestData",
+            HistoryDataSetRendererSample.N_SAMPLES);
+    private final DoubleDataSet dataSetNoError = new DoubleDataSet("TestDataNoErrors",
+            HistoryDataSetRendererSample.N_SAMPLES);
 
     private void generateData(final XYChart chart) {
-        final DoubleErrorDataSet dataSet = new DoubleErrorDataSet("TestData", HistoryDataSetRendererSample.N_SAMPLES);
-        final DoubleDataSet dataSetNoError = new DoubleDataSet("TestDataNoErrors",
-                HistoryDataSetRendererSample.N_SAMPLES);
-
         long startTime = ProcessingProfiler.getTimeStamp();
 
         dataSetNoError.lock().writeLockGuard(() -> dataSet.lock().writeLockGuard(() -> {
@@ -64,7 +64,8 @@ public class HistoryDataSetRendererSample extends Application {
                 // dataSet.set(n, x, Math.exp(1e-4*x), 1e-3, 1e-3);
                 // dataSetNoError.set(n, x, Math.exp(2e-4*x));
             }
-            dataSetNoError.setStyle("dsIndex=1;");
+
+            // dataSetNoError.setStyle("dsIndex=1;");
             // dataSet.setStyle("strokeColor=red;");
             // dataSet.setStyle("dsIndex=2;");
 
@@ -72,8 +73,6 @@ public class HistoryDataSetRendererSample extends Application {
         }));
 
         Platform.runLater(() -> {
-            dataSet.fireInvalidated(null);
-            dataSetNoError.fireInvalidated(null);
             chart.requestLayout();
             final ObservableList<Renderer> rendererList = chart.getRenderers();
             for (final Renderer rend : rendererList) {
@@ -86,8 +85,6 @@ public class HistoryDataSetRendererSample extends Application {
             // preferred method (final ie. data set attached final to renderer
             // rendererList.get(0).getDatasets().setAll(dataSet,
             // dataSetNoError);
-            rendererList.get(0).getDatasets().setAll(dataSet);
-            rendererList.get(1).getDatasets().setAll(dataSetNoError);
             // chart.getDatasets().setAll(dataSet, dataSetNoError);
             // chart.getDatasets().setAll(dataSet, dataSetNoError);
         });
@@ -103,7 +100,7 @@ public class HistoryDataSetRendererSample extends Application {
                 generateData(chart);
 
                 if (updateCount % 100 == 0) {
-                    LOGGER.atInfo().log("update iteration #" + updateCount);
+                    LOGGER.atInfo().addArgument(updateCount).log("update iteration #{}");
                 }
                 updateCount++;
             }
@@ -139,6 +136,9 @@ public class HistoryDataSetRendererSample extends Application {
         historyRenderer2.getAxes().add(yAxis2);
         chart.getRenderers().add(historyRenderer2);
         historyRenderer2.setIntensityFading(0.8); // default: 0.65
+
+        chart.getRenderers().get(0).getDatasets().setAll(dataSet);
+        historyRenderer2.getDatasets().setAll(dataSetNoError);
 
         chart.getPlugins().add(new Zoomer());
         chart.getPlugins().add(new EditAxis());

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -49,6 +49,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("CustomColourSchemeSample", new CustomColourSchemeSample()));
         buttons.getChildren().add(new MyButton("CustomFragmentedRendererSample", new CustomFragmentedRendererSample()));
         buttons.getChildren().add(new MyButton("DataViewerSample", new DataViewerSample()));
+        buttons.getChildren().add(new MyButton("DimReductionDataSetSample", new DimReductionDataSetSample()));
         buttons.getChildren().add(new MyButton("EditDataSetSample", new EditDataSetSample()));
         buttons.getChildren().add(new MyButton("ErrorDataSetRendererSample", new ErrorDataSetRendererSample()));
         buttons.getChildren()
@@ -65,6 +66,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("MountainRangeRendererSample", new MountainRangeRendererSample()));
         buttons.getChildren().add(new MyButton("MultipleAxesSample", new MultipleAxesSample()));
         buttons.getChildren().add(new MyButton("NotANumberSample", new NotANumberSample()));
+        buttons.getChildren().add(new MyButton("OscilloscopeAxisSample", new OscilloscopeAxisSample()));
         buttons.getChildren().add(new MyButton("PolarPlotSample", new PolarPlotSample()));
         buttons.getChildren().add(new MyButton("RollingBufferSample", new RollingBufferSample()));
         buttons.getChildren().add(new MyButton("RollingBufferSortedTreeSample", new RollingBufferSortedTreeSample()));

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/TimeAxisSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/TimeAxisSample.java
@@ -21,7 +21,7 @@ import de.gsi.dataset.utils.ProcessingProfiler;
 public class TimeAxisSample extends Application {
     private static final int N_SAMPLES = 10_000; // default: 10000
 
-    private void generateData(final DefaultErrorDataSet dataSet) {
+    private static void generateData(final DefaultErrorDataSet dataSet) {
         final long startTime = ProcessingProfiler.getTimeStamp();
 
         dataSet.autoNotification().set(false);

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/TransposedDataSetSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/TransposedDataSetSample.java
@@ -130,12 +130,12 @@ public class TransposedDataSetSample extends Application {
     }
 
     private static DataSet createTestData() {
-        final int nPoints = 1000;
+        final int nPoints = 300;
         final double f = 0.1;
         final double[] x = new double[nPoints];
         final double[] y = new double[2 * nPoints];
         for (int i = 0; i < x.length; i++) {
-            final double val = (i / (double) x.length - 0.5) * 10;
+            final double val = (i / (double) x.length + 0.5) * 10;
             x[i] = val;
         }
         for (int i = 0; i < y.length; i++) {
@@ -151,7 +151,7 @@ public class TransposedDataSetSample extends Application {
                 // } else {
                 // z[xIndex][yIndex] = 1000.0;
                 // }
-                z[yIndex][xIndex] = Math.sin(5.0 * Math.PI * f * x[xIndex]) * Math.cos(2.0 * Math.PI * f * y[yIndex]);
+                z[yIndex][xIndex] = (x[xIndex]) * (y[yIndex] - 3) * Math.sin(5.0 * Math.PI * f * x[xIndex]) * Math.cos(2.0 * Math.PI * f * y[yIndex]);
             }
         }
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/WriteDataSetToFileSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/WriteDataSetToFileSample.java
@@ -137,13 +137,13 @@ public class WriteDataSetToFileSample extends Application {
         // screenCapture.stop();
     }
 
-    private static DoubleDataSet getDemoDataSet(final long now, final boolean isSine) {
-        final DoubleDataSet dataSet = new DoubleDataSet((isSine ? "sine" : "cosine") + "data set #1 @t=" + now);
+    private static DoubleDataSet getDemoDataSet(final long timestamp, final boolean isSine) {
+        final DoubleDataSet dataSet = new DoubleDataSet((isSine ? "sine" : "cosine") + "data set #1 @t=" + timestamp);
 
         final double[] xValues = new double[N_SAMPLES];
         final double[] yValues = new double[N_SAMPLES];
         for (int n = 0; n < N_SAMPLES; n++) {
-            final double phase = Math.toRadians((10.0 * n) + (now / 1000.0));
+            final double phase = Math.toRadians((10.0 * n) + (timestamp / 1000.0));
             xValues[n] = n;
             yValues[n] = isSine ? Math.sin(phase) : Math.cos(phase);
         }

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/EMDSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/EMDSample.java
@@ -27,7 +27,7 @@ import de.gsi.math.spectra.EEMD;
  * @author rstein TODO: some fixes in EMD necessary
  */
 public class EMDSample extends AbstractDemoApplication {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FourierSample.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EMDSample.class);
     private static final int MAX_POINTS = 1024;
     private static final boolean LOAD_EXAMPLE_DATA = true;
     private DataSet dataset;
@@ -54,7 +54,7 @@ public class EMDSample extends AbstractDemoApplication {
                 sleep(100);
                 int status = trafoHHT.getStatus();
                 if (status > 10) {
-                    LOGGER.atInfo().log(status + " % of computation done");
+                    LOGGER.atInfo().addArgument(status).log("{}% of computation done");
                 }
             } while (trafoHHT.isBusy());
         } catch (Exception e) {
@@ -82,8 +82,9 @@ public class EMDSample extends AbstractDemoApplication {
                 for (int j = 0; j < fmodeData[nmode].length; j++) {
                     fmodeData[nmode][j] = emd.get(j, nmode) - 5 * nmode;
                 }
-                LOGGER.atInfo().log("%s mean = %f\n", name,
-                        (TMath.Mean(fmodeData[nmode]) + 2 * nmode) / TMath.PeakToPeak(fmodeData[nmode]));
+                LOGGER.atInfo().addArgument(name) //
+                        .addArgument((TMath.Mean(fmodeData[nmode]) + 2 * nmode) / TMath.PeakToPeak(fmodeData[nmode])) //
+                        .log("{} mean = {}");
                 fmodeDataSets[nmode] = new DefaultErrorDataSet(name, time, fmodeData[nmode], new double[time.length],
                         new double[time.length], time.length, true);
             }

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/GaussianFitSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/GaussianFitSample.java
@@ -1,5 +1,8 @@
 package de.gsi.math.samples;
 
+import javafx.application.Application;
+import javafx.scene.Node;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,12 +10,11 @@ import de.gsi.dataset.DataSet;
 import de.gsi.dataset.spi.DefaultDataSet;
 import de.gsi.dataset.spi.DefaultErrorDataSet;
 import de.gsi.math.TMath;
+import de.gsi.math.TMathConstants;
 import de.gsi.math.fitter.NonLinearRegressionFitter;
 import de.gsi.math.functions.AbstractFunction1D;
 import de.gsi.math.samples.utils.AbstractDemoApplication;
 import de.gsi.math.samples.utils.DemoChart;
-import javafx.application.Application;
-import javafx.scene.Node;
 
 /**
  * example illustrating fitting of a Gaussian Distribution
@@ -52,7 +54,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
         for (int i = 0; i < xValues.length; i++) {
             final double error = 0.5 * RANDOM.nextGaussian();
             xValues[i] = (i - xValues.length / 2.0) * 30.0 / MAX_POINTS; // equidistant
-                                                                         // sampling
+                    // sampling
 
             final double value = func.getValue(xValues[i]);
             // add some slope and offset to make the fit a bit more tricky
@@ -66,7 +68,6 @@ public class GaussianFitSample extends AbstractDemoApplication {
             yModel[i] = value;
             yValues[i] = value + error;
             yErrors[i] = Math.abs(error);
-
         }
 
         final NonLinearRegressionFitter fitter = new NonLinearRegressionFitter(xValues, yValues, yErrors);
@@ -102,8 +103,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
 
         LOGGER.atInfo().log("fit results chi^2 =" + fitter.getChiSquare() + ":");
         for (int i = 0; i < 3; i++) {
-            LOGGER.atInfo().log("fitted-parameter  '%s' = %f -> %f +- %f\n", func.getParameterName(i), start[i],
-                    fittedParameter[i], fittedParameterError[i]);
+            LOGGER.atInfo().addArgument(func.getParameterName(i)).addArgument(start[i]).addArgument(fittedParameter[i]).addArgument(fittedParameterError[i]).log("fitted-parameter  '{}' = {} -> {} +- {}");
         }
 
         fmodel = new DefaultDataSet("design model", xValues, yModel, xValues.length, true);
@@ -113,11 +113,12 @@ public class GaussianFitSample extends AbstractDemoApplication {
                 xValues.length, true);
 
         // plot fitting results
-        /*
-         * for (int i=0; i < func.getParameterCount(); i++) { LOGGER.atInfo().log("fitted parameter '%s': %f +- %f\n",
-         * func.getParameterName(i), func.getParameterValue(i),
-         * 0.5*(func.getParameterRangeMaximum(i)-func.getParameterRangeMinimum(i ))); }
-         */
+        // for (int i = 0; i < func.getParameterCount(); i++) {
+        //     LOGGER.atInfo().addArgument(func.getParameterName(i)) //
+        //             .addArgument(func.getParameterValue(i)) //
+        //             .addArgument(0.5 * (func.getParameterRangeMaximum(i) - func.getParameterRangeMinimum(i))) //
+        //             .log("fitted parameter '{}': {} +- {}"); //
+        // }
     }
 
     public static void main(final String[] args) {
@@ -128,7 +129,6 @@ public class GaussianFitSample extends AbstractDemoApplication {
      * example fitting function y = scale/(sqrt(2*pi*sigma)*exp(- 0.5*(x-mu)^2/sigma^2)
      */
     protected class MyGaussianFunction extends AbstractFunction1D {
-
         public MyGaussianFunction(final String name, final double[] parameter) {
             super(name, new double[3]);
             // declare parameter names
@@ -145,7 +145,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
             }
 
             // assign default values
-            final int maxIndex = TMath.Min(parameter.length, this.getParameterCount());
+            final int maxIndex = TMathConstants.Min(parameter.length, this.getParameterCount());
             for (int i = 0; i < maxIndex; i++) {
                 setParameterValue(i, parameter[i]);
             }
@@ -157,8 +157,7 @@ public class GaussianFitSample extends AbstractDemoApplication {
             final double sigma = fparameter[1];
             final double scale = fparameter[2];
 
-            return scale * 1.0 / (Math.sqrt(TMath.TwoPi()) * sigma) * Math.exp(-0.5 * Math.pow((x - mu) / sigma, 2));
+            return scale * 1.0 / (Math.sqrt(TMathConstants.TwoPi()) * sigma) * Math.exp(-0.5 * Math.pow((x - mu) / sigma, 2));
         }
     }
-
 }

--- a/chartfx-samples/src/main/java/de/gsi/math/samples/ShortTimeFourierTransformSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/math/samples/ShortTimeFourierTransformSample.java
@@ -34,6 +34,7 @@ import de.gsi.dataset.DataSet;
 import de.gsi.dataset.DataSetMetaData;
 import de.gsi.dataset.spi.DataSetBuilder;
 import de.gsi.dataset.spi.MultiDimDoubleDataSet;
+import de.gsi.dataset.spi.TransposedDataSet;
 import de.gsi.math.TMathConstants;
 import de.gsi.math.samples.utils.AbstractDemoApplication;
 import de.gsi.math.spectra.Apodization;
@@ -139,7 +140,7 @@ public class ShortTimeFourierTransformSample extends AbstractDemoApplication {
         chart1.getPlugins().add(new UpdateAxisLabels());
         chart1.getPlugins().add(new Zoomer());
         chart1.getPlugins().add(new EditAxis());
-        chart1.getDatasets().add(stftData);
+        chart1.getDatasets().add(TransposedDataSet.transpose(stftData, true));
 
         rawData.addListener(evt -> wavelet(rawData, waveletData));
         // Wavelet Transform Chart
@@ -239,7 +240,7 @@ public class ShortTimeFourierTransformSample extends AbstractDemoApplication {
         gridPane.addRow(0, new Label("n_FFT"), nFFT, new Label("[samples]"));
         nFFT.setEditable(true);
         gridPane.addRow(1, new Label("step"), step, new Label("[samples]"));
-        nSamples.setEditable(true);
+        step.setEditable(true);
         apodizationWindow.setValue(Apodization.Hann);
         gridPane.addRow(2, new Label("window function"), apodizationWindow, new Label(""));
         padding.setValue(Padding.ZERO);


### PR DESCRIPTION
Multiple small bugfixes encountered during testing:
- DataPointTooltip would log lots of errors for dataSets with nx > ny => ignoring these points for now
- contour chart renderer would use the alternative implementation for hex by default => fixed
- contour chart renderer cache would throw Exceptions for non 3D DataSets => skip datasets with malformed dimensions
- HistoryRendererSample had problems with the colors due to datasets being added multiple times
- TransposedDataSet only evaluated if data was in grid format in the constructor, if it was later changed to grid format (eg 0x0x0 (initialization) -> 2x4x8 (actualData)) it would still be treated as a normal dataSet => fixed and added unittest
- Lots of samples used `%f`type format strings , some samples where missing from the launcher