### PR TITLE
fixIssue259

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -360,12 +360,14 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             // in order to find the maximum (positive or negative)
             dataMaxValue = -Double.MAX_VALUE;
             getAutoRange().clear();
-        }
 
-        for (final Number dataValue : data) {
-            dataMinValue = Math.min(dataMinValue, dataValue.doubleValue());
-            dataMaxValue = Math.max(dataMaxValue, dataValue.doubleValue());
-            getAutoRange().add(dataValue.doubleValue());
+            for (final Number dataValue : data) {
+                dataMinValue = Math.min(dataMinValue, dataValue.doubleValue());
+                dataMaxValue = Math.max(dataMaxValue, dataValue.doubleValue());
+            }
+
+            getAutoRange().add(dataMinValue);
+            getAutoRange().add(dataMaxValue);
         }
 
         final boolean oldState = autoNotification().getAndSet(false);

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LinearAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LinearAxis.java
@@ -29,9 +29,9 @@ public class LinearAxis extends AbstractAxis {
     private static final TickUnitSupplier DEFAULT_TICK_UNIT_SUPPLIER = new DefaultTickUnitSupplier();
 
     private static final int DEFAULT_RANGE_LENGTH = 2;
-    private final Cache cache = new Cache();
+    private final transient Cache cache = new Cache();
 
-    private boolean isUpdating = true;
+    private boolean isUpdating;
 
     private final BooleanProperty forceZeroInRange = new SimpleBooleanProperty(this, "forceZeroInRange", false) {
         @Override
@@ -84,12 +84,12 @@ public class LinearAxis extends AbstractAxis {
     public LinearAxis(final String axisLabel, final double lowerBound, final double upperBound, final double tickUnit) {
         super(lowerBound, upperBound);
         this.setName(axisLabel);
-        if (lowerBound >= upperBound || lowerBound == 0 && upperBound == 0) {
+        if (lowerBound >= upperBound || lowerBound == 0 || (lowerBound == 0 && upperBound == 0)) {
             setAutoRanging(true);
         }
         setTickUnit(tickUnit);
         setMinorTickCount(LinearAxis.DEFAULT_TICK_COUNT);
-        super.currentLowerBound.addListener((evt, o, n) -> cache.updateCachedAxisVariables());
+        super.minProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         super.maxProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         super.scaleProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         widthProperty().addListener((ch, o, n) -> cache.axisWidth = getWidth());
@@ -492,12 +492,6 @@ public class LinearAxis extends AbstractAxis {
         return new AxisRange(lower, upper, axisLength, scale, getTickUnit());
     }
 
-    @Override
-    protected void setRange(final AxisRange range, final boolean animate) {
-        super.setRange(range, animate);
-        setTickUnit(range.getTickUnit());
-    }
-
     // -------------- STYLESHEET HANDLING
     // ------------------------------------------------------------------------------
 
@@ -541,7 +535,7 @@ public class LinearAxis extends AbstractAxis {
         protected double axisHeight;
 
         private void updateCachedAxisVariables() {
-            localCurrentLowerBound = currentLowerBound.get();
+            localCurrentLowerBound = LinearAxis.super.getMin();
             localCurrentUpperBound = LinearAxis.super.getMax();
             localScale = scaleProperty().get();
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LogarithmicAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LogarithmicAxis.java
@@ -34,9 +34,9 @@ public class LogarithmicAxis extends AbstractAxis {
     private static final int DEFAULT_TICK_COUNT = 9;
     private static final TickUnitSupplier DEFAULT_TICK_UNIT_SUPPLIER = new DefaultTickUnitSupplier();
 
-    private final Cache cache = new Cache();
+    private final transient Cache cache = new Cache();
 
-    private boolean isUpdating = true;
+    private boolean isUpdating;
 
     private final StyleableDoubleProperty tickUnit = CSS.createDoubleProperty(this, "tickUnit", 5d, true, null, () -> {
         if (!isAutoRanging()) {
@@ -92,12 +92,12 @@ public class LogarithmicAxis extends AbstractAxis {
             final double tickUnit) {
         super(lowerBound, upperBound);
         this.setName(axisLabel);
-        if (lowerBound >= upperBound || lowerBound == 0 && upperBound == 0) {
+        if (lowerBound >= upperBound || lowerBound == 0 || (lowerBound == 0 && upperBound == 0)) {
             setAutoRanging(true);
         }
         setTickUnit(tickUnit);
         setMinorTickCount(LogarithmicAxis.DEFAULT_TICK_COUNT);
-        super.currentLowerBound.addListener((evt, o, n) -> cache.updateCachedAxisVariables());
+        super.minProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         super.maxProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         super.scaleProperty().addListener((evt, o, n) -> cache.updateCachedAxisVariables());
         widthProperty().addListener((ch, o, n) -> cache.axisWidth = getWidth());
@@ -387,12 +387,6 @@ public class LogarithmicAxis extends AbstractAxis {
         return new AxisRange(minValue, maxValue, axisLength, newScale, tickUnit.get());
     }
 
-    @Override
-    protected void setRange(final AxisRange range, final boolean animate) {
-        super.setRange(range, animate);
-        setTickUnit(range.getTickUnit());
-    }
-
     public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
         return CSS.getCssMetaData();
     }
@@ -411,7 +405,7 @@ public class LogarithmicAxis extends AbstractAxis {
         protected double logBase;
 
         private void updateCachedAxisVariables() {
-            localCurrentLowerBound = currentLowerBound.get();
+            localCurrentLowerBound = LogarithmicAxis.super.getMin();
             localCurrentUpperBound = LogarithmicAxis.super.getMax();
             upperBoundLog = log(getMax());
             lowerBoundLog = log(getMin());

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
@@ -68,13 +68,13 @@ public final class NumericAxis extends AbstractAxis {
     public NumericAxis() {
         super();
         super.minProperty().addListener((evt, o, n) -> {
-            localCurrentLowerBound = getMin();
+            localCurrentLowerBound = n.doubleValue();
             final double zero = super.getDisplayPosition(0);
             localOffset = zero + localCurrentLowerBound * scaleProperty().get();
         });
 
         super.scaleProperty().addListener((evt, o, n) -> {
-            localScale = scaleProperty().get();
+            localScale = n.doubleValue();
             final double zero = super.getDisplayPosition(0);
             localOffset = zero + getMin() * localScale;
         });
@@ -106,8 +106,17 @@ public final class NumericAxis extends AbstractAxis {
         this.setName(axisLabel);
         setTickUnit(tickUnit);
 
-        super.minProperty().addListener((evt, o, n) -> localCurrentLowerBound = getMin());
-        super.scaleProperty().addListener((evt, o, n) -> localScale = scaleProperty().get());
+        super.minProperty().addListener((evt, o, n) -> {
+            localCurrentLowerBound = n.doubleValue();
+            final double zero = super.getDisplayPosition(0);
+            localOffset = zero + localCurrentLowerBound * scaleProperty().get();
+        });
+
+        super.scaleProperty().addListener((evt, o, n) -> {
+            localScale = n.doubleValue();
+            final double zero = super.getDisplayPosition(0);
+            localOffset = zero + getMin() * localScale;
+        });
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
@@ -67,8 +67,8 @@ public final class NumericAxis extends AbstractAxis {
      */
     public NumericAxis() {
         super();
-        super.currentLowerBound.addListener((evt, o, n) -> {
-            localCurrentLowerBound = currentLowerBound.get();
+        super.minProperty().addListener((evt, o, n) -> {
+            localCurrentLowerBound = getMin();
             final double zero = super.getDisplayPosition(0);
             localOffset = zero + localCurrentLowerBound * scaleProperty().get();
         });
@@ -76,7 +76,7 @@ public final class NumericAxis extends AbstractAxis {
         super.scaleProperty().addListener((evt, o, n) -> {
             localScale = scaleProperty().get();
             final double zero = super.getDisplayPosition(0);
-            localOffset = zero + currentLowerBound.get() * localScale;
+            localOffset = zero + getMin() * localScale;
         });
     }
 
@@ -106,7 +106,7 @@ public final class NumericAxis extends AbstractAxis {
         this.setName(axisLabel);
         setTickUnit(tickUnit);
 
-        super.currentLowerBound.addListener((evt, o, n) -> localCurrentLowerBound = currentLowerBound.get());
+        super.minProperty().addListener((evt, o, n) -> localCurrentLowerBound = getMin());
         super.scaleProperty().addListener((evt, o, n) -> localScale = scaleProperty().get());
     }
 
@@ -515,12 +515,6 @@ public final class NumericAxis extends AbstractAxis {
     // -------------- STYLESHEET HANDLING
     // ------------------------------------------------------------------------------
 
-    @Override
-    protected void setRange(final AxisRange range, final boolean animate) {
-        super.setRange(range, animate);
-        setTickUnit(range.getTickUnit());
-    }
-
     public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
         return CSS.getCssMetaData();
     }
@@ -538,27 +532,6 @@ public final class NumericAxis extends AbstractAxis {
         }
         return paddedBound;
     }
-
-    // private static class NumericAxisRange extends Range {
-    // private final double tickUnit;
-    //
-    // NumericAxisRange(final Range range, final double tickUnit) {
-    // this(range.getLowerBound(), range.getUpperBound(), range.getScale(),
-    // range.getTickFormat(), tickUnit);
-    // }
-    //
-    // NumericAxisRange(final double lowerBound, final double upperBound, final
-    // double scale, final String tickFormat,
-    // final double tickUnit) {
-    // super(lowerBound, upperBound, scale, tickFormat, tickUnit, -1);
-    // this.tickUnit = tickUnit;
-    // }
-    //
-    // @Override
-    // public double getTickUnit() {
-    // return tickUnit;
-    // }
-    // }
 
     private static double computeFistMajorTick(final double lowerBound, final double tickUnit) {
         return Math.ceil(lowerBound / tickUnit) * tickUnit;

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
@@ -44,17 +44,17 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
     public static final SortedSet<Number> DEFAULT_MULTIPLIERS1 = Collections.unmodifiableSortedSet(new TreeSet<>(Arrays.asList(1.0, 2.0, 5.0)));
     public static final SortedSet<Number> DEFAULT_MULTIPLIERS2 = Collections
                                                                          .unmodifiableSortedSet(new TreeSet<>(Arrays.asList(1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5)));
-    private final DefaultAxisTransform axisTransform = new DefaultAxisTransform(this);
-    private TickUnitSupplier tickUnitSupplier = new DefaultTickUnitSupplier(DEFAULT_MULTIPLIERS1);
-    private final DataRange clampedRange = new DataRange();
+    private final transient DefaultAxisTransform axisTransform = new DefaultAxisTransform(this);
+    private transient TickUnitSupplier tickUnitSupplier = new DefaultTickUnitSupplier(DEFAULT_MULTIPLIERS1);
+    private final transient DataRange clampedRange = new DataRange();
 
-    private final DataRange minRange = new DataRange();
-    private final DataRange maxRange = new DataRange();
+    private final transient DataRange minRange = new DataRange();
+    private final transient DataRange maxRange = new DataRange();
     private final StyleableDoubleProperty axisZeroPosition = CSS.createDoubleProperty(this, "axisZeroPosition", 0.5, true, (oldVal, newVal) -> Math.max(0.0, Math.min(newVal, 1.0)), this::requestAxisLayout);
     private final StyleableDoubleProperty axisZeroValue = CSS.createDoubleProperty(this, "axisZeroValue", 0.0, true, null, this::requestAxisLayout);
-    private final Cache cache = new Cache();
+    private final transient Cache cache = new Cache();
     private double offset;
-    protected boolean isUpdating = true;
+    protected boolean isUpdating;
 
     /**
      * Creates an {@link #autoRangingProperty() auto-ranging} Axis.
@@ -323,6 +323,9 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     protected void updateCachedVariables() {
+        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+            return;
+        }
         cache.updateCachedAxisVariables();
     }
 
@@ -358,7 +361,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
         private void updateCachedAxisVariables() {
             axisWidth = getWidth();
             axisHeight = getHeight();
-            localCurrentLowerBound = currentLowerBound.get();
+            localCurrentLowerBound = OscilloscopeAxis.super.getMin();
             localCurrentUpperBound = OscilloscopeAxis.super.getMax();
 
             upperBoundLog = axisTransform.forward(getMax());

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameter.java
@@ -1,5 +1,7 @@
 package de.gsi.chart.renderer.spi;
 
+import java.util.Objects;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
@@ -53,7 +55,7 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
     private final DoubleProperty intensityFading = new SimpleDoubleProperty(this, "intensityFading",
             AbstractErrorDataSetRendererParameter.DEFAULT_HISTORY_INTENSITY_FADING);
     private final BooleanProperty drawBubbles = new SimpleBooleanProperty(this, "drawBubbles", false);
-    private final BooleanProperty allowNaNs = new SimpleBooleanProperty(this, "allowNans", false);
+    private final BooleanProperty allowNaNs = new SimpleBooleanProperty(this, "allowNaNs", false);
 
     /**
      * 
@@ -424,11 +426,7 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
      * @return itself (fluent design)
      */
     public R setRendererDataReducer(final RendererDataReducer algorithm) {
-        if (algorithm == null) {
-            rendererDataReducerProperty().set(new DefaultDataReducer());
-        } else {
-            rendererDataReducerProperty().set(algorithm);
-        }
+        rendererDataReducerProperty().set(Objects.requireNonNullElseGet(algorithm, DefaultDataReducer::new));
         return getThis();
     }
 

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/OscilloscopeAxisTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/OscilloscopeAxisTests.java
@@ -52,18 +52,18 @@ public class OscilloscopeAxisTests {
 
     @Test
     public void computeRangeTests() {
-        final OscilloscopeAxis axis = new OscilloscopeAxis("axis title", -1.0, 1.0, 0.1);
+        OscilloscopeAxis axis = new OscilloscopeAxis("axis title", -1.0, 1.0, 0.1);
 
         final AxisRange axisRange1 = axis.computeRange(Double.NaN, Double.NaN, 1000, 0.0);
         assertEquals(-1.0, axisRange1.getMin());
         assertEquals(+1.0, axisRange1.getMax());
 
-        axis.add(2.0);
+        axis = new OscilloscopeAxis("axis title", -1.0, 2.0, 0.1);
         final AxisRange axisRange2 = axis.computeRange(Double.NaN, Double.NaN, 1000, 0.0);
         assertEquals(-2.5, axisRange2.getMin());
         assertEquals(+2.5, axisRange2.getMax());
 
-        axis.add(-2.0);
+        axis = new OscilloscopeAxis("axis title", -2.0, 2.0, 0.1);
         final AxisRange axisRange3 = axis.computeRange(Double.NaN, Double.NaN, 1000, 0.0);
         assertEquals(-2.5, axisRange3.getMin());
         assertEquals(+2.5, axisRange3.getMax());
@@ -116,7 +116,7 @@ public class OscilloscopeAxisTests {
         assertEquals(+2.0, axis.getClampedRange().getMax());
 
         axis.getMinRange().clear();
-        axis.recomputeClamedRange();
+        axis.recomputeClampedRange();
         // should be the original min/max range again
         assertEquals(0.0, axis.getClampedRange().getMin());
         assertEquals(1.0, axis.getClampedRange().getMax());

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/Histogram.java
@@ -111,24 +111,24 @@ public class Histogram extends AbstractHistogram implements Histogram1D, DataSet
     }
 
     @Override
-    public int findBin(final int dimIndex, final double x) {
+    public int findBin(final int dimIndex, final double val) {
         if (getAxisDescription(dimIndex).getLength() == 0.0) {
             return 0;
         }
-        if (!getAxisDescription(dimIndex).contains(x)) {
-            if (x < getAxisDescription(dimIndex).getMin()) {
+        if (!getAxisDescription(dimIndex).contains(val)) {
+            if (val < getAxisDescription(dimIndex).getMin()) {
                 return 0; // underflow bin
             }
             return getDataCount() - 1; // overflow bin
         }
         if (isEquiDistant()) {
-            final double diff = x - getAxisDescription(dimIndex).getMin();
+            final double diff = val - getAxisDescription(dimIndex).getMin();
             final double len = getAxisDescription(dimIndex).getLength();
             final int count = getDataCount();
             final double delta = len / count;
             return (int) Math.round(diff / delta);
         }
-        return findNextLargerIndex(axisBins[0], x);
+        return findNextLargerIndex(axisBins[0], val);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class Histogram extends AbstractHistogram implements Histogram1D, DataSet
 
     @Override
     public List<String> getErrorList() {
-        return Collections.<String>emptyList();
+        return Collections.emptyList();
     }
 
     @Override
@@ -156,7 +156,7 @@ public class Histogram extends AbstractHistogram implements Histogram1D, DataSet
 
     @Override
     public List<String> getInfoList() {
-        return Collections.<String>emptyList();
+        return Collections.emptyList();
     }
 
     //    @Override


### PR DESCRIPTION
**fixes issue #259 (re-draw via Renderer-DataSets-list change)**

N.B. optional animation of currentLowerBound caused caching issues -> removed animation functionality, recompute scale whenever the min, max, or axisLength changes, and moved caching of offset (default getDisplayPosition(..) impl) to AbstractAxisParameter.AbstractAxisParameter

Since most user care for performance rather than animation, the animation feature should be moved to another generic Axis implementation that wraps the original axis and that translates the actual min/max to a time-filtered min/max that is forwarded to the delegate Axis.

**added default XYChart() constructor**

N.B. this constructor is needed since JavaFX seems to instantiate fxml using reflection to find the corresponding constructor.

**fixed getDatasetsCopy to use new DataSet copy constructor**

**fixed indexing error and added missing recomputeLimits in AbstractHistogram**