### PR TITLE
TableViewer: fix calls to hashCode of DataSetsRow

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/TableViewer.java
@@ -742,7 +742,7 @@ public class TableViewer extends ChartPlugin {
         public boolean equals(final Object o) {
             if (o instanceof DataSetsRow) {
                 final DataSetsRow dsr = (DataSetsRow) o;
-                return ((dsr.getRow() == row) && model.equals(dsr.getModel()));
+                return ((dsr.getRow() == row) && model == dsr.getModel());
             }
             return false;
         }
@@ -762,7 +762,7 @@ public class TableViewer extends ChartPlugin {
         @Override
         public int hashCode() {
             int hash = 7;
-            hash = 31 * hash + model.hashCode();
+            hash = 31 * hash + System.identityHashCode(model);
             hash = 31 * hash + row;
             return hash;
         }

--- a/chartfx-chart/src/test/java/de/gsi/chart/plugins/TableViewerTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/plugins/TableViewerTest.java
@@ -1,6 +1,9 @@
 package de.gsi.chart.plugins;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static de.gsi.chart.plugins.TableViewer.BUTTON_BAR_STYLE_CLASS;
 import static de.gsi.chart.plugins.TableViewer.BUTTON_SWITCH_TABLE_VIEW_STYLE_CLASS;
@@ -125,6 +128,40 @@ class TableViewerTest {
         FxAssert.verifyThat(tableView.getSelectionModel().getSelectedItem(), Matchers.notNullValue());
         DataSetsRow selectedItem = tableView.getSelectionModel().getSelectedItem();
         assertEquals(valueAtX1, selectedItem.getValue(dataset, ColumnType.Y));
+    }
+
+    @Test
+    public void testThatDataSetsRowHashCodeEqualsWorks() throws TimeoutException {
+        fxRobot.interact(() -> {
+            chart.getPlugins().add(tableViewer);
+            chart.setToolBarPinned(true);
+        });
+
+        // Open the table view
+        final Button switchTableViewButton = locateTableViewButton(chart.getToolBar());
+        waitForNodeToBeVisible(switchTableViewButton); // Wait for the slowly opening toolbar to show
+        fxRobot.clickOn(switchTableViewButton);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verifyThatWithTimeout(chart.getPlotForeground(), NodeMatchers.hasChild(".table-view"));
+
+        @SuppressWarnings("unchecked")
+        TableView<DataSetsRow> tableView = (TableView<DataSetsRow>) tableViewer.getTable();
+
+        // Equals/hashCode with self is true
+        tableView.getSelectionModel().select(0);
+        DataSetsRow firstRowItem = tableView.getSelectionModel().getSelectedItem();
+        assertEquals(firstRowItem.hashCode(), firstRowItem.hashCode());
+        assertTrue(firstRowItem.equals(firstRowItem));
+
+        // Equals/hashCode with other row is false
+        tableView.getSelectionModel().clearAndSelect(1);
+        DataSetsRow secondRowItem = tableView.getSelectionModel().getSelectedItem();
+        assertNotEquals(firstRowItem.hashCode(), secondRowItem.hashCode());
+        assertFalse(firstRowItem.equals(secondRowItem));
+
+        // Equals with other type is false
+        assertFalse(firstRowItem.equals(new Object()));
     }
 
     private Button locateTableViewButton(final FlowPane toolbar) {


### PR DESCRIPTION
While working on a bugfix for the `TableViewer` I noticed a problem when the `DataSetsRow` was added to a Hashing collection. (For example the result of a `fxRobot` lookup, resulting in a Set).

The implementation of the `DataSetsRow` `equals`/`hashCode` seem to use to the `model`\`s `equals`/`hashCode` which in turn uses the Lists default implementations. Those will in turn call it's children's methods, being the `DataSetsRows`.

Try using the original methods to see a stack overflow in the test case.

I am not sure about the best implementation of the `equals`/`hashCode` methods in this case, please see it just as a suggestion.