### PR TITLE
fixed setAutoRangePadding() regression bug

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
@@ -739,14 +739,6 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
 
         // update axes range first because this may change the overall layout
         updateAxisRange();
-        for (final Axis axis : getAxes()) {
-            final boolean oldState = axis.autoNotification().getAndSet(false);
-            try {
-                axis.requestAxisLayout();
-            } finally {
-                axis.autoNotification().set(oldState);
-            }
-        }
         ProcessingProfiler.getTimeDiff(start, "updateAxisRange()");
 
         // update chart parent according to possible size changes

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -378,7 +378,17 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     }
 
     public void recomputeTickMarks() {
-        recomputeTickMarks(getRange());
+        final double axisLength = getSide().isVertical() ? getHeight() : getWidth(); // [pixel]
+        AxisRange newAxisRange = getRange();
+        final double mTickUnit = computePreferredTickUnit(axisLength);
+        if (getRange().getMin() != getMin() || getRange().getMax() != getMax()) {
+            set(getRange().getMin(), getRange().getMax());
+        }
+        newAxisRange.tickUnit = mTickUnit;
+        setTickUnit(mTickUnit);
+        newAxisRange.tickUnit = getTickUnit();
+        updateAxisLabelAndUnit();
+        recomputeTickMarks(newAxisRange);
     }
 
     /**
@@ -580,8 +590,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         final double axisLength = side.isVertical() ? height : width; // [pixel]
 
         final List<Double> oldTickValues = majorTickMark ? getTickMarkValues() : getMinorTickMarkValues();
-        final List<Double> newTickValues = majorTickMark ? calculateMajorTickValues(axisLength, range)
-                                                         : calculateMinorTickValues();
+        final List<Double> newTickValues = majorTickMark ? calculateMajorTickValues(axisLength, range) : calculateMinorTickValues();
 
         if (!oldTickValues.isEmpty() && !oldTickMarks.isEmpty() && newTickValues.equals(oldTickValues)) {
             // do not need to recompute TickMarks just reposition them
@@ -1137,17 +1146,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         if (lengthDiffers || rangeDiffers || tickUnitDiffers) {
             recomputedTicks = true;
 
-            // get range
-            AxisRange newAxisRange = getRange();
-            final double mTickUnit = computePreferredTickUnit(axisLength);
-            if (getRange().getMin() != getMin() || getRange().getMax() != getMax()) {
-                set(getRange().getMin(), getRange().getMax());
-            }
-            newAxisRange.tickUnit = mTickUnit;
-            setTickUnit(mTickUnit);
-            newAxisRange.tickUnit = this.getTickUnit();
-            updateAxisLabelAndUnit();
-            recomputeTickMarks(newAxisRange);
+            recomputeTickMarks();
 
             // mark all done
             oldAxisLength = axisLength;

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
@@ -3,6 +3,7 @@ package de.gsi.chart.axes.spi;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.beans.property.*;
@@ -62,8 +63,8 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     private final transient Path minorTickStyle = new Path();
     private final transient AxisLabel axisLabel = new AxisLabel();
     /**
-     * This is the minimum/maximum current data value and it is used while auto ranging. Package private solely for test
-     * purposes TODO: replace concept with 'actual range', 'user-defined range', 'auto-range' (+min, max range limit for
+     * This is the minimum/maximum current data value and it is used while auto ranging. Package private solely for test purposes
+     *
      * auto).... actual is used to compute tick marks and defined by either user or auto (ie. auto axis is always being
      * computed), ALSO add maybe a zoom range (ie. limited by user-set/auto-range range)
      */
@@ -166,13 +167,7 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     private final transient StyleableBooleanProperty minorTickVisible = CSS.createBooleanProperty(this, "minorTickVisible", true, this::requestAxisLayout);
 
     /** The scale factor from data units to visual units */
-    private final transient ReadOnlyDoubleWrapper scale = new ReadOnlyDoubleWrapper(this, "scale", 1) {
-        @Override
-        protected void invalidated() {
-            invalidate();
-            invokeListener(new AxisChangeEvent(AbstractAxisParameter.this));
-        }
-    };
+    private final transient ReadOnlyDoubleWrapper scale = new ReadOnlyDoubleWrapper(this, "scale", 1);
 
     /**
      * The value for the upper bound of this axis, ie max value. This is automatically set if auto ranging is on.
@@ -319,7 +314,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
         }
 
         setScale(newScale == 0 ? -1.0 : newScale);
-        updateCachedVariables();
     };
 
     /**
@@ -351,15 +345,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
             invokeListener(new AxisChangeEvent(this));
         });
 
-        final ChangeListener<Number> autoRangeChangeListener = (ch, oldValue, newValue) -> {
-            if (isAutoUnitScaling()) {
-                updateAxisLabelAndUnit();
-            }
-        };
-
-        maxProperty().addListener(autoRangeChangeListener);
-        minProperty().addListener(autoRangeChangeListener);
-
         axisLabel.textAlignmentProperty().bindBidirectional(axisLabelTextAlignmentProperty()); // NOPMD
 
         // bind limits to user-specified axis range
@@ -381,9 +366,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
         majorTickStyle.applyCss();
         minorTickStyle.applyCss();
         axisLabel.applyCss();
-
-        widthProperty().addListener((ch, o, n) -> invalidate());
-        heightProperty().addListener((ch, o, n) -> invalidate());
 
         minProperty().addListener(scaleChangeListener);
         maxProperty().addListener(scaleChangeListener);
@@ -1302,6 +1284,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
     }
 
     protected static boolean equalString(final String str1, final String str2) {
-        return (str1 == null ? str2 == null : str1.equals(str2));
+        return Objects.equals(str1, str2);
     }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LinearAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/LinearAxis.java
@@ -482,16 +482,6 @@ public class LinearAxis extends AbstractAxis {
         return computeRangeImpl(minValue, maxValue, axisLength, labelSize);
     }
 
-    @Override
-    protected AxisRange getAxisRange() {
-        final AxisRange localRange = super.getAxisRange();
-        final double lower = localRange.getLowerBound();
-        final double upper = localRange.getUpperBound();
-        final double axisLength = localRange.getAxisLength();
-        final double scale = localRange.getScale();
-        return new AxisRange(lower, upper, axisLength, scale, getTickUnit());
-    }
-
     // -------------- STYLESHEET HANDLING
     // ------------------------------------------------------------------------------
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/NumericAxis.java
@@ -511,16 +511,6 @@ public final class NumericAxis extends AbstractAxis {
         return computeRangeImpl(minValue, maxValue, axisLength, labelSize);
     }
 
-    @Override
-    protected AxisRange getAxisRange() {
-        final AxisRange localRange = super.getAxisRange();
-        final double lower = localRange.getLowerBound();
-        final double upper = localRange.getUpperBound();
-        final double axisLength = localRange.getAxisLength();
-        final double scale = localRange.getScale();
-        return new AxisRange(lower, upper, axisLength, scale, getTickUnit());
-    }
-
     // -------------- STYLESHEET HANDLING
     // ------------------------------------------------------------------------------
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
@@ -444,4 +444,8 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
             offset = isVerticalAxis ? getHeight() : getWidth();
         }
     }
+
+    protected AxisRange autoRange(final double minValue, final double maxValue, final double length, final double labelSize) {
+        return computeRange(minValue, maxValue, length, labelSize);
+    }
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/OscilloscopeAxis.java
@@ -245,7 +245,8 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
             }
             return tickValues;
         }
-        for (double major = firstTick; major <= axisRange.getMax(); major += axisRange.getTickUnit()) {
+        final int maxTickCount = getMaxMajorTickLabelCount();
+        for (double major = firstTick; (major <= axisRange.getMax() && tickValues.size() <= maxTickCount); major += axisRange.getTickUnit()) {
             tickValues.add(major);
         }
         return tickValues;
@@ -265,13 +266,16 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
         final double firstMajorTick = Math.ceil(lowerBound / majorUnit) * majorUnit;
         final double minorUnit = majorUnit / getMinorTickCount();
 
-        for (double majorTick = firstMajorTick - majorUnit; majorTick < upperBound; majorTick += majorUnit) {
+        final int maxTickCount = getMaxMajorTickLabelCount();
+        final int maxMinorTickCount = getMaxMajorTickLabelCount() * getMinorTickCount();
+        int majorTickCount = 0;
+        for (double majorTick = firstMajorTick - majorUnit; (majorTick < upperBound && majorTickCount < maxTickCount); majorTick += majorUnit) {
             if (majorTick + majorUnit == majorTick) {
                 // major ticks numerically not resolvable
                 break;
             }
             final double nextMajorTick = majorTick + majorUnit;
-            for (double minorTick = majorTick + minorUnit; minorTick < nextMajorTick; minorTick += minorUnit) {
+            for (double minorTick = majorTick + minorUnit; (minorTick < nextMajorTick && newMinorTickMarks.size() < maxMinorTickCount); minorTick += minorUnit) {
                 if (minorTick == majorTick) {
                     // minor ticks numerically not possible
                     break;
@@ -280,6 +284,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
                     newMinorTickMarks.add(minorTick);
                 }
             }
+            majorTickCount++;
         }
 
         return newMinorTickMarks;
@@ -287,7 +292,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     public boolean set(final double min, final double max) {
-        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+        if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return super.set(min, max);
         }
         final AxisRange range = computeRange(min, max, getLength(), 0.0);
@@ -301,7 +306,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     public boolean set(final String axisName, final String axisUnit, final double rangeMin, final double rangeMax) {
-        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+        if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return super.set(axisName, axisUnit, rangeMin, rangeMax);
         }
         final AxisRange range = computeRange(rangeMin, rangeMax, getLength(), 0.0);
@@ -311,7 +316,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     public boolean setMax(final double value) {
-        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+        if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return super.setMax(value);
         }
         final AxisRange range = computeRange(getMin(), value, getLength(), 0.0);
@@ -320,7 +325,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     public boolean setMin(final double value) {
-        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+        if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return super.setMin(value);
         }
         final AxisRange range = computeRange(value, getMax(), getLength(), 0.0);
@@ -365,7 +370,7 @@ public class OscilloscopeAxis extends AbstractAxis implements Axis {
 
     @Override
     protected void updateCachedVariables() {
-        if (cache == null) { // lgtm [java/useless-null-check] -- called from static initializer
+        if (cache == null) { // lgtm [java/useless-null-check] NOPMD NOSONAR -- called from static initializer
             return;
         }
         cache.updateCachedAxisVariables();

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisTests.java
@@ -37,6 +37,7 @@ import de.gsi.chart.utils.FXUtils;
 @ExtendWith(ApplicationExtension.class)
 @ExtendWith(JavaFXInterceptorUtils.SelectiveJavaFxInterceptor.class)
 class AbstractAxisTests {
+    private static final int DEFAULT_AXIS_LENGTH = 1000;
     private static final int WIDTH = 300;
     private static final int HEIGHT = 200;
     private Pane pane;
@@ -47,7 +48,7 @@ class AbstractAxisTests {
         assertFalse(axis.isAutoRangeRounding());
         final AxisRange defaultrange = axis.autoRange(1000);
         assertNotNull(defaultrange);
-        assertEquals(0, defaultrange.getAxisLength()); // since not being attache to a pane
+        assertEquals(1.0, defaultrange.getAxisLength()); // since not being attache to a pane
         assertEquals(-5.0, defaultrange.getMin());
         assertEquals(-5.0, defaultrange.getLowerBound());
         assertEquals(+5.0, defaultrange.getMax());
@@ -71,7 +72,7 @@ class AbstractAxisTests {
 
         assertDoesNotThrow(() -> axis.computeTickMarks(autoRange, false));
 
-        List<Number> numberList = Collections.unmodifiableList(axis.calculateMajorTickValues(1000, autoRange));
+        List<Number> numberList = Collections.unmodifiableList(axis.calculateMajorTickValues(DEFAULT_AXIS_LENGTH, autoRange));
         axis.invalidateRange(new ArrayList<>(numberList));
     }
 
@@ -100,7 +101,7 @@ class AbstractAxisTests {
     }
 
     @Test
-    void testGetterSetters() {
+    void testGetterSetters() { // NOPMD NOSONAR -- number of assertions is part of the unit-test
         EmptyAbstractAxis axis = new EmptyAbstractAxis();
 
         assertTrue(axis.set(-5.0, +5.0));
@@ -180,7 +181,7 @@ class AbstractAxisTests {
     @Test
     void testTickMarks() {
         AbstractAxis axis = new EmptyAbstractAxis(-5.0, 5.0);
-        final AxisRange autoRange = axis.autoRange(1000);
+        final AxisRange autoRange = axis.autoRange(DEFAULT_AXIS_LENGTH);
 
         final List<TickMark> majorTickMarks = axis.computeTickMarks(autoRange, true);
         assertNotNull(majorTickMarks);
@@ -238,6 +239,11 @@ class AbstractAxisTests {
         public double computePreferredTickUnit(final double axisLength) {
             //return axisLength / Math.abs(getMax() - getMin()) / 10.0
             return 0.1; // simplification for testing
+        }
+
+        @Override
+        protected AxisRange autoRange(final double minValue, final double maxValue, final double length, final double labelSize) {
+            return computeRange(minValue, maxValue, DEFAULT_AXIS_LENGTH, labelSize);
         }
 
         @Override

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/OscilloscopeAxisTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/OscilloscopeAxisTests.java
@@ -85,7 +85,7 @@ public class OscilloscopeAxisTests {
         final OscilloscopeAxis axis = new OscilloscopeAxis("axis title", 0.0, 100.0, 10.0);
 
         assertDoesNotThrow(() -> axis.setSide(Side.BOTTOM));
-        assertDoesNotThrow(() -> axis.updateCachedVariables());
+        assertDoesNotThrow(axis::updateCachedVariables);
 
         final double zero = axis.getDisplayPosition(axis.getValueForDisplay(0));
         assertEquals(0.0, zero);
@@ -144,10 +144,10 @@ public class OscilloscopeAxisTests {
     public void setterGetterTests() {
         final OscilloscopeAxis axis = new OscilloscopeAxis("axis title", 0.0, 100.0, 10.0);
 
-        assertEquals(false, axis.isLogAxis());
+        assertFalse(axis.isLogAxis());
         assertEquals(LogAxisType.LINEAR_SCALE, axis.getLogAxisType());
 
-        assertEquals(false, axis.isInvertedAxis());
+        assertFalse(axis.isInvertedAxis());
         //        axis.invertAxis(true);
         //        assertEquals(true, axis.isInvertedAxis());
         //        axis.invertAxis(false);
@@ -166,18 +166,18 @@ public class OscilloscopeAxisTests {
         axis.setTickUnitSupplier(testTickUnitSupplier);
         assertEquals(testTickUnitSupplier, axis.getTickUnitSupplier());
 
-        assertDoesNotThrow(() -> axis.updateCachedVariables());
+        assertDoesNotThrow(axis::updateCachedVariables);
 
         assertDoesNotThrow(() -> axis.setSide(Side.BOTTOM));
-        assertDoesNotThrow(() -> axis.updateCachedVariables());
+        assertDoesNotThrow(axis::updateCachedVariables);
 
         assertDoesNotThrow(() -> axis.setSide(Side.LEFT));
-        assertDoesNotThrow(() -> axis.updateCachedVariables());
+        assertDoesNotThrow(axis::updateCachedVariables);
 
         assertNotNull(axis.getAxisTransform());
 
         // TODO: make proper sanity checks
-        assertNotNull(axis.calculateMajorTickValues(100, axis.getAxisRange()));
+        assertNotNull(axis.calculateMajorTickValues(100, axis.getRange()));
         assertNotNull(axis.calculateMinorTickValues());
     }
 }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/SimpleChartSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/SimpleChartSample.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
 import de.gsi.chart.plugins.CrosshairIndicator;
+import de.gsi.chart.plugins.EditAxis;
 import de.gsi.chart.plugins.Zoomer;
+import de.gsi.dataset.event.UpdatedDataEvent;
 import de.gsi.dataset.spi.DoubleDataSet;
 
 /**
@@ -26,9 +28,12 @@ public class SimpleChartSample extends Application {
 
     @Override
     public void start(final Stage primaryStage) {
-        final XYChart chart = new XYChart(new DefaultNumericAxis(), new DefaultNumericAxis());
-        chart.getPlugins().add(new Zoomer()); // standard plugin, useful for most cases
-        chart.getPlugins().add(new CrosshairIndicator());
+        final DefaultNumericAxis yAxis = new DefaultNumericAxis();
+        yAxis.setAutoRanging(true); // default: true
+        yAxis.setAutoRangePadding(0.5); // here: 50% padding on top and bottom of axis
+
+        final XYChart chart = new XYChart(new DefaultNumericAxis(), yAxis);
+        chart.getPlugins().addAll(new Zoomer(), new CrosshairIndicator(), new EditAxis()); // standard plugin, useful for most cases
 
         final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1");
         final DoubleDataSet dataSet2 = new DoubleDataSet("data set #2");
@@ -37,28 +42,27 @@ public class SimpleChartSample extends Application {
         dataSet1.addListener(evt -> LOGGER.atInfo().log("dataSet1 - event: " + evt.toString()));
         dataSet2.addListener(evt -> LOGGER.atInfo().log("dataSet2 - event: " + evt.toString()));
 
-        // lineChartPlot.getDatasets().add(dataSet1); // for single data set
-        chart.getDatasets().addAll(dataSet1, dataSet2); // two data sets
+        // chart.getDatasets().add(dataSet1); // for single data set
+        chart.getDatasets().addAll(dataSet1, dataSet2); // for two data sets
 
         final double[] xValues = new double[N_SAMPLES];
         final double[] yValues1 = new double[N_SAMPLES];
-        final double[] yValues2 = new double[N_SAMPLES];
-        // dataSet2.setAutoNotification(false); // to suppress auto notification
+        dataSet2.autoNotification().set(false); // to suppress auto notification
         for (int n = 0; n < N_SAMPLES; n++) {
             final double x = n;
             final double y1 = Math.cos(Math.toRadians(10.0 * n));
             final double y2 = Math.sin(Math.toRadians(10.0 * n));
             xValues[n] = x;
             yValues1[n] = y1;
-            yValues2[n] = y2;
             dataSet2.add(n, y2); // style #1 how to set data, notifies re-draw for every 'add'
         }
         dataSet1.set(xValues, yValues1); // style #2 how to set data, notifies once per set
-        // dataSet2.setAutoNotification(false); // to suppress auto notification
-        // dataSet2.invokeListener(null); // to manually trigger an update
+        // to manually trigger an update (optional):
+        dataSet2.autoNotification().set(true); // to suppress auto notification
+        dataSet2.invokeListener(new UpdatedDataEvent(dataSet2 /* pointer to update source */, "manual update event"));
 
-        // alternatively (optional):
-        // final DoubleDataSet dataSet3 = new DoubleDataSet("data set #1", xValues, yValues1, N_SAMPLES, false);
+        // alternatively (optional via default constructor):
+        // final DoubleDataSet dataSet3 = new DoubleDataSet("data set #1", xValues, yValues1, N_SAMPLES, false)
 
         final Scene scene = new Scene(new StackPane(chart), 800, 600);
         primaryStage.setTitle(getClass().getSimpleName());


### PR DESCRIPTION
Fixed setAutoRangePadding() regression bug and simplified auto range handling

recomputation and redrawing of axes (on range-, tick unit, and notably scale changes) and update of the internal caches was done sometimes out-of-order causing the canvas being redrawn before the new axis settings have been in place. Previously this appeared to be less frequently visible since the change of the min/max axis range property triggered subsequent update events and thus drawing of the canvas. 

N.B. Interestingly, this did not show up in the numeric unit-tests and only while visually testing. The numerical API results seemed to have been always correct and only the canvas update has been missing sometimes.

Re-ordered recomputation of auto ranges, moved most of the computation into the `AbstractAxis::invalidateRange(..)` removed redundant code in the `AbstractAxis` and derived classes (notably 'getAxisRange()` which has been performing the same function as the existing 'getRange()`). The performance -- especially for rare or one-time updates -- should be more consistent now.

Updated the SimpleChartSample to reflect and test these changes (here with 50% padding on top and bottom of the DataSet):
![image](https://user-images.githubusercontent.com/46007894/96361354-42f8dd00-1125-11eb-995e-4a9ae45d013a.png)

and updated API in the commented code section (became dated/incorrect). Collateral effects remain to be checked/tested.