### PR TITLE
Show inidcators axis affiliation and allow changing label name and removing

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/Axis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/Axis.java
@@ -7,6 +7,7 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
+import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
@@ -17,7 +18,6 @@ import de.gsi.chart.axes.spi.MetricPrefix;
 import de.gsi.chart.axes.spi.TickMark;
 import de.gsi.chart.ui.geometry.Side;
 import de.gsi.dataset.AxisDescription;
-import de.gsi.dataset.event.EventSource;
 import de.gsi.dataset.event.UpdateEvent;
 
 public interface Axis extends AxisDescription {
@@ -346,4 +346,9 @@ public interface Axis extends AxisDescription {
      * @return the primary unit label property
      */
     DoubleProperty unitScalingProperty();
+
+    /**
+     * @return the canvas of the axis
+     */
+    Canvas getCanvas();
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -278,6 +278,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         return axisFormatter.get();
     }
 
+    @Override
     public Canvas getCanvas() {
         return canvas;
     }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractRangeValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractRangeValueIndicator.java
@@ -1,10 +1,11 @@
 package de.gsi.chart.plugins;
 
-import de.gsi.chart.axes.Axis;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Bounds;
 import javafx.scene.shape.Rectangle;
+
+import de.gsi.chart.axes.Axis;
 
 /**
  * Plugin indicating a value range as a rectangle drawn on the plot area, with an optional {@link #textProperty() text
@@ -22,7 +23,6 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
     protected final Rectangle rectangle = new Rectangle(0, 0, 0, 0);
 
     private final DoubleProperty lowerBound = new SimpleDoubleProperty(this, "lowerBound") {
-
         @Override
         protected void invalidated() {
             layoutChildren();
@@ -30,7 +30,6 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
     };
 
     private final DoubleProperty upperBound = new SimpleDoubleProperty(this, "upperBound") {
-
         @Override
         protected void invalidated() {
             layoutChildren();
@@ -39,7 +38,6 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
 
     private final DoubleProperty labelHorizontalPosition = new SimpleDoubleProperty(this, "labelHorizontalPosition",
             0.5) {
-
         @Override
         protected void invalidated() {
             if (get() < 0 || get() > 1) {
@@ -50,7 +48,6 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
     };
 
     private final DoubleProperty labelVerticalPosition = new SimpleDoubleProperty(this, "labelVerticalPosition", 0.5) {
-
         @Override
         protected void invalidated() {
             if (get() < 0 || get() > 1) {
@@ -141,13 +138,13 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
      */
     protected void layout(final Bounds bounds) {
         if (bounds.intersects(getChart().getCanvas().getBoundsInLocal())) {
+            layoutLabel(bounds, getLabelHorizontalPosition(), getLabelVerticalPosition());
             rectangle.setX(bounds.getMinX());
             rectangle.setY(bounds.getMinY());
             rectangle.setWidth(bounds.getWidth());
             rectangle.setHeight(bounds.getHeight());
             addChildNodeIfNotPresent(rectangle);
 
-            layoutLabel(bounds, getLabelHorizontalPosition(), getLabelVerticalPosition());
         } else {
             getChartChildren().clear();
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
@@ -153,15 +153,17 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         pickLine.setStrokeWidth(getPickingDistance());
         pickLine.mouseTransparentProperty().bind(editableIndicatorProperty().not());
         pickLine.setOnMousePressed(mouseEvent -> {
-            /*
-             * Record a delta distance for the drag and drop operation. Because layoutLine() sets the start/end points
-             * we have to use these here. It is enough to use the start point. For X indicators, start x and end x are
-             * identical and for Y indicators start y and end y are identical.
-             */
-            dragDelta.x = pickLine.getStartX() - mouseEvent.getX();
-            dragDelta.y = pickLine.getStartY() - mouseEvent.getY();
-            pickLine.setCursor(Cursor.MOVE);
-            mouseEvent.consume();
+            if (mouseEvent.isPrimaryButtonDown()) {
+                /*
+                 * Record a delta distance for the drag and drop operation. Because layoutLine() sets the start/end points
+                 * we have to use these here. It is enough to use the start point. For X indicators, start x and end x are
+                 * identical and for Y indicators start y and end y are identical.
+                 */
+                dragDelta.x = pickLine.getStartX() - mouseEvent.getX();
+                dragDelta.y = pickLine.getStartY() - mouseEvent.getY();
+                pickLine.setCursor(Cursor.MOVE);
+                mouseEvent.consume();
+            }
         });
     }
 
@@ -222,8 +224,8 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         pickLine.setEndX(endX);
         pickLine.setEndY(endY);
 
-        addChildNodeIfNotPresent(line);
         addChildNodeIfNotPresent(pickLine);
+        addChildNodeIfNotPresent(line);
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
@@ -97,10 +97,17 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         editableIndicatorProperty().addListener((ch, o, n) -> updateMouseListener(n));
         updateMouseListener(isEditable());
 
+        // remove triangle from chart foregrond when the chart is removed
+        chartProperty().addListener((p, o, n) -> {
+            if (o != null) {
+                o.getPlotForeground().getChildren().remove(triangle);
+            }
+        });
+
         // Need to add them so that at initialization of the stage the CCS is
         // applied and we can calculate label's
         // width and height
-        getChartChildren().addAll(line, triangle, label);
+        getChartChildren().addAll(line, label);
         this.value.addListener(
                 (ch, o, n) -> invokeListener(new UpdateEvent(this, "value changed to " + n + " for axis " + axis)));
     }
@@ -162,6 +169,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         triangle.visibleProperty().bind(editableIndicatorProperty());
         triangle.mouseTransparentProperty().bind(editableIndicatorProperty().not());
         triangle.setPickOnBounds(true);
+        triangle.setOpacity(0.7);
         final double a = AbstractSingleValueIndicator.triangleHalfWidth;
         triangle.getPoints().setAll(-a, -a, -a, +a, +a, +a, +a, -a);
         triangle.setOnMousePressed(mouseEvent -> {
@@ -216,7 +224,6 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
 
         addChildNodeIfNotPresent(line);
         addChildNodeIfNotPresent(pickLine);
-        // pickLine.toBack();
     }
 
     /**
@@ -234,7 +241,13 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
 
         triangle.setTranslateX(startX);
         triangle.setTranslateY(startY);
-        addChildNodeIfNotPresent(triangle);
+        triangle.toFront();
+        // triangle has to be put onto the plot foreground to be able to put it on top of axes
+        // is removed when the chart is changed
+        //addChildNodeIfNotPresent(triangle);
+        if (!getChart().getPlotForeground().getChildren().contains(triangle)) {
+            getChart().getPlotForeground().getChildren().add(triangle);
+        }
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/XValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/XValueIndicator.java
@@ -7,6 +7,7 @@ import javafx.geometry.Point2D;
 import javafx.scene.input.MouseEvent;
 
 import de.gsi.chart.axes.Axis;
+import de.gsi.chart.ui.geometry.Side;
 import de.gsi.dataset.event.EventSource;
 
 /**
@@ -44,7 +45,6 @@ public class XValueIndicator extends AbstractSingleValueIndicator implements Eve
      */
     public XValueIndicator(final Axis axis, final double value, final String text) {
         super(axis, value, text);
-        triangle.getPoints().setAll(0.0, 0.0, -8.0, -8.0, 8.0, -8.0);
         setLabelPosition(0.04);
 
         pickLine.setOnMouseDragged(this::handleDragMouseEvent);
@@ -74,13 +74,23 @@ public class XValueIndicator extends AbstractSingleValueIndicator implements Eve
         final double maxX = plotAreaBounds.getMaxX();
         final double minY = plotAreaBounds.getMinY();
         final double maxY = plotAreaBounds.getMaxY();
-        final double xPos = minX + getChart().getFirstAxis(Orientation.HORIZONTAL).getDisplayPosition(getValue());
+        final double xPos = minX + getAxis().getDisplayPosition(getValue());
+        final double axisPos;
+        if (getAxis().getSide().equals(Side.BOTTOM)) {
+            triangle.getPoints().setAll(0.0, -8.0, -8.0, 0.0, 8.0, 0.0);
+            axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(0, 0)).getY() + 6;
+        } else {
+            triangle.getPoints().setAll(0.0, 0.0, -8.0, -8.0, 8.0, -8.0);
+            axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(0, getAxis().getHeight())).getY() - 6;
+        }
+        final double xPosGlobal = getChart().getPlotForeground().sceneToLocal(getChart().getCanvas().localToScene(xPos, 0)).getX();
 
         if (xPos < minX || xPos > maxX) {
             getChartChildren().clear();
         } else {
             layoutLine(xPos, minY, xPos, maxY);
-            layoutMarker(xPos, minY + 1.5 * AbstractSingleValueIndicator.triangleHalfWidth, xPos, maxY);
+            layoutMarker(xPosGlobal, axisPos + 4, xPos, maxY);
+
             layoutLabel(new BoundingBox(xPos, minY, 0, maxY - minY), AbstractSingleValueIndicator.MIDDLE_POSITION,
                     getLabelPosition());
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/YValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/YValueIndicator.java
@@ -11,6 +11,7 @@ import javafx.geometry.Point2D;
 import javafx.scene.input.MouseEvent;
 
 import de.gsi.chart.axes.Axis;
+import de.gsi.chart.ui.geometry.Side;
 import de.gsi.dataset.event.EventSource;
 
 /**
@@ -49,7 +50,6 @@ public class YValueIndicator extends AbstractSingleValueIndicator implements Eve
      */
     public YValueIndicator(final Axis axis, final double value, final String text) {
         super(axis, value, text);
-        triangle.getPoints().setAll(0.0, 0.0, 8.0, 8.0, 8.0, -8.0);
         setLabelHorizontalAnchor(HPos.RIGHT);
         setLabelPosition(0.975);
 
@@ -81,13 +81,21 @@ public class YValueIndicator extends AbstractSingleValueIndicator implements Eve
         final double maxY = plotAreaBounds.getMaxY();
 
         final double yPos = minY + getAxis().getDisplayPosition(getValue());
+        final double axisPos;
+        if (getAxis().getSide().equals(Side.RIGHT)) {
+            axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(0, 0)).getX() + 2;
+            triangle.getPoints().setAll(0.0, 0.0, 8.0, 8.0, 8.0, -8.0);
+        } else {
+            axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(getAxis().getWidth(), 0)).getX() - 2;
+            triangle.getPoints().setAll(0.0, 0.0, -8.0, 8.0, -8.0, -8.0);
+        }
+        final double yPosGlobal = getChart().getPlotForeground().sceneToLocal(getChart().getCanvas().localToScene(0, yPos)).getY();
 
         if (yPos < minY || yPos > maxY) {
             getChartChildren().clear();
         } else {
             layoutLine(minX, yPos, maxX, yPos);
-            layoutMarker(maxX - 1.5 * AbstractSingleValueIndicator.triangleHalfWidth, yPos, minX, yPos); // +
-                    // 1.5*TRIANGLE_HALF_WIDTH
+            layoutMarker(axisPos, yPosGlobal, minX, yPos);
             layoutLabel(new BoundingBox(minX, yPos, maxX - minX, 0), getLabelPosition(),
                     AbstractSingleValueIndicator.MIDDLE_POSITION);
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/ValueIndicatorSelector.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/measurements/utils/ValueIndicatorSelector.java
@@ -73,14 +73,12 @@ public class ValueIndicatorSelector extends GridPane {
         if (plugin.getChart() != null) {
             plugin.getChart().getPlugins().addListener(pluginsChanged);
             plugin.getChart().getPlugins().forEach(this::addNewIndicators);
-            reuseIndicators.setSelected(plugin.getChart().getAxes().size() <= 2);
         }
 
         final Label label = new Label("re-use inidcators: ");
         GridPane.setConstraints(label, 0, 0);
         GridPane.setConstraints(reuseIndicators, 1, 0);
-        reuseIndicators.selectedProperty().addListener((ch, o, n) -> indicatorListView.setDisable(!n));
-
+        indicatorListView.disableProperty().bind(reuseIndicators.selectedProperty().not());
         indicatorListView.setOrientation(Orientation.VERTICAL);
         indicatorListView.setPrefSize(-1, DEFAULT_SELECTOR_HEIGHT);
         indicatorListView.setCellFactory(list -> new DataSelectorLabel());

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
@@ -6,6 +6,7 @@ import static de.gsi.dataset.DataSet.DIM_X;
 
 import java.util.List;
 
+import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
@@ -373,6 +374,11 @@ public class AbstractAxisParameterTests {
         @Override
         public void requestAxisLayout() {
             // deliberately not implemented
+        }
+
+        @Override
+        public Canvas getCanvas() {
+            return null;
         }
     }
 }


### PR DESCRIPTION
Small improvements to the indicator plugin in light of #204 : 
- move the triangle above the corresponding axis, to show which axis it belongs to
    - had to move it from chartPluginChildren to plotForeground and delete it if the plugin is removed, because chartPluginChildren are restricted to the area inside the axes. Also this makes the triangle indicators mouse transparent
    - make the triangles slightly transparent to still see the tick marks
- make the indicators editable and removable:
    - right click on the label replaces the label with a text edit
    - press `ENTER` to confirm the new label, `ESC` to discard or `CTRL`+ `DEL` to remove the indicator from the chart.