### PR TITLE
Fix bug in error point reduction

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/datareduction/DefaultDataReducer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/datareduction/DefaultDataReducer.java
@@ -2,11 +2,12 @@ package de.gsi.chart.renderer.datareduction;
 
 import java.security.InvalidParameterException;
 
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+
 import de.gsi.chart.renderer.RendererDataReducer;
 import de.gsi.dataset.utils.AssertUtils;
 import de.gsi.dataset.utils.ProcessingProfiler;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 
 /**
  * Default data reduction algorithm implementation for the ErrorDataSet Renderer <br>
@@ -17,7 +18,6 @@ import javafx.beans.property.SimpleIntegerProperty;
  * @author rstein
  */
 public class DefaultDataReducer implements RendererDataReducer {
-
     protected IntegerProperty minPointPixelDistance = new SimpleIntegerProperty(this, "minPixelDistance", 6) {
         @Override
         public void set(final int value) {
@@ -218,8 +218,8 @@ public class DefaultDataReducer implements RendererDataReducer {
         yValues[count] = yValues[indexMax - 1];
         xPointErrorsNeg[count] = xPointErrorsPos[indexMax - 1];
         xPointErrorsPos[count] = xPointErrorsNeg[indexMax - 1];
-        yPointErrorsNeg[count] = yPointErrorsPos[indexMax - 1];
-        yPointErrorsPos[count] = yPointErrorsNeg[indexMax - 1];
+        yPointErrorsNeg[count] = yPointErrorsNeg[indexMax - 1];
+        yPointErrorsPos[count] = yPointErrorsPos[indexMax - 1];
         pointSelected[count] = pointSelected[indexMax - 1];
         styles[count] = styles[indexMax - 1];
         count++;
@@ -480,5 +480,4 @@ public class DefaultDataReducer implements RendererDataReducer {
     public final void setMinPointPixelDistance(final int minPixelDistance) {
         minPointPixelDistanceProperty().setValue(minPixelDistance);
     }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -1,12 +1,7 @@
 package de.gsi.chart.renderer.spi;
 
 import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import javafx.collections.ObservableList;
 import javafx.geometry.Orientation;
@@ -492,12 +487,6 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
             yValuesSurface[i] = localCachedPoints.errorYNeg[i];
             xValuesSurface[xend - i] = localCachedPoints.xValues[i];
             yValuesSurface[xend - i] = localCachedPoints.errorYPos[i];
-        }
-        // swap y coordinates at mid-point
-        if (nDataCount > 4) {
-            final double yTmp = yValuesSurface[nDataCount - 1];
-            yValuesSurface[nDataCount - 1] = yValuesSurface[xend - nDataCount + 1];
-            yValuesSurface[xend - nDataCount + 1] = yTmp;
         }
 
         gc.setFillRule(FillRule.EVEN_ODD);

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/ErrorDataSetRendererStylingSample.java
@@ -360,6 +360,12 @@ public class ErrorDataSetRendererStylingSample extends Application {
         assumeSorted.selectedProperty().addListener((ch, old, selected) -> chart.requestLayout());
         pane.addToParameterPane("Assume sorted data: ", assumeSorted);
 
+        pane.addToParameterPane(" ", null);
+        final CheckBox cacheParallel = new CheckBox();
+        cacheParallel.selectedProperty().bindBidirectional(errorRenderer.parallelImplementationProperty());
+        cacheParallel.selectedProperty().addListener((ch, old, selected) -> chart.requestLayout());
+        pane.addToParameterPane("   Point cache parallel: ", cacheParallel);
+
         return pane;
     }
 


### PR DESCRIPTION
When reducing the points, the reducer would for some reason swap the
positive and negative error for the last point. When no actual reduction
is taking place, this leads to the values actually having the same value
which would give strange results in the error bars/surfaces.

![20200929_datareduction_errors](https://user-images.githubusercontent.com/1202371/94802520-2439dd00-03e8-11eb-840b-7cfc2c755f9c.gif)

This commit removes the swapping of the errors of the last point.

The error surface renderer would also swap these points again before
rendering, so this is also removed with this commit.

To ease testing, an option to enable/disable parallel point caching in
the renderer was added to the ErrorDataSetRendererStylingSample.