### PR TITLE
Enable rerunning failed unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
         <chartfx.javafxsvg.version>1.3.0</chartfx.javafxsvg.version>
 
         <chartfx.slf4j.version>2.0.0-alpha0</chartfx.slf4j.version>
-        <chartfx.junit.jupiter.version>5.6.2</chartfx.junit.jupiter.version>
+        <chartfx.junit.jupiter.version>5.7.0</chartfx.junit.jupiter.version>
         <chartfx.awaitility.version>4.0.3</chartfx.awaitility.version>
-        <chartfx.jacoco.version>0.8.5</chartfx.jacoco.version>
-        <chartfx.surefire.version>2.22.2</chartfx.surefire.version>
+        <chartfx.jacoco.version>0.8.6</chartfx.jacoco.version>
+        <chartfx.surefire.version>3.0.0-M5</chartfx.surefire.version>
     </properties>
 
     <licenses>
@@ -270,6 +270,7 @@
                     <!-- those command-line params here (${argLine} holds those params) -->
                     <argLine>${argLine} -Xms256m -Xmx2048m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
                     <forkCount>1</forkCount>
+                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <runOrder>random</runOrder>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is needed because on the travis runner there are some non
deterministic test failures for the allocator based tests and the testfx
based ones.

Because this feature needs feature needs surefire > 3.0.0-M4 I updated
all build plugins to their latest release.