### PR TITLE
maven: set maven surefire locale to en_US

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
                     <!-- which jacoco will not instrument. Hence it is important
                         to add -->
                     <!-- those command-line params here (${argLine} holds those params) -->
-                    <argLine>${argLine} -Xms256m -Xmx2048m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
+                    <argLine>${argLine} -Duser.language=en -Duser.country=US -Xms256m -Xmx2048m -XX:G1HeapRegionSize=32m -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw</argLine>
                     <forkCount>1</forkCount>
                     <rerunFailingTestsCount>3</rerunFailingTestsCount>
                     <runOrder>random</runOrder>


### PR DESCRIPTION
Since meging #326 `mvn test` failed on systems with non US locales, due
to some tests expecting numbers to be formated according to US locale.

This fixes the locale for running the tests to `en_US` s.t. the tests
will run through regardless of the developer's locale.