### PR TITLE
Proof of concept for custom temporary array allocation

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/AbstractErrorDataSetRendererParameter.java
@@ -2,6 +2,9 @@ package de.gsi.chart.renderer.spi;
 
 import java.util.Objects;
 
+import de.gsi.dataset.utils.ArrayPool;
+import de.gsi.dataset.utils.ArrayPool.DoubleArrayPool;
+import de.gsi.dataset.utils.DoubleArrayCache;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
@@ -56,6 +59,20 @@ public abstract class AbstractErrorDataSetRendererParameter<R extends AbstractEr
             AbstractErrorDataSetRendererParameter.DEFAULT_HISTORY_INTENSITY_FADING);
     private final BooleanProperty drawBubbles = new SimpleBooleanProperty(this, "drawBubbles", false);
     private final BooleanProperty allowNaNs = new SimpleBooleanProperty(this, "allowNaNs", false);
+
+    public DoubleArrayPool getArrayPool() {
+        return arrayPool.get();
+    }
+
+    public ObjectProperty<DoubleArrayPool> arrayPoolProperty() {
+        return arrayPool;
+    }
+
+    public void setArrayPool(DoubleArrayPool arrayPool) {
+        this.arrayPool.set(arrayPool);
+    }
+
+    private final ObjectProperty<DoubleArrayPool> arrayPool = new SimpleObjectProperty<>(DoubleArrayCache.getExactInstance());
 
     /**
      * 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -209,7 +209,7 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
                 }
 
                 final CachedDataPoints localCachedPoints = new CachedDataPoints(indexMin, indexMax,
-                        dataSet.getDataCount(), true);
+                        dataSet.getDataCount(), true, getArrayPool());
                 if (ProcessingProfiler.getDebugState()) {
                     stopStamp = ProcessingProfiler.getTimeDiff(stopStamp, "get CachedPoints");
                 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ArrayPool.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/ArrayPool.java
@@ -1,0 +1,17 @@
+package de.gsi.dataset.utils;
+
+/**
+ * Proof of concept for a user definable array cache
+ *
+ * @author ennerf
+ */
+public interface ArrayPool<T> {
+
+    public interface DoubleArrayPool extends ArrayPool<double[]> {
+    }
+
+    public T allocate(int requiredSize);
+
+    public void release(T array);
+
+}

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DoubleArrayCache.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/utils/DoubleArrayCache.java
@@ -82,4 +82,37 @@ public class DoubleArrayCache extends CacheCollection<double[]> {
     public static DoubleArrayCache getInstance() {
         return SELF;
     }
+
+    private static final ArrayPool.DoubleArrayPool EXACT_POOL = new ArrayPool.DoubleArrayPool() {
+        @Override
+        public double[] allocate(int requiredSize) {
+            return SELF.getArray(requiredSize, true);
+        }
+
+        @Override
+        public void release(double[] array) {
+            SELF.add(array);
+        }
+    };
+
+    private static final ArrayPool.DoubleArrayPool MINSIZE_POOL = new ArrayPool.DoubleArrayPool() {
+        @Override
+        public double[] allocate(int requiredSize) {
+            return SELF.getArray(requiredSize, false);
+        }
+
+        @Override
+        public void release(double[] array) {
+            SELF.add(array);
+        }
+    };
+
+    public static ArrayPool.DoubleArrayPool getExactInstance() {
+        return EXACT_POOL;
+    }
+
+    public static ArrayPool.DoubleArrayPool getMinSizeInstance() {
+        return MINSIZE_POOL;
+    }
+
 }


### PR DESCRIPTION
## Problem

During profiling I noticed that a noticeable performance degradation caused by a lot of temporary array allocations in `CachedDataPoints`. Each trace has a maximum number of points, but the amount of visible points can change on the selected time window and can become larger and smaller. This messes with the `getArrayExact` method and results in allocating new arrays at almost every frame.

A FlighRecording of 10 charts over 30 seconds looks like this:

![image](https://user-images.githubusercontent.com/5491587/109029659-59aad400-76c3-11eb-85ca-d4623dbde343.png)

## Custom Buffer Pool

In my case I already know the perfect buffer size, so all of that is unnecessary overhead. I created a little PR that allows users to customize the behavior a bit more, e.g., below is an example for a pool that doesn't require synchronization and doesn't allocate arrays below a certain size:

```java
public class ChartTrace extends ErrorDataSetRenderer {

    {
        setArrayPool(CustomPool.INSTANCE);
    }

    /**
     * Non thread-safe pool that is always called from the JavaFX thread,
     * and allocates arrays with at least MIN_SIZE length. Falls back to
     * the default implementation for larger arrays.
     */
    private static enum CustomPool implements DoubleArrayPool {
        INSTANCE;

        @Override
        public double[] allocate(int requiredSize) {
            FxUtils.checkFxThread();
            if (requiredSize <= MIN_SIZE) {
                return smallArrays.isEmpty() ? new double[MIN_SIZE] : smallArrays.pop();
            }
            return DoubleArrayCache.getMinSizeInstance().allocate(requiredSize);
        }

        @Override
        public void release(double[] array) {
            FxUtils.checkFxThread();
            if (array.length == MIN_SIZE) {
                smallArrays.push(array);
            } else {
                DoubleArrayCache.getMinSizeInstance().release(array);
            }
        }

        private final Stack<double[]> smallArrays = new Stack<>();
        private static final int MIN_SIZE = LiveChart.DEFAULT_MAX_SAMPLES;

    }

}
```

## Result

In my case this allocates a total of only 6 buffers over the entire lifetime of the app. The rendering performance at higher loads is noticeably smoother

![image](https://user-images.githubusercontent.com/5491587/109030638-43e9de80-76c4-11eb-987d-82d9b19fb66a.png)

