### PR TITLE
TableViewer: table cells can now be selected again

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
@@ -225,7 +225,7 @@ public class TableViewer extends ChartPlugin {
                 plotForegroundChildren.remove(table);
                 table.prefWidthProperty().unbind();
                 table.prefHeightProperty().unbind();
-            } else {
+            } else { // !isTablePresent means add the table
                 plotForegroundChildren.add(table);
                 table.toFront();
                 table.prefWidthProperty().bind(getChart().getPlotForeground().widthProperty());
@@ -233,8 +233,8 @@ public class TableViewer extends ChartPlugin {
             }
 
             switchTableView.setGraphic(isTablePresent ? tableView : graphView);
-            getChart().getPlotForeground().setMouseTransparent(!isTablePresent);
-            table.setMouseTransparent(!isTablePresent);
+            getChart().getPlotForeground().setMouseTransparent(isTablePresent);
+            table.setMouseTransparent(isTablePresent);
             dsModel.datasetsChanged(null);
         });
 

--- a/chartfx-chart/src/test/java/de/gsi/chart/plugins/TableViewerTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/plugins/TableViewerTest.java
@@ -2,16 +2,11 @@ package de.gsi.chart.plugins;
 
 import static de.gsi.chart.plugins.TableViewer.BUTTON_BAR_STYLE_CLASS;
 import static de.gsi.chart.plugins.TableViewer.BUTTON_SWITCH_TABLE_VIEW_STYLE_CLASS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import javafx.scene.Node;
-import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.layout.FlowPane;
-import javafx.stage.Stage;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -26,7 +21,18 @@ import org.testfx.util.NodeQueryUtils;
 import org.testfx.util.WaitForAsyncUtils;
 
 import de.gsi.chart.XYChart;
+import de.gsi.chart.plugins.TableViewer.ColumnType;
+import de.gsi.chart.plugins.TableViewer.DataSetsRow;
+import de.gsi.dataset.DataSet;
 import de.gsi.dataset.testdata.spi.CosineFunction;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.TableView;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.FlowPane;
+import javafx.stage.Stage;
 
 /**
  * Test the table viewer plugin
@@ -38,6 +44,7 @@ class TableViewerTest {
     private final FxRobot fxRobot = new FxRobot();
     private XYChart chart;
     private TableViewer tableViewer;
+    private CosineFunction dataset;
 
     @Start
     public void start(Stage stage) {
@@ -47,7 +54,8 @@ class TableViewerTest {
         tableViewer = new TableViewer();
         chart.setPrefWidth(400);
         chart.setPrefHeight(300);
-        chart.getDatasets().add(new CosineFunction("Cosine", 50));
+        dataset = new CosineFunction("Cosine", 50);
+        chart.getDatasets().add(dataset);
         stage.setScene(scene);
         stage.show();
     }
@@ -78,6 +86,43 @@ class TableViewerTest {
         // Expect the table view to be removed after clicking the button
         fxRobot.sleep(200); // it might need some time to be gone
         FxAssert.verifyThat(chart.getPlotForeground(), Matchers.not(NodeMatchers.hasChild(".table-view")));
+    }
+    
+    @Test
+    public void testThatTableCellsAreClickable() throws TimeoutException { // NOPMD JUnitTestsShouldIncludeAssert
+        fxRobot.interact(() -> {
+            chart.getPlugins().add(tableViewer);
+            chart.setToolBarPinned(true);
+        });
+
+        // Open the table view
+        final Button switchTableViewButton = locateTableViewButton(chart.getToolBar());
+        waitForNodeToBeVisible(switchTableViewButton); // Wait for the slowly opening toolbar to show
+        fxRobot.clickOn(switchTableViewButton);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verifyThatWithTimeout(chart.getPlotForeground(), NodeMatchers.hasChild(".table-view"));
+        
+        // Make sure nothing is selected
+        @SuppressWarnings("unchecked")
+        TableView<DataSetsRow> tableView = fxRobot.from(chart.getPlotForeground()).lookup(".table-view").queryAs(TableView.class);
+        tableView.getSelectionModel().clearSelection();
+        
+        // Find a cell in the table so we can move to it using the mouse
+        final double valueAtX1 = dataset.getValue(DataSet.DIM_Y, 1);
+        final String valueValueAtX1 = Double.toString(valueAtX1);
+        final Labeled fieldValue1 = fxRobot.from(tableView).lookup(".table-cell").lookup(valueValueAtX1).queryAs(Labeled.class);
+        
+        // Move to a cell
+        fxRobot.moveTo(fieldValue1);
+        
+        // Click on it / select it
+        fxRobot.clickOn(MouseButton.PRIMARY);
+        
+        // Make sure the cell is actually selected on the model side
+        FxAssert.verifyThat(tableView.getSelectionModel().getSelectedItem(), Matchers.notNullValue());
+        DataSetsRow selectedItem = tableView.getSelectionModel().getSelectedItem();
+        assertEquals(valueAtX1, selectedItem.getValue(dataset, ColumnType.Y));
     }
 
     private Button locateTableViewButton(final FlowPane toolbar) {


### PR DESCRIPTION
TableViewer: table cells can now be selected again

- Mouse transparency was set incorrectly after commit eb7a286 (#280)

Added a test for the specific problem.

(sorry)