### PR TITLE
Fix MultiArray and DoubleGrid data set to use row major storage as documented

### DIFF
--- a/chartfx-dataset/src/main/codegen/de/gsi/dataset/spi/utils/MultiArrayProto.java
+++ b/chartfx-dataset/src/main/codegen/de/gsi/dataset/spi/utils/MultiArrayProto.java
@@ -189,14 +189,26 @@ public class MultiArrayProto extends MultiArray<double[]> { //// codegen: subst:
 
         protected MultiArray2DProto(final double[] elements, final int[] dimensions, final int offset) { //// codegen: subst:U:double[]:U[]
             super(elements, dimensions, offset);
-            stride = dimensions[0];
+            stride = dimensions[1];
         }
 
-        public double get(final int column, final int row) {
+        /**
+         *
+         * @param row rowIndex
+         * @param column columnIndex
+         * @return value at M(rowIndex,columnIndex)
+         */
+        public double get(final int row, final int column) {
             return elements[offset + column + row * stride];
         }
 
-        public void set(final int column, final int row, final double value) {
+        /**
+         *
+         * @param row rowIndex
+         * @param column columnIndex
+         * @param value new value: M(rowIndex,columnIndex) == value
+         */
+        public void set(final int row, final int column, final double value) {
             elements[offset + column + row * stride] = value;
         }
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleGridDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleGridDataSet.java
@@ -52,7 +52,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
      */
     public DoubleGridDataSet(String name, int nDims, int[] shape) {
         super(name, nDims);
-        this.shape = shape;
+        this.shape = reverseOrder(shape);
         if (shape.length > nDims) {
             throw new IllegalArgumentException("nDims must be greater or equal to grid shape");
         }
@@ -66,7 +66,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
             grid[i] = IntStream.range(0, shape[i]).asDoubleStream().toArray();
         }
         for (int i = shape.length; i < nDims; i++) {
-            values[i - shape.length] = MultiArrayDouble.wrap(new double[dataCount], 0, shape);
+            values[i - shape.length] = MultiArrayDouble.wrap(new double[dataCount], 0, this.shape);
         }
     }
 
@@ -79,7 +79,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
     public DoubleGridDataSet(String name, int[] shape, final boolean copy, double[]... vals) {
         super(name, shape.length + vals.length);
         final int nDims = shape.length + vals.length;
-        this.shape = shape.clone();
+        this.shape = reverseOrder(shape.clone());
 
         grid = new double[shape.length][];
         values = new MultiArrayDouble[vals.length];
@@ -93,7 +93,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
             if (vals[i - shape.length].length != dataCount) {
                 throw new IllegalArgumentException("Dimension missmatch between grid and values");
             }
-            values[i - shape.length] = MultiArrayDouble.wrap(copy ? vals[i - shape.length].clone() : vals[i - shape.length], 0, shape);
+            values[i - shape.length] = MultiArrayDouble.wrap(copy ? vals[i - shape.length].clone() : vals[i - shape.length], 0, this.shape);
         }
     }
 
@@ -169,7 +169,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
             if (nDims != grid.length + vals.length) {
                 throw new IllegalArgumentException("grid + value dimensions must match dataset dimensions");
             }
-            shape = Arrays.stream(grid).mapToInt(doubles -> doubles.length).toArray();
+            shape = reverseOrder(Arrays.stream(grid).mapToInt(doubles -> doubles.length).toArray());
             this.grid = copy ? new double[shape.length][] : grid;
             dataCount = 1;
             for (int i = 0; i < shape.length; i++) {
@@ -256,5 +256,13 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
 
     public void clearData() {
         set(false, new double[shape.length][0], new double[1][0]);
+    }
+
+    private static int[] reverseOrder(final int[] input) {
+        final int[] result = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            result[i] = input[input.length - 1 - i];
+        }
+        return result;
     }
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleGridDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/DoubleGridDataSet.java
@@ -14,7 +14,7 @@ import de.gsi.dataset.spi.utils.MultiArrayDouble;
  * The dimension of the dataSet is n+m.
  *
  * The data is stored in a row-major container, but as the renderer interface expects column major, the data is transposed
- * on internally in the DoubleGridDataSet.
+ * internally in the DoubleGridDataSet.
  *
  * @author Alexander Krimm
  */
@@ -51,7 +51,7 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
     /**
      * @param name name for this DataSet
      * @param nDims number of Dimensions
-     * @param shape Shape of the grid
+     * @param shape Shape of the grid, length cannot exceed number of dimensions: double[nGrid] {n_x, n_y, ...}
      */
     public DoubleGridDataSet(String name, int nDims, int[] shape) {
         super(name, nDims);
@@ -76,18 +76,18 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
 
     /**
      * @param name name for the dataSet
-     * @param shape shape of the grid
-     * @param copy whether to copy the values in vals
-     * @param vals values
+     * @param shape shape of the grid: double[nGrid] {n_x, n_y, ...}
+     * @param copy whether to copy the values in values
+     * @param values values in column-major order (2d case: double[n_x * n_y]{z(0,0), z(1,0) ... z(m-1,n), z(m,n)})
      */
-    public DoubleGridDataSet(String name, int[] shape, final boolean copy, double[]... vals) {
-        super(name, shape.length + vals.length);
-        final int nDims = shape.length + vals.length;
+    public DoubleGridDataSet(String name, int[] shape, final boolean copy, double[]... values) {
+        super(name, shape.length + values.length);
+        final int nDims = shape.length + values.length;
         this.shape = shape.clone();
         final int[] containerShape = reverseOrder(shape);
 
         grid = new double[shape.length][];
-        values = new MultiArrayDouble[vals.length];
+        this.values = new MultiArrayDouble[values.length];
 
         dataCount = 1;
         for (int i = 0; i < shape.length; i++) {
@@ -95,22 +95,22 @@ public class DoubleGridDataSet extends AbstractGridDataSet<DoubleGridDataSet> im
             grid[i] = IntStream.range(0, shape[i]).asDoubleStream().toArray();
         }
         for (int i = shape.length; i < nDims; i++) {
-            if (vals[i - shape.length].length != dataCount) {
+            if (values[i - shape.length].length != dataCount) {
                 throw new IllegalArgumentException("Dimension missmatch between grid and values");
             }
-            values[i - shape.length] = MultiArrayDouble.wrap(copy ? vals[i - shape.length].clone() : vals[i - shape.length], 0, containerShape);
+            this.values[i - shape.length] = MultiArrayDouble.wrap(copy ? values[i - shape.length].clone() : values[i - shape.length], 0, containerShape);
         }
     }
 
     /**
      * @param name name for the dataSet
-     * @param copy whether to copy the values from grid and vals
-     * @param grid values for the grid
-     * @param vals values
+     * @param copy whether to copy the values from grid and values
+     * @param grid values for the grid double[nGrid][m/n/...] {{x_0 ... x_n}, {y_0 ... y_m}, ...}
+     * @param values values in column-major order (2d case: double[n_x * n_y]{z(0,0), z(1,0) ... z(m-1,n), z(m,n)})
      */
-    public DoubleGridDataSet(final String name, final boolean copy, final double[][] grid, final double[]... vals) {
-        super(name, grid.length + vals.length);
-        set(copy, grid, vals);
+    public DoubleGridDataSet(final String name, final boolean copy, final double[][] grid, final double[]... values) {
+        super(name, grid.length + values.length);
+        set(copy, grid, values);
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/utils/MultiArray.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/utils/MultiArray.java
@@ -112,11 +112,11 @@ public abstract class MultiArray<T> {
         this.elements = elements;
         this.offset = offset;
         strides = new int[dimensions.length];
-        strides[0] = 1;
-        for (int i = 1; i < dimensions.length; i++) {
-            strides[i] = strides[i - 1] * dimensions[i - 1];
+        strides[dimensions.length - 1] = 1;
+        for (int i = dimensions.length - 2; i >= 0; i--) {
+            strides[i] = strides[i + 1] * dimensions[i + 1];
         }
-        this.elementCount = strides[dimensions.length - 1] * dimensions[dimensions.length - 1];
+        this.elementCount = strides[0] * dimensions[0];
     }
 
     /**
@@ -146,12 +146,16 @@ public abstract class MultiArray<T> {
      */
     public int getIndex(final int[] indices) {
         int index = offset;
-        for (int i = 0; i < dimensions.length; i++) {
+        int multiplier = 1;
+
+        for (int i = indices.length - 1; i >= 0; i--) {
             if (indices[i] < 0 || indices[i] >= dimensions[i]) {
                 throw new IndexOutOfBoundsException("Index " + indices[i] + " for dimension " + i + " out of bounds " + dimensions[i]);
             }
-            index += indices[i] * strides[i];
+            index += indices[i] * multiplier;
+            multiplier *= dimensions[i];
         }
+
         return index;
     }
 
@@ -167,13 +171,10 @@ public abstract class MultiArray<T> {
             return new int[dimensions.length];
         }
         final int[] indices = new int[dimensions.length];
-        int ind = index - offset;
-        for (int i = dimensions.length - 1; i >= 0; i--) {
-            if (dimensions[i] == 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            indices[i] = ind / strides[i];
-            ind = ind % strides[i];
+        int lindex = index - offset;
+        for (int i = 0; i < dimensions.length; i++) {
+            indices[i] = lindex / strides[i];
+            lindex -= indices[i] * strides[i];
         }
         return indices;
     }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DoubleGridDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DoubleGridDataSetTests.java
@@ -55,14 +55,14 @@ class DoubleGridDataSetTests {
     @Test
     void nonPermutableShape() {
         double[] data = new double[] {
-                // first slice
-                1, 2, 3, 4, //first row
-                5, 6, 7, 8, //
-                9, 10, 11, 12, //
-                // second slice
-                13,14,15,16, // first row
-                17,18,19,20, //
-                21,22,23,24 //
+            // first slice
+            1, 2, 3, 4, //first row
+            5, 6, 7, 8, //
+            9, 10, 11, 12, //
+            // second slice
+            13, 14, 15, 16, // first row
+            17, 18, 19, 20, //
+            21, 22, 23, 24 //
         };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", new int[] { 4, 3, 2 }, false, data);
         assertSame(data, dataset.getValues(3));
@@ -86,14 +86,14 @@ class DoubleGridDataSetTests {
     @Test
     void testEquidistantFullDataConstructor() {
         double[] data = new double[] {
-                // first slice
-                1, 2, // first row
-                3, 4, // second row
-                5, 6, // third row
-                // second slice
-                7, 8, // first row
-                9, 10, // second row
-                11, 12 // third row
+            // first slice
+            1, 2, // first row
+            3, 4, // second row
+            5, 6, // third row
+            // second slice
+            7, 8, // first row
+            9, 10, // second row
+            11, 12 // third row
         };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", new int[] { 2, 3, 2 }, false, data);
 
@@ -121,14 +121,14 @@ class DoubleGridDataSetTests {
     @Test
     void testFullDataConstructor() {
         double[] data = new double[] {
-                // first slice
-                1, 2, // first row
-                3, 4, // second row
-                5, 6, // third row
-                // second slice
-                7, 8, // first row
-                9, 10, // second row
-                11, 12 // third row
+            // first slice
+            1, 2, // first row
+            3, 4, // second row
+            5, 6, // third row
+            // second slice
+            7, 8, // first row
+            9, 10, // second row
+            11, 12 // third row
         };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", false, new double[][] { { 0.1, 0.2 }, { 1.1, 2.2, 3.3 }, { -0.5, 0.5 } }, data);
 

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DoubleGridDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DoubleGridDataSetTests.java
@@ -25,7 +25,7 @@ import de.gsi.dataset.event.UpdateEvent;
  */
 class DoubleGridDataSetTests {
     @Test
-    public void testEmptyGridConstructor() {
+    void testEmptyGridConstructor() {
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", 3);
         assertEquals("testGridDataSet", dataset.getName());
         assertArrayEquals(new int[] { 0, 0 }, dataset.getShape());
@@ -34,7 +34,8 @@ class DoubleGridDataSetTests {
     }
 
     @Test
-    public void testZeroInitializedConstructor() {
+    void testZeroInitializedConstructor() {
+        // create a grid data set with 3rows x 4columns x 2slices
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", 5, new int[] { 3, 4, 2 });
         assertEquals("testGridDataSet", dataset.getName());
         assertArrayEquals(new int[] { 3, 4, 2 }, dataset.getShape());
@@ -52,8 +53,48 @@ class DoubleGridDataSetTests {
     }
 
     @Test
-    public void testEquidistantFullDataConstructor() {
-        double[] data = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+    void nonPermutableShape() {
+        double[] data = new double[] {
+                // first slice
+                1, 2, 3, 4, //first row
+                5, 6, 7, 8, //
+                9, 10, 11, 12, //
+                // second slice
+                13,14,15,16, // first row
+                17,18,19,20, //
+                21,22,23,24 //
+        };
+        DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", new int[] { 4, 3, 2 }, false, data);
+        assertSame(data, dataset.getValues(3));
+        assertEquals("testGridDataSet", dataset.getName());
+        assertArrayEquals(new int[] { 4, 3, 2 }, dataset.getShape());
+        assertEquals(4, dataset.getDimension());
+        assertEquals(4 * 3 * 2, dataset.getDataCount());
+        assertArrayEquals(new double[] { 0, 1, 2, 3 }, dataset.getGridValues(DIM_X));
+
+        // test grid values
+        assertEquals(3, dataset.get(DIM_X, 19));
+        assertEquals(2, dataset.get(DIM_Y, 21));
+        assertEquals(1, dataset.get(DIM_Z, 17));
+
+        // test data values
+        assertEquals(2, dataset.get(3, 1, 0, 0));
+        assertEquals(5, dataset.get(3, 0, 1, 0));
+        assertEquals(13, dataset.get(3, 0, 0, 1));
+    }
+
+    @Test
+    void testEquidistantFullDataConstructor() {
+        double[] data = new double[] {
+                // first slice
+                1, 2, // first row
+                3, 4, // second row
+                5, 6, // third row
+                // second slice
+                7, 8, // first row
+                9, 10, // second row
+                11, 12 // third row
+        };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", new int[] { 2, 3, 2 }, false, data);
 
         assertSame(data, dataset.getValues(3));
@@ -78,8 +119,17 @@ class DoubleGridDataSetTests {
     }
 
     @Test
-    public void testFullDataConstructor() {
-        double[] data = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+    void testFullDataConstructor() {
+        double[] data = new double[] {
+                // first slice
+                1, 2, // first row
+                3, 4, // second row
+                5, 6, // third row
+                // second slice
+                7, 8, // first row
+                9, 10, // second row
+                11, 12 // third row
+        };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", false, new double[][] { { 0.1, 0.2 }, { 1.1, 2.2, 3.3 }, { -0.5, 0.5 } }, data);
 
         assertEquals("testGridDataSet", dataset.getName());
@@ -93,6 +143,8 @@ class DoubleGridDataSetTests {
         assertEquals(6.0, dataset.get(3, 5));
         assertEquals(0.1, dataset.get(DIM_X, 2));
         assertEquals(2.0, dataset.get(3, 1, 0, 0));
+        assertEquals(3.0, dataset.get(3, 0, 1, 0));
+        assertEquals(11.0, dataset.get(3, 0, 2, 1));
         assertEquals(12.0, dataset.get(3, 1, 2, 1));
         assertEquals(0.2, dataset.get(DIM_X, 1, 2, 1));
         assertEquals(-0.5, dataset.get(DIM_Z, 0, 2, 0));
@@ -114,7 +166,7 @@ class DoubleGridDataSetTests {
     }
 
     @Test
-    public void testCopyConstructor() {
+    void testCopyConstructor() {
         double[] data = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", false, new double[][] { { 0.1, 0.2 }, { 1.1, 2.2, 3.3 }, { -0.5, 0.5 } }, data);
         dataset.addDataLabel(10, "test");
@@ -128,7 +180,7 @@ class DoubleGridDataSetTests {
     }
 
     @Test
-    public void testSettersAndListeners() {
+    void testSettersAndListeners() {
         double[] data = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         DoubleGridDataSet dataset = new DoubleGridDataSet("testGridDataSet", false, new double[][] { { 0.1, 0.2 }, { 1.1, 2.2, 3.3 }, { -0.5, 0.5 } }, data);
 

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
@@ -1,5 +1,8 @@
 package de.gsi.dataset.spi;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+import static de.gsi.dataset.DataSet.DIM_Z;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -10,19 +13,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static de.gsi.dataset.DataSet.DIM_X;
-import static de.gsi.dataset.DataSet.DIM_Y;
-import static de.gsi.dataset.DataSet.DIM_Z;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
 import de.gsi.dataset.AxisDescription;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.GridDataSet;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Alexander Krimm
@@ -226,28 +224,32 @@ public class TransposedDataSetTest {
         // generate 3D dataset
         final double[] xvalues = new double[] { 1, 2, 3, 4 };
         final double[] yvalues = new double[] { -3, -2, -0, 2, 4 };
-        final double[] zvalues = new double[] { 1, 2, 3, 4, //
-            5, 6, 7, 8, //
-            9, 10, 11, 12, //
-            -1, -2, -3, -4, //
-            1337, 2337, 4242, 2323 };
+        final double[] zvalues = new double[] {
+            //
+            1, 2, 3, 4, // row 0
+            5, 6, 7, 8, // row 1
+            9, 10, 11, 12, // row 2
+            -1, -2, -3, -4, // row 3
+            1337, 2337, 4242, 2323 // row 4
+        };
         final GridDataSet dataset = new DataSetBuilder("testdataset") //
                                             .setValuesNoCopy(DIM_X, xvalues) //
                                             .setValuesNoCopy(DIM_Y, yvalues) //
                                             .setValuesNoCopy(DIM_Z, zvalues) //
                                             .build(GridDataSet.class);
         assertThat(dataset, instanceOf(GridDataSet.class));
+        assertEquals(4242.0, dataset.get(DIM_Z, 4, 2));
         // transpose dataset and test indexing
         TransposedDataSet datasetTransposed = TransposedDataSet.transpose(dataset);
         assertThat(datasetTransposed, instanceOf(GridDataSet.class));
         final GridDataSet gridDatasetTransposed = (GridDataSet) datasetTransposed;
-        assertThat(gridDatasetTransposed.getShape(), equalTo(new int[] { 5, 4 }));
+        assertThat(gridDatasetTransposed.getShape(), equalTo(new int[] { 4, 5 }));
         assertEquals("testdataset", datasetTransposed.getName());
         assertEquals(20, datasetTransposed.getDataCount());
         // assertEquals(4242, datasetTransposed.get(DIM_Z, 14));
         // assertEquals(6, datasetTransposed.get(DIM_Z, 6));
         // assertEquals(7, datasetTransposed.get(DIM_Z, 11));
-        assertEquals(4242.0, gridDatasetTransposed.get(DIM_Z, 4, 2));
+        assertEquals(4242.0, gridDatasetTransposed.get(DIM_Z, 2, 4));
         assertEquals(4, gridDatasetTransposed.getGrid(DIM_Y, 3));
         assertEquals(4, gridDatasetTransposed.getGrid(DIM_X, 4));
         assertEquals(3, gridDatasetTransposed.getGridIndex(DIM_Y, 3.9));

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
@@ -6,12 +6,7 @@ import static de.gsi.dataset.DataSet.DIM_Z;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,9 +20,9 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Alexander Krimm
  */
-public class TransposedDataSetTest {
+class TransposedDataSetTest {
     @Test
-    public void testWithDataSet2D() {
+    void testWithDataSet2D() {
         DataSet dataSet = new DataSetBuilder("Test Default Data Set") //
                                   .setValuesNoCopy(DIM_X, new double[] { 1, 2, 3 }) //
                                   .setValuesNoCopy(DIM_Y, new double[] { 4, 7, 6 }) //
@@ -103,12 +98,12 @@ public class TransposedDataSetTest {
         assertEquals("", transposed2.getStyle());
         assertDoesNotThrow(() -> transposed2.setStyle("fx-color: red"));
         assertEquals("fx-color: red", transposed2.getStyle());
-        assertEquals(null, transposed2.getStyle(0));
-        assertEquals(null, transposed2.getDataLabel(0));
+        assertNull(transposed2.getStyle(0));
+        assertNull(transposed2.getDataLabel(0));
     }
 
     @Test
-    public void testWithDataSet3D() {
+    void testWithDataSet3D() {
         // generate 3D dataset
         double[] xvalues = new double[] { 1, 2, 3, 4 };
         double[] yvalues = new double[] { -3, -2, -0, 2, 4 };
@@ -220,17 +215,16 @@ public class TransposedDataSetTest {
     }
 
     @Test
-    public void testWithGridDataSet() {
+    void testWithGridDataSet() {
         // generate 3D dataset
         final double[] xvalues = new double[] { 1, 2, 3, 4 };
         final double[] yvalues = new double[] { -3, -2, -0, 2, 4 };
         final double[] zvalues = new double[] {
-            //
-            1, 2, 3, 4, // row 0
-            5, 6, 7, 8, // row 1
-            9, 10, 11, 12, // row 2
-            -1, -2, -3, -4, // row 3
-            1337, 2337, 4242, 2323 // row 4
+                1, 2, 3, 4, // row 1
+                5, 6, 7, 8,  // row 2
+                9, 10, 11, 12,  // row 3
+                -1, -2, -3, -4,  // row 4
+                1337, 2337, 4242, 2323  // row 5
         };
         final GridDataSet dataset = new DataSetBuilder("testdataset") //
                                             .setValuesNoCopy(DIM_X, xvalues) //
@@ -238,18 +232,18 @@ public class TransposedDataSetTest {
                                             .setValuesNoCopy(DIM_Z, zvalues) //
                                             .build(GridDataSet.class);
         assertThat(dataset, instanceOf(GridDataSet.class));
-        assertEquals(4242.0, dataset.get(DIM_Z, 4, 2));
+        assertEquals(4242.0, dataset.get(DIM_Z, 2, 4));
         // transpose dataset and test indexing
         TransposedDataSet datasetTransposed = TransposedDataSet.transpose(dataset);
         assertThat(datasetTransposed, instanceOf(GridDataSet.class));
         final GridDataSet gridDatasetTransposed = (GridDataSet) datasetTransposed;
-        assertThat(gridDatasetTransposed.getShape(), equalTo(new int[] { 4, 5 }));
+        assertThat(gridDatasetTransposed.getShape(), equalTo(new int[] { 5, 4 }));
         assertEquals("testdataset", datasetTransposed.getName());
         assertEquals(20, datasetTransposed.getDataCount());
         // assertEquals(4242, datasetTransposed.get(DIM_Z, 14));
         // assertEquals(6, datasetTransposed.get(DIM_Z, 6));
         // assertEquals(7, datasetTransposed.get(DIM_Z, 11));
-        assertEquals(4242.0, gridDatasetTransposed.get(DIM_Z, 2, 4));
+        assertEquals(4242.0, gridDatasetTransposed.get(DIM_Z, 4, 2));
         assertEquals(4, gridDatasetTransposed.getGrid(DIM_Y, 3));
         assertEquals(4, gridDatasetTransposed.getGrid(DIM_X, 4));
         assertEquals(3, gridDatasetTransposed.getGridIndex(DIM_Y, 3.9));
@@ -292,8 +286,7 @@ public class TransposedDataSetTest {
         assertThrows(IndexOutOfBoundsException.class, () -> gridDatasetTransposed.getGrid(DIM_X, 4));
         assertThrows(IndexOutOfBoundsException.class, () -> gridDatasetTransposed.get(DIM_Z, 1, 5));
         assertThrows(IndexOutOfBoundsException.class, () -> gridDatasetTransposed.get(DIM_Z, 4, 0));
-        // TODO: check event generation. all events should be passed through and every transposition/permutation should
-        // also trigger an event
+        // TODO: check event generation. all events should be passed through and every transposition/permutation should also trigger an event
         assertThrows(ArrayIndexOutOfBoundsException.class, () -> datasetTransposed.setPermutation(new int[] { 0, 1 }));
         assertThrows(IllegalArgumentException.class, () -> datasetTransposed.setPermutation(new int[] { 0, 1, 3 }));
         assertThrows(IllegalArgumentException.class, () -> datasetTransposed.setPermutation(new int[] { 0, 2, 1 }));
@@ -301,7 +294,7 @@ public class TransposedDataSetTest {
     }
 
     @Test
-    public void testWithMultiDimDataSet() {
+    void testWithMultiDimDataSet() {
         // generate 3D dataset
         final double[] xvalues = new double[] { 1, 2, 3, 4, 5, 6 };
         final double[] yvalues = new double[] { -3, -2, -0, 2, 4, 5 };
@@ -350,7 +343,7 @@ public class TransposedDataSetTest {
     }
 
     @Test
-    public void testInvalidData() {
+    void testInvalidData() {
         assertThrows(IllegalArgumentException.class, () -> TransposedDataSet.transpose(null));
         assertThrows(IllegalArgumentException.class, () -> TransposedDataSet.permute(null, new int[] { 1, 0 }));
         assertThrows(IllegalArgumentException.class, () -> TransposedDataSet.permute(new DefaultDataSet("test", 5), null));

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
@@ -1,21 +1,23 @@
 package de.gsi.dataset.spi;
 
-import static de.gsi.dataset.DataSet.DIM_X;
-import static de.gsi.dataset.DataSet.DIM_Y;
-import static de.gsi.dataset.DataSet.DIM_Z;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import static de.gsi.dataset.DataSet.DIM_X;
+import static de.gsi.dataset.DataSet.DIM_Y;
+import static de.gsi.dataset.DataSet.DIM_Z;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import de.gsi.dataset.AxisDescription;
 import de.gsi.dataset.DataSet;
 import de.gsi.dataset.GridDataSet;
-import org.junit.jupiter.api.Test;
 
 /**
  * @author Alexander Krimm
@@ -220,11 +222,11 @@ class TransposedDataSetTest {
         final double[] xvalues = new double[] { 1, 2, 3, 4 };
         final double[] yvalues = new double[] { -3, -2, -0, 2, 4 };
         final double[] zvalues = new double[] {
-                1, 2, 3, 4, // row 1
-                5, 6, 7, 8,  // row 2
-                9, 10, 11, 12,  // row 3
-                -1, -2, -3, -4,  // row 4
-                1337, 2337, 4242, 2323  // row 5
+            1, 2, 3, 4, // row 1
+            5, 6, 7, 8, // row 2
+            9, 10, 11, 12, // row 3
+            -1, -2, -3, -4, // row 4
+            1337, 2337, 4242, 2323 // row 5
         };
         final GridDataSet dataset = new DataSetBuilder("testdataset") //
                                             .setValuesNoCopy(DIM_X, xvalues) //

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
@@ -74,7 +74,18 @@ class MultiArrayTest {
 
     @Test
     void testMultiArrayInt() {
-        final MultiArray<int[]> array = MultiArray.wrap(new int[] { 123, 321, 213, 9, 8, 7, 6, 5, 4, 1, 2, 3, 11, 22, 33 }, 3, new int[] { 2, 3, 2 });
+        final MultiArray<int[]> array = MultiArray.wrap(
+                new int[] {
+                        123, 321, 213, // offset
+                        //row 0
+                        9, 8, // column 0
+                        7, 6, // column 1
+                        5, 4, // column 2
+                        // row 1
+                        1, 2, // column 0
+                        3,11, // column 1
+                        22, 33 // column 2
+                }, 3, new int[] { 2, 3, 2 });
         assertTrue(array instanceof MultiArrayInt);
         assertEquals(3, array.getOffset());
         final MultiArrayInt arrayInt = (MultiArrayInt) array;
@@ -97,7 +108,12 @@ class MultiArrayTest {
 
     @Test
     void testMultiArrayInt2D() {
-        final MultiArray<int[]> array = MultiArray.wrap(new int[] { 0, 0, 0, 0, 9, 8, 7, 6, 5, 4 }, 4, new int[] { 2, 3 });
+        final MultiArray<int[]> array = MultiArray.wrap(
+                new int[] {
+                        0, 0, 0, 0, // offset
+                        9, 8, 7, // row 0
+                        6, 5, 4  // row 1
+                }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayInt.MultiArray2DInt);
         final MultiArrayInt.MultiArray2DInt array2d = (MultiArrayInt.MultiArray2DInt) array;
         assertArrayEquals(new int[] { 6, 5, 4 }, array2d.getRow(1));

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
@@ -1,6 +1,9 @@
 package de.gsi.dataset.spi.utils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +29,7 @@ class MultiArrayTest {
         assertArrayEquals(new int[] { 2, 3, 2 }, arrayDouble.getDimensions());
         assertEquals(33, arrayDouble.get(new int[] { 1, 2, 1 }));
         assertEquals(7, arrayDouble.get(new int[] { 0, 1, 0 }));
-        assertEquals(8, arrayDouble.get(new int[] { 1, 0, 0 }));
+        assertEquals(1, arrayDouble.get(new int[] { 1, 0, 0 }));
         arrayDouble.set(new int[] { 1, 1, 1 }, 1.337);
         assertEquals(1.337, arrayDouble.get(new int[] { 1, 1, 1 }));
         assertArrayEquals(new double[] { 123, 321, 213, 9, 8, 7, 6, 5, 4, 1, 2, 3, 1.337, 22, 33 }, arrayDouble.elements());
@@ -44,10 +47,10 @@ class MultiArrayTest {
         final MultiArray<double[]> array = MultiArray.wrap(new double[] { 0, 0, 0, 0, 9, 8, 7, 6, 5, 4 }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayDouble.MultiArray2DDouble);
         final MultiArrayDouble.MultiArray2DDouble array2d = (MultiArrayDouble.MultiArray2DDouble) array;
-        assertArrayEquals(new double[] { 7, 6 }, array2d.getRow(1));
+        assertArrayEquals(new double[] { 6, 5, 4 }, array2d.getRow(1));
         assertEquals(4, array.getOffset());
-        assertEquals(8, ((MultiArrayDouble) array).get(new int[] { 1, 0 }));
-        assertEquals(8, array2d.get(1, 0));
+        assertEquals(6, ((MultiArrayDouble) array).get(new int[] { 1, 0 }));
+        assertEquals(6, array2d.get(1, 0));
         assertEquals(4, ((MultiArrayDouble) array).get(new int[] { 1, 2 }));
         assertEquals(4, array2d.get(1, 2));
         array2d.set(1, 2, 1.337);
@@ -79,7 +82,7 @@ class MultiArrayTest {
         assertArrayEquals(new int[] { 2, 3, 2 }, arrayInt.getDimensions());
         assertEquals(33, arrayInt.get(new int[] { 1, 2, 1 }));
         assertEquals(7, arrayInt.get(new int[] { 0, 1, 0 }));
-        assertEquals(8, arrayInt.get(new int[] { 1, 0, 0 }));
+        assertEquals(1, arrayInt.get(new int[] { 1, 0, 0 }));
         arrayInt.set(new int[] { 1, 1, 1 }, 1337);
         assertEquals(1337, arrayInt.get(new int[] { 1, 1, 1 }));
         assertArrayEquals(new int[] { 123, 321, 213, 9, 8, 7, 6, 5, 4, 1, 2, 3, 1337, 22, 33 }, arrayInt.elements());
@@ -97,10 +100,10 @@ class MultiArrayTest {
         final MultiArray<int[]> array = MultiArray.wrap(new int[] { 0, 0, 0, 0, 9, 8, 7, 6, 5, 4 }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayInt.MultiArray2DInt);
         final MultiArrayInt.MultiArray2DInt array2d = (MultiArrayInt.MultiArray2DInt) array;
-        assertArrayEquals(new int[] { 7, 6 }, array2d.getRow(1));
+        assertArrayEquals(new int[] { 6, 5, 4 }, array2d.getRow(1));
         assertEquals(4, array.getOffset());
-        assertEquals(8, ((MultiArrayInt) array).get(new int[] { 1, 0 }));
-        assertEquals(8, array2d.get(1, 0));
+        assertEquals(6, ((MultiArrayInt) array).get(new int[] { 1, 0 }));
+        assertEquals(6, array2d.get(1, 0));
         assertEquals(4, ((MultiArrayInt) array).get(new int[] { 1, 2 }));
         assertEquals(4, array2d.get(1, 2));
         array2d.set(1, 2, 1337);
@@ -138,7 +141,7 @@ class MultiArrayTest {
         assertArrayEquals(new int[] { 2, 3, 2 }, arrayFloat.getDimensions());
         assertEquals(33, arrayFloat.get(new int[] { 1, 2, 1 }));
         assertEquals(7, arrayFloat.get(new int[] { 0, 1, 0 }));
-        assertEquals(8, arrayFloat.get(new int[] { 1, 0, 0 }));
+        assertEquals(1, arrayFloat.get(new int[] { 1, 0, 0 }));
         arrayFloat.set(new int[] { 1, 1, 1 }, 1.337f);
         assertEquals(1.337f, arrayFloat.get(new int[] { 1, 1, 1 }));
         assertArrayEquals(new float[] { 123, 321, 213, 9, 8, 7, 6, 5, 4, 1, 2, 3, 1.337f, 22, 33 }, arrayFloat.elements());
@@ -156,10 +159,10 @@ class MultiArrayTest {
         final MultiArray<float[]> array = MultiArray.wrap(new float[] { 0, 0, 0, 0, 9, 8, 7, 6, 5, 4 }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayFloat.MultiArray2DFloat);
         final MultiArrayFloat.MultiArray2DFloat array2d = (MultiArrayFloat.MultiArray2DFloat) array;
-        assertArrayEquals(new float[] { 7, 6 }, array2d.getRow(1));
+        assertArrayEquals(new float[] { 6, 5, 4 }, array2d.getRow(1));
         assertEquals(4, array.getOffset());
-        assertEquals(8, ((MultiArrayFloat) array).get(new int[] { 1, 0 }));
-        assertEquals(8, array2d.get(1, 0));
+        assertEquals(6, ((MultiArrayFloat) array).get(new int[] { 1, 0 }));
+        assertEquals(6, array2d.get(1, 0));
         assertEquals(4, ((MultiArrayFloat) array).get(new int[] { 1, 2 }));
         assertEquals(4, array2d.get(1, 2));
         array2d.set(1, 2, 1.337f);
@@ -197,7 +200,7 @@ class MultiArrayTest {
         assertArrayEquals(new int[] { 2, 3, 2 }, arrayLong.getDimensions());
         assertEquals(33, arrayLong.get(new int[] { 1, 2, 1 }));
         assertEquals(7, arrayLong.get(new int[] { 0, 1, 0 }));
-        assertEquals(8, arrayLong.get(new int[] { 1, 0, 0 }));
+        assertEquals(1, arrayLong.get(new int[] { 1, 0, 0 }));
         arrayLong.set(new int[] { 1, 1, 1 }, 1337);
         assertEquals(1337, arrayLong.get(new int[] { 1, 1, 1 }));
         assertArrayEquals(new long[] { 123, 321, 213, 9, 8, 7, 6, 5, 4, 1, 2, 3, 1337, 22, 33 }, arrayLong.elements());
@@ -215,10 +218,10 @@ class MultiArrayTest {
         final MultiArray<long[]> array = MultiArray.wrap(new long[] { 0, 0, 0, 0, 9, 8, 7, 6, 5, 4 }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayLong.MultiArray2DLong);
         final MultiArrayLong.MultiArray2DLong array2d = (MultiArrayLong.MultiArray2DLong) array;
-        assertArrayEquals(new long[] { 7, 6 }, array2d.getRow(1));
+        assertArrayEquals(new long[] { 6, 5, 4 }, array2d.getRow(1));
         assertEquals(4, array.getOffset());
-        assertEquals(8, ((MultiArrayLong) array).get(new int[] { 1, 0 }));
-        assertEquals(8, array2d.get(1, 0));
+        assertEquals(6, ((MultiArrayLong) array).get(new int[] { 1, 0 }));
+        assertEquals(6, array2d.get(1, 0));
         assertEquals(4, ((MultiArrayLong) array).get(new int[] { 1, 2 }));
         assertEquals(4, array2d.get(1, 2));
         array2d.set(1, 2, 1337);
@@ -256,7 +259,7 @@ class MultiArrayTest {
         assertArrayEquals(new int[] { 2, 3, 2 }, arrayObject.getDimensions());
         assertEquals("o", arrayObject.get(new int[] { 1, 2, 1 }));
         assertEquals("f", arrayObject.get(new int[] { 0, 1, 0 }));
-        assertEquals("e", arrayObject.get(new int[] { 1, 0, 0 }));
+        assertEquals("j", arrayObject.get(new int[] { 1, 0, 0 }));
         arrayObject.set(new int[] { 1, 1, 1 }, "foobar");
         assertEquals("foobar", arrayObject.get(new int[] { 1, 1, 1 }));
         assertArrayEquals(new String[] { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "foobar", "n", "o" }, arrayObject.elements());
@@ -274,10 +277,10 @@ class MultiArrayTest {
         final MultiArray<String[]> array = MultiArray.wrap(new String[] { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j" }, 4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayObject.MultiArray2DObject);
         final MultiArrayObject.MultiArray2DObject array2d = (MultiArrayObject.MultiArray2DObject) array;
-        assertArrayEquals(new String[] { "g", "h" }, array2d.getRow(1));
+        assertArrayEquals(new String[] { "h", "i", "j" }, array2d.getRow(1));
         assertEquals(4, array.getOffset());
-        assertEquals("f", ((MultiArrayObject) array).get(new int[] { 1, 0 }));
-        assertEquals("f", array2d.get(1, 0));
+        assertEquals("h", ((MultiArrayObject) array).get(new int[] { 1, 0 }));
+        assertEquals("h", array2d.get(1, 0));
         assertEquals("j", ((MultiArrayObject) array).get(new int[] { 1, 2 }));
         assertEquals("j", array2d.get(1, 2));
         array2d.set(1, 2, "foobar");

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/utils/MultiArrayTest.java
@@ -83,9 +83,10 @@ class MultiArrayTest {
                         5, 4, // column 2
                         // row 1
                         1, 2, // column 0
-                        3,11, // column 1
+                        3, 11, // column 1
                         22, 33 // column 2
-                }, 3, new int[] { 2, 3, 2 });
+                },
+                3, new int[] { 2, 3, 2 });
         assertTrue(array instanceof MultiArrayInt);
         assertEquals(3, array.getOffset());
         final MultiArrayInt arrayInt = (MultiArrayInt) array;
@@ -112,8 +113,9 @@ class MultiArrayTest {
                 new int[] {
                         0, 0, 0, 0, // offset
                         9, 8, 7, // row 0
-                        6, 5, 4  // row 1
-                }, 4, new int[] { 2, 3 });
+                        6, 5, 4 // row 1
+                },
+                4, new int[] { 2, 3 });
         assertTrue(array instanceof MultiArrayInt.MultiArray2DInt);
         final MultiArrayInt.MultiArray2DInt array2d = (MultiArrayInt.MultiArray2DInt) array;
         assertArrayEquals(new int[] { 6, 5, 4 }, array2d.getRow(1));


### PR DESCRIPTION
The MultiArray container was documented to use row-major storage to be compatible with c++ and other existing code, but implemented as column major.

This PR fixes this discrepancy by using row-major.

Also DoubleGridData set had to be adapted, because the expectation here that colums correspond to the x-axis and rows to the y-axis, so the data has to be transposed here.

If they do not use the internal MultiArray type, nothing should change for end users, there are not modifications to the samples.