### PR TITLE
Housekeeping: change default version and reduce test logging

### DIFF
--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/financial/CandleStickRendererTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/financial/CandleStickRendererTest.java
@@ -42,7 +42,7 @@ public class CandleStickRendererTest {
 
     @Start
     public void start(Stage stage) throws Exception {
-        ProcessingProfiler.setDebugState(true);
+        ProcessingProfiler.setDebugState(false); // enable for detailed renderer tracing
         ohlcvDataSet = new OhlcvDataSet("ohlc1");
         ohlcvDataSet.setData(FinancialTestUtils.createTestOhlcv());
         rendererTested = new CandleStickRenderer(true);

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/financial/HighLowRendererTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/spi/financial/HighLowRendererTest.java
@@ -42,7 +42,7 @@ public class HighLowRendererTest {
 
     @Start
     public void start(Stage stage) throws Exception {
-        ProcessingProfiler.setDebugState(true);
+        ProcessingProfiler.setDebugState(false); // enable for detailed renderer tracing
         ohlcvDataSet = new OhlcvDataSet("ohlc1");
         ohlcvDataSet.setData(FinancialTestUtils.createTestOhlcv());
         rendererTested = new HighLowRenderer(true);

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </modules>
 
     <properties>
-        <revision>11.2.0</revision>
+        <revision>master</revision>
         <changelist>-SNAPSHOT</changelist>
         <sha1 />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -370,7 +370,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Remove version number from pom, always build as master for local builds, in the CI this gets overwritten anyway and manually bumping the pom file generates unnecessary commit noise.

Disabling trace output in unit tests to keep the build logs more manageable.