### PR TITLE
Fix IoClassSerialiser.setDataBuffer

### DIFF
--- a/chartfx-samples/src/main/java/de/gsi/dataset/samples/DataSetToByteArraySample.java
+++ b/chartfx-samples/src/main/java/de/gsi/dataset/samples/DataSetToByteArraySample.java
@@ -102,7 +102,11 @@ public class DataSetToByteArraySample {
         byteBuffer.reset(); // '0' writing at start of buffer
         serialiser.serialiseObject(dsOrig);
         byteBuffer.reset(); // reset to read position (==0)
-        serialiser.deserialiseObject(cpOrig);
+        final Object retOrig = serialiser.deserialiseObject(cpOrig);
+
+        if (cpOrig != retOrig) { // NOPMD - we actually want to compare references
+            throw new IllegalStateException("Deserialisation should be in-place");
+        }
 
         if (!(cpOrig.source instanceof DoubleErrorDataSet)) {
             throw new IllegalStateException(
@@ -142,7 +146,11 @@ public class DataSetToByteArraySample {
             serialiser.serialiseObject(dsOrig);
 
             byteBuffer.reset(); // reset to read position (==0)
-            serialiser.deserialiseObject(cpOrig);
+            final Object retOrig = serialiser.deserialiseObject(cpOrig);
+
+            if (retOrig != cpOrig) { // NOPMD - we actually want to compare references
+                throw new IllegalStateException("Deserialisation should be in-place");
+            }
 
             if (!dsOrig.source.getName().equals(cpOrig.source.getName())) {
                 LOGGER.atError().addArgument(dsOrig.source.getName()).addArgument(cpOrig.source.getName()).log("ERROR DataSet '{}' does not match '{}' -> potential streaming error at index = " + i);

--- a/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
@@ -66,8 +66,8 @@ public class IoClassSerialiser {
         dataBuffer = ioBuffer;
         // add default IoSerialiser Implementations
         ioSerialisers.add(new BinarySerialiser(dataBuffer));
-        ioSerialisers.add(new CmwLightSerialiser(dataBuffer));
         ioSerialisers.add(new JsonSerialiser(dataBuffer));
+        ioSerialisers.add(new CmwLightSerialiser(dataBuffer));
         if (ioSerialiserTypeClass.length > 0) {
             setMatchedIoSerialiser(ioSerialiserTypeClass[0]);
         } else {
@@ -117,19 +117,20 @@ public class IoClassSerialiser {
      * if enabled ({@link #isAutoMatchSerialiser()} then set matching serialiser
      */
     public void autoUpdateSerialiser() {
+        ioSerialisers.forEach(s -> s.setBuffer(dataBuffer));
         if (!isAutoMatchSerialiser()) {
             return;
         }
         final int originalPosition = dataBuffer.position();
         for (IoSerialiser ioSerialiser : ioSerialisers) {
             try {
-                ioSerialiser.setBuffer(dataBuffer);
                 ioSerialiser.checkHeaderInfo();
                 this.setMatchedIoSerialiser(ioSerialiser);
                 LOGGER.atTrace().addArgument(matchedIoSerialiser).addArgument(matchedIoSerialiser.getBuffer().capacity()).log("set autoUpdateSerialiser() to {} - buffer capacity = {}");
+                dataBuffer.position(originalPosition);
                 return;
-            } catch (IllegalStateException e) {
-                LOGGER.atWarn().setCause(e).addArgument(ioSerialiser).log("could not match IoSerialiser '{}'");
+            } catch (Throwable e) { // NOPMD NOSONAR expected failures for protocol mismatch
+                LOGGER.atTrace().setCause(e).addArgument(ioSerialiser).log("could not match IoSerialiser '{}'");
             }
             dataBuffer.position(originalPosition);
         }

--- a/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/IoClassSerialiser.java
@@ -49,7 +49,7 @@ public class IoClassSerialiser {
     protected IoBuffer dataBuffer;
     protected Consumer<FieldDescription> startMarkerFunction;
     protected Consumer<FieldDescription> endMarkerFunction;
-    private boolean autoMatchSerialiser = false;
+    private boolean autoMatchSerialiser = true;
     private boolean useCustomJsonSerialiser = false;
 
     /**

--- a/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
@@ -1,10 +1,6 @@
 package de.gsi.serializer;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 
 import java.lang.reflect.InvocationTargetException;
@@ -56,8 +52,9 @@ class IoClassSerialiserTests {
 
         final IoClassSerialiser deserialiser = new IoClassSerialiser(new FastByteBuffer(0));
         deserialiser.setDataBuffer(FastByteBuffer.wrap(bytes));
-        deserialiser.deserialiseObject(classAfterTest);
+        final Object returnedClass = deserialiser.deserialiseObject(classAfterTest);
 
+        assertSame(classAfterTest, returnedClass); // deserialisation should be in place
         assertEquals(classUnderTest, classAfterTest);
     }
 
@@ -210,7 +207,9 @@ class IoClassSerialiserTests {
         serialiser.deserialiseObject(destinationClass);
 
         buffer.reset(); // reset to read position (==0)
-        serialiser.deserialiseObject(destinationClass);
+        final Object returnedClass = serialiser.deserialiseObject(destinationClass);
+
+        assertSame(returnedClass, destinationClass); // deserialisation should be should be in-place
 
         assertEquals(sourceClass.integerBoxed, destinationClass.integerBoxed);
 

--- a/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoClassSerialiserTests.java
@@ -34,10 +34,7 @@ import de.gsi.dataset.spi.utils.MultiArrayInt;
 import de.gsi.dataset.spi.utils.MultiArrayLong;
 import de.gsi.dataset.spi.utils.MultiArrayObject;
 import de.gsi.dataset.spi.utils.MultiArrayShort;
-import de.gsi.serializer.spi.BinarySerialiser;
-import de.gsi.serializer.spi.ByteBuffer;
-import de.gsi.serializer.spi.FastByteBuffer;
-import de.gsi.serializer.spi.WireDataFieldDescription;
+import de.gsi.serializer.spi.*;
 
 /**
  * @author rstein
@@ -45,6 +42,24 @@ import de.gsi.serializer.spi.WireDataFieldDescription;
 class IoClassSerialiserTests {
     private static final int BUFFER_SIZE = 20000;
     private static final String GLOBAL_LOCK = "lock";
+
+    @ParameterizedTest(name = "Serialiser class - {0}")
+    @ValueSource(classes = { CmwLightSerialiser.class, BinarySerialiser.class, JsonSerialiser.class })
+    @ResourceLock(value = GLOBAL_LOCK, mode = READ_WRITE)
+    void testChangingBuffers(final Class<? extends IoSerialiser> serialiserClass) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+        final CustomClass2 classUnderTest = new CustomClass2(1.337, 42, "pi equals exactly three!");
+        final CustomClass2 classAfterTest = new CustomClass2();
+
+        IoClassSerialiser serialiser = new IoClassSerialiser(new FastByteBuffer(2 * BUFFER_SIZE), serialiserClass);
+        serialiser.serialiseObject(classUnderTest);
+        final byte[] bytes = serialiser.getDataBuffer().elements();
+
+        final IoClassSerialiser deserialiser = new IoClassSerialiser(new FastByteBuffer(0));
+        deserialiser.setDataBuffer(FastByteBuffer.wrap(bytes));
+        deserialiser.deserialiseObject(classAfterTest);
+
+        assertEquals(classUnderTest, classAfterTest);
+    }
 
     @ParameterizedTest(name = "IoBuffer class - {0}")
     @ValueSource(classes = { ByteBuffer.class, FastByteBuffer.class })
@@ -55,6 +70,7 @@ class IoClassSerialiserTests {
         final IoBuffer buffer = bufferClass.getConstructor(int.class).newInstance(2 * BUFFER_SIZE);
 
         IoClassSerialiser serialiser = new IoClassSerialiser(buffer, BinarySerialiser.class);
+        serialiser.setAutoMatchSerialiser(false);
 
         final AtomicInteger writerCalled = new AtomicInteger(0);
         final AtomicInteger returnCalled = new AtomicInteger(0);
@@ -304,6 +320,44 @@ class IoClassSerialiserTests {
         @Override
         public String toString() {
             return "CustomClass(" + testDouble + ", " + testInt + ", " + testString + ")";
+        }
+    }
+
+    /**
+     * Duplicate of CustomClass, because Custom Class gets registered for a custom (de)serialiser and we don't want that for all tests.
+     */
+    public static class CustomClass2 {
+        public double testDouble;
+        public int testInt;
+        public String testString;
+
+        public CustomClass2() {
+            this(-1.0, -1, "null string"); // null instantiation
+        }
+        public CustomClass2(final double testDouble, final int testInt, final String testString) {
+            this.testDouble = testDouble;
+            this.testInt = testInt;
+            this.testString = testString;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            final CustomClass2 that = (CustomClass2) o;
+            return Double.compare(that.testDouble, testDouble) == 0 && testInt == that.testInt && Objects.equals(testString, that.testString);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(testDouble, testInt, testString);
+        }
+
+        @Override
+        public String toString() {
+            return "CustomClass2(" + testDouble + ", " + testInt + ", " + testString + ")";
         }
     }
 

--- a/microservice/src/test/java/de/gsi/serializer/IoSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoSerialiserTests.java
@@ -114,6 +114,8 @@ class IoSerialiserTests {
         final IoBuffer buffer = bufferClass.getConstructor(int.class).newInstance(BUFFER_SIZE);
 
         final IoClassSerialiser serialiser = new IoClassSerialiser(buffer, BinarySerialiser.class);
+        // disable auto serialiser selection because otherwise it will get detected as CMWLightSerialiser (strangely only for FastByteBuffer)
+        serialiser.setAutoMatchSerialiser(false);
         assertEquals(bufferClass, buffer.getClass());
         assertEquals(bufferClass, serialiser.getDataBuffer().getClass());
 

--- a/microservice/src/test/java/de/gsi/serializer/IoSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/IoSerialiserTests.java
@@ -1,10 +1,6 @@
 package de.gsi.serializer;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static de.gsi.dataset.DataSet.DIM_X;
 
@@ -168,7 +164,9 @@ class IoSerialiserTests {
         ioClassSerialiser.serialiseObject(inputObject);
 
         buffer.flip();
-        ioClassSerialiser.deserialiseObject(outputObject);
+        final Object returnedObject = ioClassSerialiser.deserialiseObject(outputObject);
+
+        assertSame(outputObject, returnedObject, "Deserialisation should be in-place");
 
         // second test - both vectors should have the same initial values after serialise/deserialise
         assertArrayEquals(inputObject.stringArray, outputObject.stringArray);
@@ -201,7 +199,9 @@ class IoSerialiserTests {
         //        }
 
         buffer.flip();
-        ioClassSerialiser.deserialiseObject(outputObject);
+        final Object returnedObject = ioClassSerialiser.deserialiseObject(outputObject);
+
+        assertSame(outputObject, returnedObject, "Deserialisation should be in-place");
 
         assertEquals(inputObject, outputObject, "TestDataClass input-output equality");
 

--- a/microservice/src/test/java/de/gsi/serializer/helper/CmwLightHelper.java
+++ b/microservice/src/test/java/de/gsi/serializer/helper/CmwLightHelper.java
@@ -1,7 +1,6 @@
 package de.gsi.serializer.helper;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.concurrent.TimeUnit;
 
@@ -129,7 +128,9 @@ public class CmwLightHelper {
         // fieldRoot.printFieldStructure();
 
         byteBuffer.reset();
-        ioSerialiser.deserialiseObject(outputObject);
+        final Object returnedObject = ioSerialiser.deserialiseObject(outputObject);
+
+        assertSame(outputObject, returnedObject, "Deserialisation expected to be in-place");
 
         // second test - both vectors should have the same initial values after serialise/deserialise
         assertArrayEquals(inputObject.stringArray, outputObject.stringArray);
@@ -349,6 +350,7 @@ public class CmwLightHelper {
         final long startTime = System.nanoTime();
 
         for (int i = 0; i < iterations; i++) {
+            outputObject.clear();
             byteBuffer.reset();
             CmwLightHelper.serialiseCustom(cmwLightSerialiser, inputObject);
 
@@ -379,6 +381,7 @@ public class CmwLightHelper {
         cmwLightSerialiser.setPutFieldMetaData(true);
         final long startTime = System.nanoTime();
         for (int i = 0; i < iterations; i++) {
+            outputObject.clear();
             if (i == 1) {
                 // only stream meta-data the first iteration
                 cmwLightSerialiser.setPutFieldMetaData(false);
@@ -388,7 +391,11 @@ public class CmwLightHelper {
 
             byteBuffer.reset();
 
-            ioSerialiser.deserialiseObject(outputObject);
+            final Object returnedObject = ioSerialiser.deserialiseObject(outputObject);
+
+            if (outputObject != returnedObject) { // NOPMD - we actually want to compare references
+                throw new IllegalStateException("Deserialisation expected to be in-place");
+            }
 
             if (!inputObject.string1.contentEquals(outputObject.string1)) {
                 // quick check necessary so that the above is not optimised by the Java JIT compiler to NOP

--- a/microservice/src/test/java/de/gsi/serializer/helper/JsonHelper.java
+++ b/microservice/src/test/java/de/gsi/serializer/helper/JsonHelper.java
@@ -157,6 +157,7 @@ public final class JsonHelper {
         final long startTime = System.nanoTime();
 
         for (int i = 0; i < iterations; i++) {
+            outputObject.clear();
             byteBuffer.reset();
             JsonHelper.serialiseCustom(jsonSerialiser, inputObject);
 
@@ -188,6 +189,7 @@ public final class JsonHelper {
         JsonStream.setMode(EncodingMode.REFLECTION_MODE);
         JsonIterator.setMode(DecodingMode.REFLECTION_MODE);
 
+        outputObject.clear();
         final long startTime = System.nanoTime();
         testPerformancePojoNoPrintout(iterations, inputObject, outputObject);
         if (iterations <= 1) {
@@ -209,6 +211,7 @@ public final class JsonHelper {
         JsonStream.setMode(EncodingMode.DYNAMIC_MODE);
         JsonIterator.setMode(DecodingMode.DYNAMIC_MODE_AND_MATCH_FIELD_WITH_HASH);
 
+        outputObject.clear();
         final long startTime = System.nanoTime();
         testPerformancePojoNoPrintout(iterations, inputObject, outputObject);
         if (iterations <= 1) {

--- a/microservice/src/test/java/de/gsi/serializer/spi/iobuffer/DataSetSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/spi/iobuffer/DataSetSerialiserTests.java
@@ -1,11 +1,6 @@
 package de.gsi.serializer.spi.iobuffer;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -266,7 +261,9 @@ class DataSetSerialiserTests {
         // root.printFieldStructure();
 
         buffer.reset(); // reset to read position (==0)
-        serialiser.deserialiseObject(cpOrig);
+        final Object retOrig = serialiser.deserialiseObject(cpOrig);
+
+        assertSame(cpOrig, retOrig, "Deserialisation expected to be in-place");
 
         // check DataSet for equality
         if (!(cpOrig.source instanceof DataSetError)) {
@@ -324,7 +321,9 @@ class DataSetSerialiserTests {
         // root.printFieldStructure();
 
         buffer.reset(); // reset to read position (==0)
-        serialiser.deserialiseObject(cpOrig);
+        final Object retOrig = serialiser.deserialiseObject(cpOrig);
+
+        assertSame(cpOrig, retOrig, "Deserialisation expected to be in-place");
 
         // check DataSet for equality
         if (!(cpOrig.source instanceof DataSetError)) {


### PR DESCRIPTION
Fixes the `setDataBuffer` method to also update the buffers of the underlying implementations. Also fixed the tests to fix these issues.

Another small improvement is to enable the automatic serialiser detection by default. There are some cornercases where this has to be disabled, but most of the time it does the right thing.

As a follow up of #281 I changed all occurences of `deserialiseObject()` to also use their return value instead of blindly trusting that the deserialisation will be in-place.