### PR TITLE
Fix error data set renderer for inverted x axis

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -160,8 +160,9 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         final Axis yAxis = yAxisTemp;
         final long start = ProcessingProfiler.getTimeStamp();
         final double xAxisWidth = xAxis.getWidth();
-        final double xMin = xAxis.getValueForDisplay(0);
-        final double xMax = xAxis.getValueForDisplay(xAxisWidth);
+        final boolean xAxisInverted = xAxis.isInvertedAxis();
+        final double xMin = xAxis.getValueForDisplay(xAxisInverted ? xAxisWidth : 0.0);
+        final double xMax = xAxis.getValueForDisplay(xAxisInverted ? 0.0 : xAxisWidth);
 
         if (ProcessingProfiler.getDebugState()) {
             ProcessingProfiler.getTimeDiff(start, "init");
@@ -200,11 +201,6 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
                 } else {
                     indexMin = 0;
                     indexMax = dataSet.getDataCount();
-                }
-                if (xAxis.isInvertedAxis()) {
-                    final int temp = indexMin;
-                    indexMin = indexMax - 1;
-                    indexMax = temp + 1;
                 }
 
                 if (indexMax - indexMin <= 0) {

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
@@ -354,6 +354,12 @@ public class ErrorDataSetRendererStylingSample extends Application {
         reductionDashSize.valueProperty().addListener((ch, old, value) -> chart.requestLayout());
         pane.addToParameterPane("   Red. Min Distance: ", reductionDashSize);
 
+        pane.addToParameterPane(" ", null);
+        final CheckBox assumeSorted = new CheckBox();
+        assumeSorted.selectedProperty().bindBidirectional(errorRenderer.assumeSortedDataProperty());
+        assumeSorted.selectedProperty().addListener((ch, old, selected) -> chart.requestLayout());
+        pane.addToParameterPane("Assume sorted data: ", assumeSorted);
+
         return pane;
     }
 


### PR DESCRIPTION
For inverted x-Axis, the Renderer first checked for the points to
render and then swapped them and tried to account for the fact that the
points might not be exactly on the axis bounds by adding a fixed extra
point to each side, which should have been two, because the code which
determines which points to include for normal axes also adds one in the
other direction.
This commit replaces this by the cleaner approach of obtaining xMax at
the left bound of an inverted axis and vice versa.

Also adds a a switch for assumeSorted to the ErrorDataSetStylingSample.

fixes #265 