### PR TITLE
Serialiser coverity fixes

### DIFF
--- a/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
@@ -519,6 +519,7 @@ public class IoClassSerialiser {
     private void setMatchedIoSerialiser(final IoSerialiser matchedIoSerialiser) {
         this.matchedIoSerialiser = matchedIoSerialiser;
         this.matchedIoSerialiser.setBuffer(dataBuffer);
+        this.matchedIoSerialiser.setFieldSerialiserLookupFunction(getSerialiserLookupFunction());
         assert this.matchedIoSerialiser.getBuffer() == dataBuffer;
         startMarkerFunction = this.matchedIoSerialiser::putStartMarker;
         endMarkerFunction = this.matchedIoSerialiser::putEndMarker;

--- a/microservice/src/main/java/de/gsi/serializer/IoSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/IoSerialiser.java
@@ -63,7 +63,7 @@ public interface IoSerialiser {
 
     char[] getCharArray(final char[] dst, final int length);
 
-    <E> Collection<E> getCollection(Collection<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> Collection<E> getCollection(Collection<E> collection);
 
     <E> E getCustomData(FieldSerialiser<E> serialiser);
 
@@ -109,7 +109,7 @@ public interface IoSerialiser {
 
     int[] getIntArray(final int[] dst, final int length);
 
-    <E> List<E> getList(List<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> List<E> getList(List<E> collection);
 
     long getLong();
 
@@ -123,11 +123,11 @@ public interface IoSerialiser {
 
     long[] getLongArray(final long[] dst, final int length);
 
-    <K, V, E> Map<K, V> getMap(Map<K, V> map, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <K, V, E> Map<K, V> getMap(Map<K, V> map);
 
-    <E> Queue<E> getQueue(Queue<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> Queue<E> getQueue(Queue<E> collection);
 
-    <E> Set<E> getSet(Set<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> Set<E> getSet(Set<E> collection);
 
     short getShort(); // NOPMD by rstein
 
@@ -161,17 +161,17 @@ public interface IoSerialiser {
 
     WireDataFieldDescription parseIoStream(boolean readHeader);
 
-    <E> void put(FieldDescription fieldDescription, Collection<E> collection, Type valueType, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> void put(FieldDescription fieldDescription, Collection<E> collection, Type valueType);
 
     void put(FieldDescription fieldDescription, Enum<?> enumeration);
 
-    <K, V, E> void put(FieldDescription fieldDescription, Map<K, V> map, Type keyType, Type valueType, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <K, V, E> void put(FieldDescription fieldDescription, Map<K, V> map, Type keyType, Type valueType);
 
-    <E> void put(String fieldName, Collection<E> collection, Type valueType, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <E> void put(String fieldName, Collection<E> collection, Type valueType);
 
     void put(String fieldName, Enum<?> enumeration);
 
-    <K, V, E> void put(String fieldName, Map<K, V> map, Type keyType, Type valueType, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup);
+    <K, V, E> void put(String fieldName, Map<K, V> map, Type keyType, Type valueType);
 
     default void put(FieldDescription fieldDescription, final boolean[] src) {
         put(fieldDescription, src, -1);
@@ -374,4 +374,8 @@ public interface IoSerialiser {
     void putStartMarker(FieldDescription fieldDescription);
 
     void updateDataEndMarker(WireDataFieldDescription fieldHeader);
+
+    void setFieldSerialiserLookupFunction(BiFunction<Type, Type[], FieldSerialiser<Object>> serialiserLookupFunction);
+
+    BiFunction<Type, Type[], FieldSerialiser<Object>> getSerialiserLookupFunction();
 }

--- a/microservice/src/main/java/de/gsi/serializer/spi/CmwLightSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/CmwLightSerialiser.java
@@ -100,6 +100,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     private IoBuffer buffer;
     private WireDataFieldDescription parent;
     private WireDataFieldDescription lastFieldHeader;
+    private BiFunction<Type, Type[], FieldSerialiser<Object>> fieldSerialiserLookupFunction;
 
     public CmwLightSerialiser(final IoBuffer buffer) {
         super();
@@ -175,7 +176,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> Collection<E> getCollection(final Collection<E> collection, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Collection<E> getCollection(final Collection<E> collection) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -286,7 +287,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> List<E> getList(final List<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> List<E> getList(final List<E> collection) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -302,7 +303,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> Map<K, V> getMap(final Map<K, V> map, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <K, V, E> Map<K, V> getMap(final Map<K, V> map) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -311,12 +312,12 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> Queue<E> getQueue(final Queue<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Queue<E> getQueue(final Queue<E> collection) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
     @Override
-    public <E> Set<E> getSet(final Set<E> collection, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Set<E> getSet(final Set<E> collection) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -424,7 +425,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> void put(final FieldDescription fieldDescription, final Collection<E> collection, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> void put(final FieldDescription fieldDescription, final Collection<E> collection, final Type valueType) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -434,7 +435,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> void put(final FieldDescription fieldDescription, final Map<K, V> map, Type keyType, Type valueType, BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <K, V, E> void put(final FieldDescription fieldDescription, final Map<K, V> map, Type keyType, Type valueType) {
         throw new UnsupportedOperationException(NOT_IMPLEMENTED);
     }
 
@@ -903,7 +904,7 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> void put(final String fieldName, final Collection<E> collection, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> void put(final String fieldName, final Collection<E> collection, final Type valueType) {
         final DataType dataType;
         if (collection instanceof Queue) {
             dataType = DataType.QUEUE;
@@ -916,7 +917,7 @@ public class CmwLightSerialiser implements IoSerialiser {
         }
 
         final WireDataFieldDescription fieldHeader = putFieldHeader(fieldName, dataType);
-        this.put((FieldDescription) null, collection, valueType, serialiserLookup);
+        this.put((FieldDescription) null, collection, valueType);
         this.updateDataEndMarker(fieldHeader);
     }
 
@@ -928,9 +929,9 @@ public class CmwLightSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> void put(final String fieldName, final Map<K, V> map, final Type keyType, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <K, V, E> void put(final String fieldName, final Map<K, V> map, final Type keyType, final Type valueType) {
         final WireDataFieldDescription fieldHeader = putFieldHeader(fieldName, DataType.MAP);
-        this.put((FieldDescription) null, map, keyType, valueType, serialiserLookup);
+        this.put((FieldDescription) null, map, keyType, valueType);
         this.updateDataEndMarker(fieldHeader);
     }
 
@@ -1096,5 +1097,15 @@ public class CmwLightSerialiser implements IoSerialiser {
         }
 
         throw new IllegalArgumentException("DataType byteValue=" + byteValue + " rawByteValue=" + (byteValue & 0xFF) + " not mapped");
+    }
+
+    @Override
+    public void setFieldSerialiserLookupFunction(final BiFunction<Type, Type[], FieldSerialiser<Object>> serialiserLookupFunction) {
+        this.fieldSerialiserLookupFunction = serialiserLookupFunction;
+    }
+
+    @Override
+    public BiFunction<Type, Type[], FieldSerialiser<Object>> getSerialiserLookupFunction() {
+        return fieldSerialiserLookupFunction;
     }
 }

--- a/microservice/src/main/java/de/gsi/serializer/spi/JsonSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/JsonSerialiser.java
@@ -49,6 +49,7 @@ public class JsonSerialiser implements IoSerialiser {
     private String queryFieldName = null;
     private boolean hasFieldBefore = false;
     private String indentation = "";
+    private BiFunction<Type, Type[], FieldSerialiser<Object>> fieldSerialiserLookupFunction;
 
     /**
      * @param buffer the backing IoBuffer (see e.g. {@link FastByteBuffer} or{@link ByteBuffer}
@@ -147,7 +148,7 @@ public class JsonSerialiser implements IoSerialiser {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> Collection<E> getCollection(final Collection<E> collection, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Collection<E> getCollection(final Collection<E> collection) {
         return tempRoot.get(queryFieldName).as(ArrayList.class);
     }
 
@@ -204,7 +205,7 @@ public class JsonSerialiser implements IoSerialiser {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> List<E> getList(final List<E> collection, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> List<E> getList(final List<E> collection) {
         return tempRoot.get(queryFieldName).as(List.class);
     }
 
@@ -219,7 +220,7 @@ public class JsonSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> Map<K, V> getMap(final Map<K, V> map, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <K, V, E> Map<K, V> getMap(final Map<K, V> map) {
         return null;
     }
 
@@ -229,7 +230,7 @@ public class JsonSerialiser implements IoSerialiser {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> Queue<E> getQueue(final Queue<E> collection, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Queue<E> getQueue(final Queue<E> collection) {
         return tempRoot.get(queryFieldName).as(ArrayDeque.class);
     }
 
@@ -239,7 +240,7 @@ public class JsonSerialiser implements IoSerialiser {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> Set<E> getSet(final Set<E> collection, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> Set<E> getSet(final Set<E> collection) {
         return tempRoot.get(queryFieldName).as(HashSet.class);
     }
 
@@ -290,8 +291,8 @@ public class JsonSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <E> void put(final FieldDescription fieldDescription, final Collection<E> collection, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
-        put(fieldDescription.getFieldName(), collection, valueType, serialiserLookup);
+    public <E> void put(final FieldDescription fieldDescription, final Collection<E> collection, final Type valueType) {
+        put(fieldDescription.getFieldName(), collection, valueType);
     }
 
     @Override
@@ -300,12 +301,12 @@ public class JsonSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> void put(final FieldDescription fieldDescription, final Map<K, V> map, final Type keyType, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
-        put(fieldDescription.getFieldName(), map, keyType, valueType, serialiserLookup);
+    public <K, V, E> void put(final FieldDescription fieldDescription, final Map<K, V> map, final Type keyType, final Type valueType) {
+        put(fieldDescription.getFieldName(), map, keyType, valueType);
     }
 
     @Override
-    public <E> void put(final String fieldName, final Collection<E> collection, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <E> void put(final String fieldName, final Collection<E> collection, final Type valueType) {
         lineBreak();
         builder.append('\"').append(fieldName).append("\", ").append("[");
         if (collection == null || collection.isEmpty()) {
@@ -330,7 +331,7 @@ public class JsonSerialiser implements IoSerialiser {
     }
 
     @Override
-    public <K, V, E> void put(final String fieldName, final Map<K, V> map, final Type keyType, final Type valueType, final BiFunction<Type, Type[], FieldSerialiser<E>> serialiserLookup) {
+    public <K, V, E> void put(final String fieldName, final Map<K, V> map, final Type keyType, final Type valueType) {
         lineBreak();
         builder.append('\"').append(fieldName).append("\", ").append('{');
         if (map == null || map.isEmpty()) {
@@ -909,5 +910,15 @@ public class JsonSerialiser implements IoSerialiser {
             }
         }
         //add if necessary new WireDataFieldDescription(this, fieldRoot, fieldName.hashCode(), fieldName, DataType.END_MARKER, 0, -1, -1)
+    }
+
+    @Override
+    public void setFieldSerialiserLookupFunction(final BiFunction<Type, Type[], FieldSerialiser<Object>> serialiserLookupFunction) {
+        this.fieldSerialiserLookupFunction = serialiserLookupFunction;
+    }
+
+    @Override
+    public BiFunction<Type, Type[], FieldSerialiser<Object>> getSerialiserLookupFunction() {
+        return fieldSerialiserLookupFunction;
     }
 }

--- a/microservice/src/main/java/de/gsi/serializer/spi/WireDataFieldDescription.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/WireDataFieldDescription.java
@@ -236,15 +236,15 @@ public class WireDataFieldDescription implements FieldDescription {
         case ENUM:
             return ioSerialiser.getEnum(null);
         case LIST:
-            return ioSerialiser.getList(null, null);
+            return ioSerialiser.getList(null);
         case MAP:
-            return ioSerialiser.getMap(null, null);
+            return ioSerialiser.getMap(null);
         case QUEUE:
-            return ioSerialiser.getQueue(null, null);
+            return ioSerialiser.getQueue(null);
         case SET:
-            return ioSerialiser.getSet(null, null);
+            return ioSerialiser.getSet(null);
         case COLLECTION:
-            return ioSerialiser.getCollection(null, null);
+            return ioSerialiser.getCollection(null);
         case OTHER:
             return ioSerialiser.getCustomData(null);
         default:

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/DataSetSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/DataSetSerialiser.java
@@ -225,13 +225,13 @@ public class DataSetSerialiser { // NOPMD
     protected void parseDataLabels(final DataSetBuilder builder, final FieldDescription fieldRoot) {
         if (checkFieldCompatibility(fieldRoot, DATA_LABELS.hashCode(), DATA_LABELS, DataType.MAP) != null) {
             Map<Integer, String> map = new HashMap<>();
-            map = ioSerialiser.getMap(map, null);
+            map = ioSerialiser.getMap(map);
             builder.setDataLabelMap(map);
         }
 
         if (checkFieldCompatibility(fieldRoot, DATA_STYLES.hashCode(), DATA_STYLES, DataType.MAP) != null) {
             Map<Integer, String> map = new HashMap<>();
-            map = ioSerialiser.getMap(map, null);
+            map = ioSerialiser.getMap(map);
             builder.setDataStyleMap(map);
         }
     }
@@ -267,7 +267,7 @@ public class DataSetSerialiser { // NOPMD
 
         if (checkFieldCompatibility(rootField, META_INFO.hashCode(), META_INFO, DataType.MAP) != null) {
             Map<String, String> map = new HashMap<>();
-            map = ioSerialiser.getMap(map, null);
+            map = ioSerialiser.getMap(map);
             builder.setMetaInfoMap(map);
         }
     }
@@ -293,11 +293,11 @@ public class DataSetSerialiser { // NOPMD
         if (dataSet instanceof AbstractDataSet) {
             final StringHashMapList labelMap = ((AbstractDataSet<?>) dataSet).getDataLabelMap();
             if (!labelMap.isEmpty()) {
-                ioSerialiser.put(DATA_LABELS, labelMap, Integer.class, String.class, null);
+                ioSerialiser.put(DATA_LABELS, labelMap, Integer.class, String.class);
             }
             final StringHashMapList styleMap = ((AbstractDataSet<?>) dataSet).getDataStyleMap();
             if (!styleMap.isEmpty()) {
-                ioSerialiser.put(DATA_STYLES, styleMap, Integer.class, String.class, null);
+                ioSerialiser.put(DATA_STYLES, styleMap, Integer.class, String.class);
             }
             return;
         }
@@ -311,7 +311,7 @@ public class DataSetSerialiser { // NOPMD
             }
         }
         if (!labelMap.isEmpty()) {
-            ioSerialiser.put(DATA_LABELS, labelMap, Integer.class, String.class, null);
+            ioSerialiser.put(DATA_LABELS, labelMap, Integer.class, String.class);
         }
 
         final Map<Integer, String> styleMap = new HashMap<>();
@@ -322,7 +322,7 @@ public class DataSetSerialiser { // NOPMD
             }
         }
         if (!styleMap.isEmpty()) {
-            ioSerialiser.put(DATA_STYLES, styleMap, Integer.class, String.class, null);
+            ioSerialiser.put(DATA_STYLES, styleMap, Integer.class, String.class);
         }
     }
 
@@ -360,7 +360,7 @@ public class DataSetSerialiser { // NOPMD
         ioSerialiser.put(INFO_LIST, metaDataSet.getInfoList().toArray(new String[0]));
         ioSerialiser.put(WARNING_LIST, metaDataSet.getWarningList().toArray(new String[0]));
         ioSerialiser.put(ERROR_LIST, metaDataSet.getErrorList().toArray(new String[0]));
-        ioSerialiser.put(META_INFO, metaDataSet.getMetaInfo(), String.class, String.class, null);
+        ioSerialiser.put(META_INFO, metaDataSet.getMetaInfo(), String.class, String.class);
     }
 
     /**

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldBoxedValueArrayHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldBoxedValueArrayHelper.java
@@ -23,49 +23,49 @@ public final class FieldBoxedValueArrayHelper {
     public static void register(final IoClassSerialiser serialiser) {
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getBooleanArray())), // reader
-                (io, obj, field) -> (Boolean[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toBoolPrimitive((Boolean[]) field.getField().get(obj))), // writer
                 Boolean[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getByteArray())), // reader
-                (io, obj, field) -> (Byte[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toBytePrimitive((Byte[]) field.getField().get(obj))), // writer
                 Byte[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getCharArray())), // reader
-                (io, obj, field) -> (Character[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toCharPrimitive((Character[]) field.getField().get(obj))), // writer
                 Character[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getShortArray())), // reader
-                (io, obj, field) -> (Short[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toShortPrimitive((Short[]) field.getField().get(obj))), // writer
                 Short[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getIntArray())), // reader
-                (io, obj, field) -> (Integer[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toIntegerPrimitive((Integer[]) field.getField().get(obj))), // writer
                 Integer[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getLongArray())), // reader
-                (io, obj, field) -> (Long[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toLongPrimitive((Long[]) field.getField().get(obj))), // writer
                 Long[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getFloatArray())), // reader
-                (io, obj, field) -> (Float[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toFloatPrimitive((Float[]) field.getField().get(obj))), // writer
                 Float[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, GenericsHelper.toObject(io.getDoubleArray())), // reader
-                (io, obj, field) -> (Double[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, GenericsHelper.toDoublePrimitive((Double[]) field.getField().get(obj))), // writer
                 Double[].class));
     }

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldBoxedValueHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldBoxedValueHelper.java
@@ -23,43 +23,43 @@ public final class FieldBoxedValueHelper {
     public static void register(final IoClassSerialiser serialiser) {
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getBoolean()), // reader
-                (io, obj, field) -> (Boolean) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Boolean) field.getField().get(obj)), // writer
                 Boolean.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getByte()), // reader
-                (io, obj, field) -> (Byte) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Byte) field.getField().get(obj)), // writer
                 Byte.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getShort()), // reader
-                (io, obj, field) -> (Short) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Short) field.getField().get(obj)), // writer
                 Short.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getInt()), // reader
-                (io, obj, field) -> (Integer) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Integer) field.getField().get(obj)), // writer
                 Integer.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getLong()), // reader
-                (io, obj, field) -> (Long) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Long) field.getField().get(obj)), // writer
                 Long.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getFloat()), // reader
-                (io, obj, field) -> (Float) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Float) field.getField().get(obj)), // writer
                 Float.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getDouble()), // reader
-                (io, obj, field) -> (Double) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (Double) field.getField().get(obj)), // writer
                 Double.class));
     }

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldCollectionsHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldCollectionsHelper.java
@@ -22,22 +22,22 @@ public class FieldCollectionsHelper {
     public static void register(final IoClassSerialiser serialiser) {
         // Collection serialiser mapper to IoBuffer
         final FieldSerialiser.TriFunction<Collection<?>> returnCollection = (io, obj, field) -> //
-                io.getCollection(field == null ? null : (Collection<?>) field.getField().get(obj), serialiser.getSerialiserLookupFunction()); // return function
+                io.getCollection(field == null ? null : (Collection<?>) field.getField().get(obj)); // return function
         final FieldSerialiser.TriFunction<Collection<?>> returnList = (io, obj, field) -> //
-                io.getList(field == null ? null : (List<?>) field.getField().get(obj), serialiser.getSerialiserLookupFunction()); // return function
+                io.getList(field == null ? null : (List<?>) field.getField().get(obj)); // return function
         final FieldSerialiser.TriFunction<Collection<?>> returnQueue = (io, obj, field) -> //
-                io.getQueue(field == null ? null : (Queue<?>) field.getField().get(obj), serialiser.getSerialiserLookupFunction()); // return function
+                io.getQueue(field == null ? null : (Queue<?>) field.getField().get(obj)); // return function
         final FieldSerialiser.TriFunction<Collection<?>> returnSet = (io, obj, field) -> //
-                io.getSet(field == null ? null : (Set<?>) field.getField().get(obj), serialiser.getSerialiserLookupFunction()); // return function
+                io.getSet(field == null ? null : (Set<?>) field.getField().get(obj)); // return function
 
         final FieldSerialiser.TriConsumer collectionWriter = (io, obj, field) -> {
             if (field != null && !field.getActualTypeArguments().isEmpty() && ClassUtils.isPrimitiveWrapperOrString(ClassUtils.getRawType(field.getActualTypeArguments().get(0)))) {
-                io.put(field, (Collection<?>) field.getField().get(obj), field.getActualTypeArguments().get(0), null);
+                io.put(field, (Collection<?>) field.getField().get(obj), field.getActualTypeArguments().get(0));
                 return;
             }
             if (field != null) {
                 // Collection<custom class> serialiser
-                io.put(field, (Collection<?>) field.getField().get(obj), field.getActualTypeArguments().get(0), serialiser.getSerialiserLookupFunction());
+                io.put(field, (Collection<?>) field.getField().get(obj), field.getActualTypeArguments().get(0));
                 return;
             }
             throw new IllegalArgumentException("serialiser for obj = '" + obj + "' and type = '" + (obj == null ? "null" : obj.getClass()) + "'  not yet implemented, field = " + field);

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldListAxisDescription.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldListAxisDescription.java
@@ -31,7 +31,7 @@ public class FieldListAxisDescription extends FieldSerialiser<List<AxisDescripti
     }
 
     protected List<AxisDescription> execFieldReturn(final IoSerialiser ioSerialiser, Object obj, ClassFieldDescription field) {
-        final Object oldObject = field.getField().get(obj);
+        final Object oldObject = field == null ? null : field.getField().get(obj);
         final boolean isListPresent = oldObject instanceof List;
 
         final int nElements = ioSerialiser.getBuffer().getInt(); // number of elements

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldMapHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldMapHelper.java
@@ -20,13 +20,13 @@ public class FieldMapHelper {
 
         final FieldSerialiser.TriFunction<Map<?, ?>> returnMapFunction = (io, obj, field) -> {
             final Map<?, ?> origMap = field == null ? null : (Map<?, ?>) field.getField().get(obj);
-            return io.getMap(origMap, serialiser.getSerialiserLookupFunction());
+            return io.getMap(origMap);
         };
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, returnMapFunction.apply(io, obj, field)), // reader
                 returnMapFunction, // return
-                (io, obj, field) -> io.put(field, (Map<?, ?>) field.getField().get(obj), field.getActualTypeArguments().get(0), field.getActualTypeArguments().get(1), serialiser.getSerialiserLookupFunction()), // writer
+                (io, obj, field) -> io.put(field, (Map<?, ?>) field.getField().get(obj), field.getActualTypeArguments().get(0), field.getActualTypeArguments().get(1)), // writer
                 Map.class));
     }
 }

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldPrimitiveValueHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldPrimitiveValueHelper.java
@@ -21,55 +21,55 @@ public final class FieldPrimitiveValueHelper {
     public static void register(final IoClassSerialiser serialiser) {
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setBoolean(obj, io.getBoolean()), // reader
-                (io, obj, field) -> (Boolean) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getBoolean(obj)), // writer
                 boolean.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setByte(obj, io.getByte()), // reader
-                (io, obj, field) -> (Byte) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getByte(obj)), // writer
                 byte.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setChar(obj, io.getChar()), // reader
-                (io, obj, field) -> (Character) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getChar(obj)), // writer
                 char.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setShort(obj, io.getShort()), // reader
-                (io, obj, field) -> (Short) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getShort(obj)), // writer
                 short.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setInt(obj, io.getInt()), // reader
-                (io, obj, field) -> (Integer) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getInt(obj)), // writer
                 int.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setLong(obj, io.getLong()), // reader
-                (io, obj, field) -> (Long) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getLong(obj)), // writer
                 long.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setFloat(obj, io.getFloat()), // reader
-                (io, obj, field) -> (Float) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getFloat(obj)), // writer
                 float.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().setDouble(obj, io.getDouble()), // reader
-                (io, obj, field) -> (Double) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, field.getField().getDouble(obj)), // writer
                 double.class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getString()), // reader
-                (io, obj, field) -> (String) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (String) field.getField().get(obj)), // writer
                 String.class));
     }

--- a/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldPrimitveValueArrayHelper.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/iobuffer/FieldPrimitveValueArrayHelper.java
@@ -23,55 +23,55 @@ public final class FieldPrimitveValueArrayHelper {
     public static void register(final IoClassSerialiser serialiser) {
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getBooleanArray((boolean[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (boolean[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (boolean[]) field.getField().get(obj)), // writer
                 boolean[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getByteArray((byte[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (byte[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (byte[]) field.getField().get(obj)), // writer
                 byte[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getCharArray((char[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (char[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (char[]) field.getField().get(obj)), // writer
                 char[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getShortArray((short[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (short[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (short[]) field.getField().get(obj)), // writer
                 short[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getIntArray((int[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (int[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (int[]) field.getField().get(obj)), // writer
                 int[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getLongArray((long[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (long[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (long[]) field.getField().get(obj)), // writer
                 long[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getFloatArray((float[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (float[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (float[]) field.getField().get(obj)), // writer
                 float[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getDoubleArray((double[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (double[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (double[]) field.getField().get(obj)), // writer
                 double[].class));
 
         serialiser.addClassDefinition(new FieldSerialiser<>( //
                 (io, obj, field) -> field.getField().set(obj, io.getStringArray((String[]) field.getField().get(obj))), // reader
-                (io, obj, field) -> (String[]) field.getField().get(obj), // return
+                (io, obj, field) -> { throw new UnsupportedOperationException("return function not supported for primitive types"); }, // return
                 (io, obj, field) -> io.put(field, (String[]) field.getField().get(obj)), // writer
                 String[].class));
     }

--- a/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
@@ -132,6 +132,8 @@ class IoClassSerialiserTests {
         IoClassSerialiser serialiser = new IoClassSerialiser(buffer, BinarySerialiser.class);
 
         TestClass sourceClass = new TestClass();
+        sourceClass.integerBoxed = Integer.valueOf(1337);
+
         sourceClass.integerList = new ArrayList<>();
         sourceClass.integerList.add(1);
         sourceClass.integerList.add(2);
@@ -182,10 +184,17 @@ class IoClassSerialiserTests {
         buffer.reset(); // '0' writing at start of buffer
         serialiser.serialiseObject(sourceClass);
         buffer.reset(); // reset to read position (==0)
+
+        final WireDataFieldDescription root = serialiser.getMatchedIoSerialiser().parseIoStream(true);
+        root.printFieldStructure();
+        assertEquals(sourceClass.integerBoxed, ((WireDataFieldDescription) root.findChildField("de.gsi.serializer.IoClassSerialiserTests$TestClass").findChildField("integerBoxed")).data());
+        buffer.reset(); // reset to read position (==0)
         serialiser.deserialiseObject(destinationClass);
 
         buffer.reset(); // reset to read position (==0)
         serialiser.deserialiseObject(destinationClass);
+
+        assertEquals(sourceClass.integerBoxed, destinationClass.integerBoxed);
 
         assertEquals(sourceClass.integerList, destinationClass.integerList);
         assertEquals(1, destinationClass.integerList.get(0));
@@ -300,6 +309,8 @@ class IoClassSerialiserTests {
      * small test class to test (de-)serialisation of wrapped and/or compound object types
      */
     static class TestClass {
+        public Integer integerBoxed;
+
         public List<Integer> integerList;
         public List<String> stringList;
         public List<Integer> nullIntegerList;

--- a/microservice/src/test/java/de/gsi/serializer/spi/BinarySerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/spi/BinarySerialiserTests.java
@@ -420,26 +420,26 @@ class BinarySerialiserTests {
         // add Collection - List<E>
         final List<Integer> list = Arrays.asList(1, 2, 3);
         positionBefore.add(buffer.position());
-        ioSerialiser.put("collection", list, Integer.class, null);
+        ioSerialiser.put("collection", list, Integer.class);
         positionAfter.add(buffer.position());
 
         // add Collection - Set<E>
         final Set<Integer> set = Set.of(1, 2, 3);
         positionBefore.add(buffer.position());
-        ioSerialiser.put("set", set, Integer.class, null);
+        ioSerialiser.put("set", set, Integer.class);
         positionAfter.add(buffer.position());
 
         // add Collection - Queue<E>
         final Queue<Integer> queue = new LinkedList<>(Arrays.asList(1, 2, 3));
         positionBefore.add(buffer.position());
-        ioSerialiser.put("queue", queue, Integer.class, null);
+        ioSerialiser.put("queue", queue, Integer.class);
         positionAfter.add(buffer.position());
 
         // add Map
         final Map<Integer, String> map = new HashMap<>();
         list.forEach(item -> map.put(item, "Item#" + item.toString()));
         positionBefore.add(buffer.position());
-        ioSerialiser.put("map", map, Integer.class, String.class, null);
+        ioSerialiser.put("map", map, Integer.class, String.class);
         positionAfter.add(buffer.position());
 
         // add Enum
@@ -493,13 +493,13 @@ class BinarySerialiserTests {
         assertEquals(3, ioSerialiser.getBuffer().getInt(), "array size");
         buffer.position(header.getDataStartPosition());
         final int readPosition = buffer.position();
-        Collection<Integer> retrievedCollection = ioSerialiser.getCollection(null, null);
+        Collection<Integer> retrievedCollection = ioSerialiser.getCollection(null);
         assertNotNull(retrievedCollection, "retrieved collection not null");
         assertEquals(list, retrievedCollection);
         assertEquals(buffer.position(), header.getDataStartPosition() + header.getDataSize(), "buffer position data end");
         // check for specific List interface
         buffer.position(readPosition);
-        List<Integer> retrievedList = ioSerialiser.getList(null, null);
+        List<Integer> retrievedList = ioSerialiser.getList(null);
         assertNotNull(retrievedList, "retrieved collection List not null");
         assertEquals(list, retrievedList);
         assertEquals(positionAfter.removeFirst(), buffer.position());
@@ -517,7 +517,7 @@ class BinarySerialiserTests {
         assertEquals(ARRAY_DIM_1D, ioSerialiser.getBuffer().getInt(), "dimension");
         assertEquals(3, ioSerialiser.getBuffer().getInt(), "array size");
         buffer.position(header.getDataStartPosition());
-        Collection<Integer> retrievedSet = ioSerialiser.getSet(null, null);
+        Collection<Integer> retrievedSet = ioSerialiser.getSet(null);
         assertNotNull(retrievedSet, "retrieved set not null");
         assertEquals(set, retrievedSet);
         assertEquals(positionAfter.removeFirst(), buffer.position());
@@ -535,7 +535,7 @@ class BinarySerialiserTests {
         assertEquals(ARRAY_DIM_1D, ioSerialiser.getBuffer().getInt(), "dimension");
         assertEquals(3, ioSerialiser.getBuffer().getInt(), "array size");
         buffer.position(header.getDataStartPosition());
-        Queue<Integer> retrievedQueue = ioSerialiser.getQueue(null, null);
+        Queue<Integer> retrievedQueue = ioSerialiser.getQueue(null);
         assertNotNull(retrievedQueue, "retrieved set not null");
         // assertEquals(queue, retrievedQueue); // N.B. no direct comparison possible -> only partial Queue interface overlapp
         while (!queue.isEmpty() && !retrievedQueue.isEmpty()) {
@@ -558,7 +558,7 @@ class BinarySerialiserTests {
         assertEquals(ARRAY_DIM_1D, ioSerialiser.getBuffer().getInt(), "dimension");
         assertEquals(3, ioSerialiser.getBuffer().getInt(), "array size");
         buffer.position(header.getDataStartPosition());
-        Map<Integer, String> retrievedMap = ioSerialiser.getMap(null, null);
+        Map<Integer, String> retrievedMap = ioSerialiser.getMap(null);
         assertNotNull(retrievedMap, "retrieved set not null");
         assertEquals(map, retrievedMap); // N.B. no direct comparison possible -> only partial Queue interface overlapp
         assertEquals(positionAfter.removeFirst(), buffer.position());
@@ -644,20 +644,20 @@ class BinarySerialiserTests {
         ioSerialiser.put("string[]", new String[] { "string" }, 1);
 
         final Collection<Integer> collection = Arrays.asList(1, 2, 3);
-        ioSerialiser.put("collection", collection, Integer.class, null); // add Collection - List<E>
+        ioSerialiser.put("collection", collection, Integer.class); // add Collection - List<E>
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
-        ioSerialiser.put("list", list, Integer.class, null); // add Collection - List<E>
+        ioSerialiser.put("list", list, Integer.class); // add Collection - List<E>
 
         final Set<Integer> set = Set.of(1, 2, 3);
-        ioSerialiser.put("set", set, Integer.class, null); // add Collection - Set<E>
+        ioSerialiser.put("set", set, Integer.class); // add Collection - Set<E>
 
         final Queue<Integer> queue = new LinkedList<>(Arrays.asList(1, 2, 3));
-        ioSerialiser.put("queue", queue, Integer.class, null); // add Collection - Queue<E>
+        ioSerialiser.put("queue", queue, Integer.class); // add Collection - Queue<E>
 
         final Map<Integer, String> map = new HashMap<>();
         list.forEach(item -> map.put(item, "Item#" + item.toString()));
-        ioSerialiser.put("map", map, Integer.class, String.class, null); // add Map
+        ioSerialiser.put("map", map, Integer.class, String.class); // add Map
 
         ioSerialiser.put("enum", DataType.ENUM); // add Enum
 


### PR DESCRIPTION
Fixes two classes of issues in the Serialiser discovered by coverity:
- The IoSerialiser needs access to the registered FieldSerialisers
- The return functions are never used for primitve / boxed / array types and did not have null checks. fixed by throwing errors in the return functions, alternative: add null checks, should have no performance impact, because the code is actually never called. I prefer the exceptions, because it reduces the amount of code we have to think about, but if there are cornercases where the return functions are needed we should use the null checks.