### PR TITLE
Correct automatic module names

### DIFF
--- a/chartfx-acc/pom.xml
+++ b/chartfx-acc/pom.xml
@@ -11,6 +11,9 @@
     <groupId>de.gsi.acc</groupId>
     <artifactId>chartfx-acc</artifactId>
     <name>acc</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.acc</project.moduleName>
+    </properties>
 
     <description>
         Collection of accelerator specific widget and functionalities that directly depend on chart-fx or which no other suitable place has been identified (yet).

--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -12,6 +12,9 @@
     <groupId>de.gsi.chart</groupId>
     <artifactId>chartfx-chart</artifactId>
     <name>chartfx-chart</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.chart</project.moduleName>
+    </properties>
 
     <description>This charting library ${project.artifactId}- is an extension
 		in the spirit of Oracle's XYChart and performance/time-proven JDataViewer charting functionalities.

--- a/chartfx-dataset/pom.xml
+++ b/chartfx-dataset/pom.xml
@@ -11,6 +11,9 @@
     <groupId>de.gsi.dataset</groupId>
     <artifactId>chartfx-dataset</artifactId>
     <name>dataset</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.dataset</project.moduleName>
+    </properties>
 
     <description>
 		Container for handling different types of datasets with metadata, uncertainties, etc.

--- a/chartfx-generate/pom.xml
+++ b/chartfx-generate/pom.xml
@@ -14,6 +14,10 @@
     <artifactId>chartfx-generate</artifactId>
     <packaging>maven-plugin</packaging>
     <name>chartfx-generate</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.generate</project.moduleName>
+    </properties>
+
 
     <description>
         Code generation utilities that generate implementations or various Java primitives

--- a/chartfx-math/pom.xml
+++ b/chartfx-math/pom.xml
@@ -12,6 +12,9 @@
     <groupId>de.gsi.math</groupId>
     <artifactId>chartfx-math</artifactId>
     <name>math</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.math</project.moduleName>
+    </properties>
 
     <description>
         A small set of math routines that can operate directly on the DataSet primitive for fitting,

--- a/chartfx-samples/pom.xml
+++ b/chartfx-samples/pom.xml
@@ -12,6 +12,9 @@
     </parent>
     <artifactId>chartfx-samples</artifactId>
     <name>chartfx-samples</name>
+    <properties>
+        <project.moduleName>de.gsi.chartfx.samples</project.moduleName>
+    </properties>
 
     <description>
 		Small sample applications to showcase the features of the chart-fx library.

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -23,6 +23,7 @@
         <micrometer.version>1.5.1</micrometer.version>
         <velocity.version>2.0</velocity.version>
         <okHttp3.version>4.8.1</okHttp3.version>
+        <project.moduleName>de.gsi.microservice</project.moduleName>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <changelist>-SNAPSHOT</changelist>
         <sha1 />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.moduleName>de.gsi.chartfx</project.moduleName>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
@@ -127,7 +128,7 @@
                                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
                             <manifestEntries>
-                              <Automatic-Module-Name>${project.groupId}.${project.artifactId}</Automatic-Module-Name>
+                              <Automatic-Module-Name>${project.moduleName}</Automatic-Module-Name>
                             </manifestEntries>
                         </archive>
                     </configuration>


### PR DESCRIPTION
Module names should not contain hyphens, so we cannot reuse our artifact
names. Instead introduce a new property which will be set in each
module.

fixes #321