### PR TITLE
Fix travis for branches with slashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - if [ -n "$GPG_KEY" ]; then echo $GPG_KEY | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ -n "$GPG_KEY" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
   # setup version information
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then export REVISION=${TRAVIS_BRANCH}; else export REVISION=${TRAVIS_BRANCH}PR${TRAVIS_PULL_REQUEST}; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then export REVISION=${TRAVIS_BRANCH//\//-}; else export REVISION=${TRAVIS_BRANCH//\//-}PR${TRAVIS_PULL_REQUEST}; fi
   - if [[ -z "$TRAVIS_TAG" || ! "$TRAVIS_TAG" =~ ^11\.[0-9]*\.[0-9]*$ ]]; then export CHANGELIST=-SNAPSHOT; fi
   # download coverity tools and determine if extended scans should be performed
   - export COVERITY_RESULTS_ARCHIVE=coverity_report.tar.bz2


### PR DESCRIPTION
Because we ues the branch name in the REVISION part of the module
version, branches with slashes will fail the maven build as slashes in
the version are not supported.