### PR TITLE
Exclude tests from coverage

### DIFF
--- a/chartfx-report/pom.xml
+++ b/chartfx-report/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>chartfx-acc</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>de.gsi</groupId>
+            <artifactId>microservice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "*/src/test/**/*"
+  - "chartfx-samples/**/*"


### PR DESCRIPTION
This PR excludes tests, benchmarks and samples from the coverage computation.

Additionally adds the microservice tot the reports submodule where it was missing.