### PR TITLE
Histogram, GridRenderer redraw and chartfx-generator with mvn clean

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
@@ -89,6 +89,8 @@ public class XYChart extends Chart {
 
         gridRenderer.horizontalGridLinesVisibleProperty().addListener(gridLineVisibilitychange);
         gridRenderer.verticalGridLinesVisibleProperty().addListener(gridLineVisibilitychange);
+        gridRenderer.getHorizontalMinorGrid().visibleProperty().addListener(gridLineVisibilitychange);
+        gridRenderer.getVerticalMinorGrid().visibleProperty().addListener(gridLineVisibilitychange);
         gridRenderer.drawOnTopProperty().addListener(gridLineVisibilitychange);
 
         this.setAnimated(false);

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
@@ -54,7 +54,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
 
     private final StyleableIntegerProperty dimIndex = CSS.createIntegerProperty(this, "dimIndex", -1, this::requestAxisLayout);
     /**
-     * Paths used for css-type styling. Not used for actual drawing. Used as a storage contained for the settings
+     * Paths used for css-type styling. Not used for actual drawing. Used as a storage container for the settings
      * applied to GraphicsContext which allow much faster (and less complex) drawing routines but do no not allow
      * CSS-type styling.
      */

--- a/chartfx-dataset/pom.xml
+++ b/chartfx-dataset/pom.xml
@@ -65,15 +65,6 @@
             <plugin>
                 <groupId>de.gsi.generate</groupId>
                 <artifactId>chartfx-generate</artifactId>
-                <version>${revision}${sha1}${changelist}</version>
-                <executions>
-                    <execution>
-                        <id>generate-sources</id>
-                        <goals>
-                            <goal>generate-sources</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/Histogram.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/Histogram.java
@@ -1,11 +1,17 @@
 package de.gsi.dataset;
 
 /**
- * @author rstein
+ * Specialized DataSet interface for storing and processing Histogram data.
  *
+ * A histogram with bins 1...N is defined by n+1 values defining the steps between the bins.
+ * The bins can be equidistant or not.
+ *
+ * The bins 0 and N+1 have a special meaning and contain the data for data which is out of range.
+ * They are not drawn by default.
+ *
+ * @author rstein
  */
 public interface Histogram extends DataSet, DataSetMetaData {
-
     /**
      * Increment bin content by 1. More...
      * 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/FieldSerialiser.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/FieldSerialiser.java
@@ -165,6 +165,7 @@ public class FieldSerialiser<R> {
          * @param ioSerialiser the reference to the calling IoSerialiser
          * @param rootObj the specific root object reference the given field is part of
          * @param field the description for the given class member, if null then rootObj is written/read directly
+         * @return The value of the field which is either taken from rootObj if present or compatible or newly allocated otherwise
          */
         R apply(IoSerialiser ioSerialiser, Object rootObj, ClassFieldDescription field);
     }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/IoClassSerialiser.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/IoClassSerialiser.java
@@ -214,6 +214,7 @@ public class IoClassSerialiser {
      * @param type the class or interface
      * @param classGenericArguments optional generics arguments
      * @return FieldSerialiser matching the base class/interface and generics arguments
+     * @param <E> The type of the Object to (de)serialise
      */
     @SuppressWarnings("unchecked")
     public <E> FieldSerialiser<E> findFieldSerialiser(Type type, List<Type> classGenericArguments) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/spi/WireDataFieldDescription.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/serializer/spi/WireDataFieldDescription.java
@@ -189,6 +189,7 @@ public class WireDataFieldDescription implements FieldDescription {
     /**
      * @return raw ioSerialiser reference this field was retrieved with the position in the underlying IoBuffer at the to be read field
      * N.B. this is a safe convenience method and not performance optimised
+     * @param overwriteType optional DataType as which the data should be interpreted
      */
     public Object data(DataType... overwriteType) {
         ioSerialiser.setQueryFieldName(fieldName, fieldDataStart);

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
@@ -51,9 +51,10 @@ public class Histogram extends AbstractHistogram implements Histogram1D, DataSet
      * @param nBins number of bins
      * @param minX minimum of range
      * @param maxX maximum of range
+     * @param boundsType How the min and max value should be interpreted
      */
-    public Histogram(String name, int nBins, double minX, double maxX) {
-        this(name, nBins, minX, maxX, true);
+    public Histogram(String name, int nBins, double minX, double maxX, final HistogramOuterBounds boundsType) {
+        this(name, nBins, minX, maxX, true, boundsType);
     }
 
     /**
@@ -64,13 +65,14 @@ public class Histogram extends AbstractHistogram implements Histogram1D, DataSet
      * @param minX minimum of range
      * @param maxX maximum of range
      * @param horizontal whether binning is performed in X
+     * @param boundsType How the min and max value should be interpreted
      */
-    public Histogram(String name, int nBins, double minX, double maxX, final boolean horizontal) {
-        super(name, nBins, minX, maxX);
+    public Histogram(String name, int nBins, double minX, double maxX, final boolean horizontal, final HistogramOuterBounds boundsType) {
+        super(name, nBins, minX, maxX, boundsType);
         isHorizontal = horizontal;
         if (!isHorizontal) {
+            getAxisDescription(DIM_Y).set(getAxisDescription(DIM_X));
             getAxisDescription(DIM_X).clear();
-            getAxisDescription(DIM_Y).set(minX, maxX);
         }
     }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
@@ -32,6 +32,7 @@ public class Histogram2 extends AbstractHistogram implements Histogram2D {
      * @param nBinsY number of vertical bins
      * @param minY minimum of vertical range
      * @param maxY maximum of vertical range
+     * @param boundsType How the min and max value should be interpreted
      */
     public Histogram2(String name, int nBinsX, double minX, double maxX, final int nBinsY, final double minY, final double maxY, final HistogramOuterBounds boundsType) {
         super(name, nBinsX, minX, maxX, nBinsY, minY, maxY, boundsType);

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram2.java
@@ -33,10 +33,10 @@ public class Histogram2 extends AbstractHistogram implements Histogram2D {
      * @param minY minimum of vertical range
      * @param maxY maximum of vertical range
      */
-    public Histogram2(String name, int nBinsX, double minX, double maxX, final int nBinsY, final double minY, final double maxY) {
-        super(name, nBinsX, minX, maxX, nBinsY, minY, maxY);
-        xProjection = new Histogram(name + "-Proj-X", nBinsX, minX, maxX, true);
-        yProjection = new Histogram(name + "-Proj-Y", nBinsY, minY, maxY, false);
+    public Histogram2(String name, int nBinsX, double minX, double maxX, final int nBinsY, final double minY, final double maxY, final HistogramOuterBounds boundsType) {
+        super(name, nBinsX, minX, maxX, nBinsY, minY, maxY, boundsType);
+        xProjection = new Histogram(name + "-Proj-X", nBinsX, minX, maxX, true, boundsType);
+        yProjection = new Histogram(name + "-Proj-Y", nBinsY, minY, maxY, false, boundsType);
     }
 
     /*

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetEqualityTests.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static de.gsi.dataset.DataSet.DIM_X;
 import static de.gsi.dataset.DataSet.DIM_Y;
+import static de.gsi.dataset.spi.AbstractHistogram.HistogramOuterBounds.BINS_ALIGNED_WITH_BOUNDARY;
 
 import java.util.Arrays;
 
@@ -42,7 +43,7 @@ public class DataSetEqualityTests {
         assertEquals(new DoubleErrorDataSet("default"), new DoubleErrorDataSet("default"));
         assertEquals(new FifoDoubleErrorDataSet("default", 10), new FifoDoubleErrorDataSet("default", 11));
         assertEquals(new FragmentedDataSet("default"), new FragmentedDataSet("default"));
-        assertEquals(new Histogram("default", 10, 0.0, 1.0), new Histogram("default", 10, 0.0, 1.0));
+        assertEquals(new Histogram("default", 10, 0.0, 1.0, BINS_ALIGNED_WITH_BOUNDARY), new Histogram("default", 10, 0.0, 1.0, BINS_ALIGNED_WITH_BOUNDARY));
         // assertEquals(new Histogram2("default", 10, 0.0, 1.0, 10, 0.0, 1.0),
         // new Histogram2("default", 10, 0.0, 1.0, 10, 0.0, 1.0));
         assertEquals(new LabelledMarkerDataSet("default"), new LabelledMarkerDataSet("default"));

--- a/chartfx-generate/pom.xml
+++ b/chartfx-generate/pom.xml
@@ -52,6 +52,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin> <!-- do not clean the plugin as it is still required for cleaning dataset and math -->
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin> <!-- Also compile the plugin at the end of the clean phase, skipping clean doesn't seem to be enough -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile4clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/chartfx-math/pom.xml
+++ b/chartfx-math/pom.xml
@@ -47,18 +47,6 @@
             <plugin>
                 <groupId>de.gsi.generate</groupId>
                 <artifactId>chartfx-generate</artifactId>
-                <version>${revision}${sha1}${changelist}</version>
-                <executions>
-                    <execution>
-                        <id>generate-sources</id>
-                        <goals>
-                            <goal>generate-sources</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <input>${project.basedir}/src/main/codegen</input>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
@@ -182,10 +182,20 @@ public class ErrorDataSetRendererStylingSample extends Application {
         chart.horizontalGridLinesVisibleProperty().bindBidirectional(gridVisibleX.selectedProperty());
         pane.addToParameterPane("Show X-Grid: ", gridVisibleX);
 
+        final CheckBox gridVisibleXMinor = new CheckBox("");
+        gridVisibleXMinor.setSelected(true);
+        chart.getGridRenderer().getVerticalMinorGrid().visibleProperty().bindBidirectional(gridVisibleXMinor.selectedProperty());
+        pane.addToParameterPane("Show Minor X-Grid: ", gridVisibleXMinor);
+
         final CheckBox gridVisibleY = new CheckBox("");
         gridVisibleY.setSelected(true);
         chart.verticalGridLinesVisibleProperty().bindBidirectional(gridVisibleY.selectedProperty());
         pane.addToParameterPane("Show Y-Grid: ", gridVisibleY);
+
+        final CheckBox gridVisibleYMinor = new CheckBox("");
+        gridVisibleYMinor.setSelected(true);
+        chart.getGridRenderer().getHorizontalMinorGrid().visibleProperty().bindBidirectional(gridVisibleYMinor.selectedProperty());
+        pane.addToParameterPane("Show Minor Y-Grid: ", gridVisibleYMinor);
 
         final CheckBox gridOnTop = new CheckBox("");
         gridOnTop.setSelected(true);

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/Histogram2DimSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/Histogram2DimSample.java
@@ -1,5 +1,7 @@
 package de.gsi.chart.samples;
 
+import static de.gsi.dataset.spi.AbstractHistogram.HistogramOuterBounds.BINS_ALIGNED_WITH_BOUNDARY;
+
 import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -31,8 +33,8 @@ public class Histogram2DimSample extends Application {
     private static final int N_BINS_Y = 120;
     private final Random rnd = new Random();
 
-    private final Histogram2 histogram1 = new Histogram2("hist1", N_BINS_X, 0.0, 20.0, N_BINS_Y, 0.0, 30.0);
-    private final Histogram2 histogram2 = new Histogram2("hist2", N_BINS_X, 0.0, 20.0, N_BINS_Y, 0.0, 30.0);
+    private final Histogram2 histogram1 = new Histogram2("hist1", N_BINS_X, 0.0, 20.0, N_BINS_Y, 0.0, 30.0, BINS_ALIGNED_WITH_BOUNDARY);
+    private final Histogram2 histogram2 = new Histogram2("hist2", N_BINS_X, 0.0, 20.0, N_BINS_Y, 0.0, 30.0, BINS_ALIGNED_WITH_BOUNDARY);
     private int counter;
 
     private void fillData() {

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/HistogramBasicSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/HistogramBasicSample.java
@@ -1,0 +1,152 @@
+package de.gsi.chart.samples;
+
+import static de.gsi.dataset.spi.AbstractHistogram.HistogramOuterBounds.BINS_ALIGNED_WITH_BOUNDARY;
+
+import java.text.DateFormatSymbols;
+import java.util.*;
+
+import javax.tools.Tool;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.scene.Scene;
+import javafx.scene.control.*;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.CategoryAxis;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.ParameterMeasurements;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.chart.renderer.ErrorStyle;
+import de.gsi.chart.renderer.LineStyle;
+import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.chart.renderer.spi.MetaDataRenderer;
+import de.gsi.chart.utils.FXUtils;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.spi.AbstractHistogram;
+import de.gsi.dataset.spi.Histogram;
+import de.gsi.dataset.testdata.spi.RandomDataGenerator;
+import de.gsi.math.Math;
+
+public class HistogramBasicSample extends Application {
+    private Histogram dataSet1 = new Histogram("myHistogram1", 4, 0.0, 4.0, BINS_ALIGNED_WITH_BOUNDARY);
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final XYChart chart = new XYChart();
+
+        final ErrorDataSetRenderer renderer1 = new ErrorDataSetRenderer();
+        renderer1.setPolyLineStyle(LineStyle.HISTOGRAM_FILLED);
+        chart.getRenderers().add(renderer1);
+        renderer1.getDatasets().addAll(dataSet1);
+
+        chart.getPlugins().add(new EditAxis());
+        final Zoomer zoomer = new Zoomer();
+        zoomer.setSliderVisible(false);
+        chart.getPlugins().add(zoomer);
+
+        final VBox root = new VBox();
+        final Scene scene = new Scene(root, 800, 600);
+        // Controls to generate new equidistant dataset
+        final ToolBar addDataSet = new ToolBar();
+        final Slider nBinsSlider = new Slider(1, 25, 4);
+        nBinsSlider.setMajorTickUnit(1);
+        nBinsSlider.setSnapToTicks(true);
+        nBinsSlider.setShowTickLabels(true);
+        nBinsSlider.setShowTickMarks(true);
+        final Slider minSlider = new Slider(-10, 10, 0);
+        minSlider.setShowTickLabels(true);
+        minSlider.setShowTickMarks(true);
+        final Slider maxSlider = new Slider(-10, 10, 4);
+        maxSlider.setShowTickLabels(true);
+        maxSlider.setShowTickMarks(true);
+        final ComboBox<AbstractHistogram.HistogramOuterBounds> histoBoundsCombo = new ComboBox<>(FXCollections.observableList(List.of(AbstractHistogram.HistogramOuterBounds.values())));
+        histoBoundsCombo.setValue(BINS_ALIGNED_WITH_BOUNDARY);
+        final Button newHistogramButton = new Button("New Histogram");
+        newHistogramButton.setOnAction(e -> {
+            dataSet1 = new Histogram("myHistogram1", (int) nBinsSlider.getValue(), minSlider.getValue(), maxSlider.getValue(), histoBoundsCombo.getValue());
+            for (int i = 0; i < dataSet1.getDataCount() + 2; i++) {
+                dataSet1.addBinContent(i, dataSet1.getDataCount() + 2.0 - Math.abs(i - 0.5 * (dataSet1.getDataCount() + 2)));
+            }
+            renderer1.getDatasets().setAll(dataSet1);
+        });
+        addDataSet.getItems().addAll( //
+                new Label("nBins: "), nBinsSlider, //
+                new Label("min: "), minSlider, //
+                new Label("max: "), maxSlider, //
+                histoBoundsCombo, //
+                newHistogramButton //
+        );
+        // controls to generate new non-equidistant histogram
+        final ToolBar addNeqDataSet = new ToolBar();
+        final TextField points = new TextField("0.0, 1.0, 2.0, 3.0, 4.0");
+        final Button newNeqHistogramButton = new Button("New non-equidistant Histogram");
+        newNeqHistogramButton.setOnAction(e -> {
+            dataSet1 = new Histogram("Non equidistant histogram", Arrays.stream(points.getText().split(",")).mapToDouble(v -> Double.parseDouble(v.trim())).toArray());
+            for (int i = 0; i < dataSet1.getDataCount() + 2; i++) {
+                dataSet1.addBinContent(i, dataSet1.getDataCount() + 2.0 - Math.abs(i - 0.5 * (dataSet1.getDataCount() + 2)));
+            }
+            renderer1.getDatasets().setAll(dataSet1);
+        });
+        addNeqDataSet.getItems().addAll( //
+                new Label("Bin boundaries: "), points, //
+                newNeqHistogramButton, //
+                new Label("NOTE: because the ErrorDataSetRenderer cannot obtain the widths of the bins, bin boundaries will be off") //
+        );
+
+        // controls to add data points
+        final ToolBar addDataBar = new ToolBar();
+        final ToggleGroup addDataToggleGroup = new ToggleGroup();
+        final RadioButton addDataValueRadio = new RadioButton("Add data to value: ");
+        addDataValueRadio.setToggleGroup(addDataToggleGroup);
+        addDataValueRadio.setSelected(true);
+        final Spinner<Double> valueToAddTo = new Spinner<>(new SpinnerValueFactory.DoubleSpinnerValueFactory(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1.0, 0.1));
+        valueToAddTo.setEditable(true);
+        valueToAddTo.disableProperty().bind(Bindings.not(addDataValueRadio.selectedProperty()));
+        final RadioButton addDataBinRadio = new RadioButton("Add data to bin: ");
+        addDataBinRadio.setToggleGroup(addDataToggleGroup);
+        final Spinner<Integer> binToAddTo = new Spinner<>(0, Integer.MAX_VALUE, 2);
+        binToAddTo.setEditable(true);
+        binToAddTo.disableProperty().bind(Bindings.not(addDataBinRadio.selectedProperty()));
+        final Spinner<Double> valueToAdd = new Spinner<>(new SpinnerValueFactory.DoubleSpinnerValueFactory(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1.0, 0.1));
+        valueToAdd.setEditable(true);
+        final Button addDataBtn = new Button("add");
+        addDataBtn.setOnAction(e -> {
+            if (addDataValueRadio.isSelected()) {
+                dataSet1.addBinContent(dataSet1.findBin(DataSet.DIM_X, valueToAddTo.getValue()), valueToAdd.getValue());
+            } else {
+                dataSet1.addBinContent(binToAddTo.getValue(), valueToAdd.getValue());
+            }
+        });
+        addDataBar.getItems().addAll( //
+                addDataValueRadio, valueToAddTo, //
+                addDataBinRadio, binToAddTo, //
+                new Label("Weight: "), valueToAdd, //
+                addDataBtn //
+        );
+        // show all controls
+        root.getChildren().addAll(addDataSet, addNeqDataSet, addDataBar, chart);
+        VBox.setVgrow(chart, Priority.ALWAYS);
+        primaryStage.setTitle(this.getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+
+        primaryStage.setOnCloseRequest(evt -> {
+            Platform.exit();
+        });
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/HistogramSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/HistogramSample.java
@@ -1,5 +1,7 @@
 package de.gsi.chart.samples;
 
+import static de.gsi.dataset.spi.AbstractHistogram.HistogramOuterBounds.BINS_ALIGNED_WITH_BOUNDARY;
+
 import java.text.DateFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,8 +36,8 @@ public class HistogramSample extends Application {
     private static final int N_BINS = 30;
     private final double[] xBins = { 0.0, 0.1, 0.2, 0.3, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 15.0, 16.0, 17.0, 18.0, 19.0,
         19.7, 19.8, 19.9, 20.0 };
-    private final Histogram dataSet1 = new Histogram("myHistogram1", N_BINS, 0.0, 20.0);
-    private final Histogram dataSet2 = new Histogram("myHistogram2", N_BINS, 0.0, 20.0);
+    private final Histogram dataSet1 = new Histogram("myHistogram1", N_BINS, 0.0, 20.0, BINS_ALIGNED_WITH_BOUNDARY);
+    private final Histogram dataSet2 = new Histogram("myHistogram2", N_BINS, 0.0, 20.0, BINS_ALIGNED_WITH_BOUNDARY);
     private final Histogram dataSet3 = new Histogram("myHistogram3", xBins); // custom, non-equidistant histogram
 
     private int counter;

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -58,6 +58,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("GridRendererSample", new GridRendererSample()));
         buttons.getChildren().add(new MyButton("HexagonSamples", new HexagonSamples()));
         buttons.getChildren().add(new MyButton("Histogram2DimSample", new Histogram2DimSample()));
+        buttons.getChildren().add(new MyButton("HistogramBasicSample", new HistogramBasicSample()));
         buttons.getChildren().add(new MyButton("HistogramSample", new HistogramSample()));
         buttons.getChildren().add(new MyButton("HistoryDataSetRendererSample", new HistoryDataSetRendererSample()));
         buttons.getChildren().add(new MyButton("LabelledMarkerSample", new LabelledMarkerSample()));

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,19 @@
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.6.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>de.gsi.generate</groupId>
+                    <artifactId>chartfx-generate</artifactId>
+                    <version>${revision}${sha1}${changelist}</version>
+                    <executions>
+                        <execution>
+                            <id>generate-sources</id>
+                            <goals>
+                                <goal>generate-sources</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This PR adds a missing redraw listener (see #237) and adds more documentation, an additional sample and some small changes to Histogram to adress #246.
Also fixes the issue that mvn clean after mvn compile would fail if the chartfx-generate plugin was not in the local or remote repository, because it would be deleted before the modules using it. This was solved by adding the compile step to the clean step of the plugin.