### PR TITLE
Show Tooltips for all renderers and dataset in the chart and use the either the specified formater or the axis formater

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -183,7 +183,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         pickingDistanceProperty().set(distance);
     }
 
-    private void updateLabel(final MouseEvent event, final Bounds plotAreaBounds, final DataPoint dataPoint) {
+    protected void updateLabel(final MouseEvent event, final Bounds plotAreaBounds, final DataPoint dataPoint) {
         label.setText(formatLabel(dataPoint));
         final double mouseX = event.getX();
         final double spaceLeft = mouseX - plotAreaBounds.getMinX();

--- a/chartfx-chart/src/test/java/de/gsi/chart/plugins/DataPointTooltipTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/plugins/DataPointTooltipTest.java
@@ -1,0 +1,105 @@
+package de.gsi.chart.plugins;
+
+import static org.testfx.util.NodeQueryUtils.hasText;
+
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+
+import javafx.geometry.Point2D;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxAssert;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.DebugUtils;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.Axis;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.chart.ui.geometry.Side;
+import de.gsi.dataset.DataSet;
+import de.gsi.dataset.spi.DataSetBuilder;
+import de.gsi.dataset.testdata.spi.CosineFunction;
+
+/**
+ * Test the DataPointTooltip Plugin
+ * 
+ * @author Alexander Krimm
+ */
+@ExtendWith(ApplicationExtension.class)
+class DataPointTooltipTest {
+    private XYChart chart;
+    private CosineFunction ds1;
+    private DataSet ds2;
+    private Axis xAxis1;
+    private Axis yAxis1;
+    private Axis xAxis2;
+    private Axis yAxis2;
+    private ErrorDataSetRenderer renderer2;
+
+    @Start
+    public void start(Stage stage) {
+        chart = new XYChart();
+        final DataPointTooltip tooltip = new DataPointTooltip();
+        chart.getPlugins().add(tooltip);
+        chart.setId("myChart");
+        chart.setPrefWidth(400);
+        chart.setPrefHeight(300);
+
+        // ordered Dataset
+        xAxis1 = new DefaultNumericAxis("xAxis1", "t");
+        xAxis1.setSide(Side.BOTTOM);
+        yAxis1 = new DefaultNumericAxis("yAxis1", "m");
+        yAxis1.setSide(Side.LEFT);
+        final ErrorDataSetRenderer renderer1 = new ErrorDataSetRenderer();
+        renderer1.getAxes().setAll(xAxis1, yAxis1);
+        ds1 = new CosineFunction("Cosine", 50);
+        ds1.addDataLabel(17, "SpecialPoint");
+        renderer1.getDatasets().add(ds1);
+
+        // unordered dataset
+        xAxis2 = new DefaultNumericAxis("xAxis2", "V");
+        xAxis2.setSide(Side.TOP);
+        yAxis2 = new DefaultNumericAxis("yAxis2", "m");
+        yAxis2.setSide(Side.RIGHT);
+        renderer2 = new ErrorDataSetRenderer();
+        renderer2.getAxes().setAll(xAxis2, yAxis2);
+        ds2 = new DataSetBuilder("nonsorted")
+                      .setValues(DIM_X, new double[] { 0, 1, 1, 0.5, 0, 0, 0.9, 0.1, 0.9 })
+                      .setValues(DIM_Y, new double[] { 0, 0, 1, 1.5, 1, 0.1, 1, 1, 0.1 })
+                      .build();
+        renderer2.getDatasets().add(ds2);
+
+        chart.getRenderers().setAll(renderer1, renderer2);
+        Scene scene = new Scene(chart, 400, 300);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    @Test
+    void testThatTooltipIsShown(final FxRobot fxRobot) { // NOPMD JUnitTestsShouldIncludeAssert
+        fxRobot.interrupt();
+
+        // ordered dataset
+        fxRobot.moveTo(getPointOnDataSet(xAxis1, yAxis1, ds1, 17)).moveBy(1, 0);
+        FxAssert.verifyThat("." + DataPointTooltip.STYLE_CLASS_LABEL, hasText("'SpecialPoint'\n17.0, -0.8090169943749469"), DebugUtils.informedErrorMessage(fxRobot));
+        fxRobot.moveTo(getPointOnDataSet(xAxis1, yAxis1, ds1, 36)).moveBy(1, 0);
+        FxAssert.verifyThat("." + DataPointTooltip.STYLE_CLASS_LABEL, hasText("'Cosine [36]'\n36.0, 0.3090169943749491"), DebugUtils.informedErrorMessage(fxRobot));
+
+        // unordered DataSet
+        fxRobot.interact(() -> renderer2.setAssumeSortedData(false));
+        fxRobot.moveTo(getPointOnDataSet(xAxis2, yAxis2, ds2, 5)).moveBy(1, 0);
+        FxAssert.verifyThat("." + DataPointTooltip.STYLE_CLASS_LABEL, hasText("'nonsorted [5]'\n0.0, 0.1"), DebugUtils.informedErrorMessage(fxRobot));
+    }
+
+    private Point2D getPointOnDataSet(final Axis xAxis, final Axis yAxis, final DataSet ds, final int index) {
+        return chart.getCanvas().localToScreen(new Point2D(
+                xAxis.getDisplayPosition(ds.get(DIM_X, index)),
+                yAxis.getDisplayPosition(ds.get(DIM_Y, index))));
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/MultipleAxesSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/MultipleAxesSample.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import de.gsi.chart.XYChart;
 import de.gsi.chart.axes.Axis;
 import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.DataPointTooltip;
 import de.gsi.chart.plugins.EditAxis;
 import de.gsi.chart.plugins.ParameterMeasurements;
 import de.gsi.chart.plugins.Zoomer;
@@ -52,6 +53,9 @@ public class MultipleAxesSample extends Application {
 
         final DefaultNumericAxis xAxis1 = new DefaultNumericAxis("x axis");
         xAxis1.setAnimated(false);
+        final DefaultNumericAxis xAxis2 = new DefaultNumericAxis("x axis2");
+        xAxis2.setSide(Side.TOP);
+        xAxis2.setAnimated(false);
         final DefaultNumericAxis yAxis1 = new DefaultNumericAxis("y axis", "random");
         yAxis1.setAnimated(false);
         final DefaultNumericAxis yAxis2 = new DefaultNumericAxis("y axis", "sine/cosine");
@@ -71,15 +75,16 @@ public class MultipleAxesSample extends Application {
         final ErrorDataSetRenderer errorRenderer2 = new ErrorDataSetRenderer();
         errorRenderer2.getAxes().add(yAxis2);
         final ErrorDataSetRenderer errorRenderer3 = new ErrorDataSetRenderer();
-        errorRenderer3.getAxes().add(yAxis3);
+        errorRenderer3.getAxes().addAll(xAxis2, yAxis3);
         chart.getRenderers().addAll(errorRenderer2, errorRenderer3);
 
         chart.getPlugins().add(new ParameterMeasurements());
+        chart.getPlugins().add(new DataPointTooltip());
         final Zoomer zoom = new Zoomer();
         // add axes that shall be excluded from the zoom action
         zoom.omitAxisZoomList().add(yAxis3);
         // alternatively (uncomment):
-        // Zoomer.setOmitZoom(yAxis3, true);
+        Zoomer.setOmitZoom(xAxis2, true);
         chart.getPlugins().add(zoom);
         chart.getToolBar().getChildren().add(new MyZoomCheckBox(zoom, yAxis3));
         chart.getPlugins().add(new EditAxis());


### PR DESCRIPTION
* Allow the Tooltip to be shown for all renderers and datasets shown in the chart
* use the formaters which are customizable in the AbstractDataFormating parent plugin or if they are not available the formaters of the axis
* Add TestFx tests for the tooltip

solves #286