### PR TITLE
fixes IoClassSerialiserTests for custom pojos directly serialised as rootObj

### DIFF
--- a/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
@@ -105,7 +105,7 @@ class IoClassSerialiserTests {
                 /* return */ returnFunction, //
                 /* write */ writeFunction, CustomClass.class));
 
-        final CustomClass sourceClass = new CustomClass();
+        final CustomClass sourceClass = new CustomClass(1.2, 2, "Hello World!");
         final CustomClass destinationClass = new CustomClass();
 
         writerCalled.set(0);
@@ -117,9 +117,11 @@ class IoClassSerialiserTests {
         final WireDataFieldDescription root = serialiser.getMatchedIoSerialiser().parseIoStream(true);
         root.printFieldStructure();
         buffer.reset(); // reset to read position (==0)
-        serialiser.deserialiseObject(destinationClass);
+        final Object returnObject = serialiser.deserialiseObject(destinationClass);
 
-        assertEquals(sourceClass, destinationClass);
+        assertEquals(sourceClass, returnObject);
+        // TODO: future upgrade that this tests also passes:
+        // assertEquals(sourceClass, destinationClass)
     }
 
     @ParameterizedTest(name = "IoBuffer class - {0}")
@@ -132,7 +134,7 @@ class IoClassSerialiserTests {
         IoClassSerialiser serialiser = new IoClassSerialiser(buffer, BinarySerialiser.class);
 
         TestClass sourceClass = new TestClass();
-        sourceClass.integerBoxed = Integer.valueOf(1337);
+        sourceClass.integerBoxed = 1337;
 
         sourceClass.integerList = new ArrayList<>();
         sourceClass.integerList.add(1);
@@ -172,7 +174,7 @@ class IoClassSerialiserTests {
         sourceClass.multiArrayChar = MultiArrayChar.wrap(new char[] { 1, 2, 3, 4, 5, 6 }, new int[] { 2, 3 });
         sourceClass.multiArrayBoolean = MultiArrayBoolean.wrap(new boolean[] { true, false, false, true, true, false }, new int[] { 2, 3 });
         sourceClass.multiArrayByte = MultiArrayByte.wrap(new byte[] { 1, 2, 3, 4, 5, 6 }, new int[] { 2, 3 });
-        sourceClass.multiArrayString = MultiArrayObject.<String>wrap(new String[] { "aa", "ba", "ab", "bb", "ac", "bc" }, new int[] { 2, 3 });
+        sourceClass.multiArrayString = MultiArrayObject.wrap(new String[] { "aa", "ba", "ab", "bb", "ac", "bc" }, new int[] { 2, 3 }); // NOPMD NOSONAR -- String type is known
 
         TestClass destinationClass = new TestClass();
         destinationClass.nullIntegerList = new ArrayList<>();


### PR DESCRIPTION
The corresponding routine in IoSerialiser
<E> E getCustomData(FieldSerialiser<E> serialiser);
does not provide any provisions to make in-place modification and thus always returns a new custom object. 

Thus the return value needs to be always used for testing the deserialisation identity. Updated the test accordingly.

N.B. this is different for custom objects that are nested within another (generic) pojo. In this case the regular return/read FieldSerialiser call-back functions are used.