### PR TITLE
Allow serialisation of empty subelements in cmwLightSerialiser

### DIFF
--- a/microservice/src/main/java/de/gsi/serializer/spi/BinarySerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/BinarySerialiser.java
@@ -111,7 +111,7 @@ import de.gsi.serializer.utils.ClassUtils;
  */
 @SuppressWarnings({ "PMD.CommentSize", "PMD.ExcessivePublicCount", "PMD.PrematureDeclaration" }) // variables need to be read from stream
 public class BinarySerialiser implements IoSerialiser {
-    public static final int VERSION_MAGIC_NUMBER = 0x00000000; // '0' since CmwLight cannot (usually) start with 0 length fields
+    public static final int VERSION_MAGIC_NUMBER = -1; // '-1' since CmwLight cannot have a negative number of entries
     public static final String PROTOCOL_NAME = "YaS"; // Yet another Serialiser implementation
     public static final byte VERSION_MAJOR = 1;
     public static final byte VERSION_MINOR = 0;

--- a/microservice/src/main/java/de/gsi/serializer/spi/CmwLightSerialiser.java
+++ b/microservice/src/main/java/de/gsi/serializer/spi/CmwLightSerialiser.java
@@ -389,8 +389,8 @@ public class CmwLightSerialiser implements IoSerialiser {
         }
         buffer.position(fieldRoot.getDataStartPosition());
         final int nEntries = buffer.getInt();
-        if (nEntries <= 0) {
-            throw new IllegalStateException("nEntries = " + nEntries + " <= 0!");
+        if (nEntries < 0) {
+            throw new IllegalStateException("nEntries = " + nEntries + " < 0!");
         }
         parent = lastFieldHeader = fieldRoot;
         for (int i = 0; i < nEntries; i++) {

--- a/microservice/src/test/java/de/gsi/serializer/spi/CmwLightSerialiserTests.java
+++ b/microservice/src/test/java/de/gsi/serializer/spi/CmwLightSerialiserTests.java
@@ -1,0 +1,26 @@
+package de.gsi.serializer.spi;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import de.gsi.serializer.FieldDescription;
+
+public class CmwLightSerialiserTests {
+    @Test
+    public void testCmwData() {
+        final CmwLightSerialiser serialiser = new CmwLightSerialiser(FastByteBuffer.wrap(new byte[] {
+                7, 0, 0, 0, 2, 0, 0, 0, 48, 0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 49, 0, 7, 1, 0, 0, 0, 0, 2, 0, 0,
+                0, 50, 0, 1, 5, 2, 0, 0, 0, 51, 0, 8, 1, 0, 0, 0, 2, 0, 0, 0, 98, 0, 4, 114, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+                0, 0, 55, 0, 1, 0, 2, 0, 0, 0, 100, 0, 7, 1, 0, 0, 0, 0, 2, 0, 0, 0, 102, 0, 7, 1, 0, 0, 0, 0 }));
+        final FieldDescription fieldDescription = serialiser.parseIoStream(true).getChildren().get(0);
+        // fieldDescription.printFieldStructure();
+        assertEquals(1L, ((WireDataFieldDescription) fieldDescription.findChildField("0")).data());
+        assertEquals("", ((WireDataFieldDescription) fieldDescription.findChildField("1")).data());
+        assertEquals((byte) 5, ((WireDataFieldDescription) fieldDescription.findChildField("2")).data());
+        assertEquals(114L, ((WireDataFieldDescription) fieldDescription.findChildField("3").findChildField("b")).data());
+        assertEquals((byte) 0, ((WireDataFieldDescription) fieldDescription.findChildField("7")).data());
+        assertEquals("", ((WireDataFieldDescription) fieldDescription.findChildField("d")).data());
+        assertEquals("", ((WireDataFieldDescription) fieldDescription.findChildField("f")).data());
+    }
+}


### PR DESCRIPTION
Add a testcase with a message serialized by the reference serialiser and fix the bug it triggers.
Also changes the auto protocol detection mechanism because before it relied on the size field of cmw never to be zero, now use negative field size instead.