### PR TITLE
ci: allow to restart deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           gpg-passphrase: GPG_PASS
       - name: Deploy to Github Packages
         run: if [ -z "$CHANGELIST" ]; then mvn -DskipTests --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dchangelist=${CHANGELIST} -Drelease=github deploy; fi
+        continue-on-error: true # allows to restart the deployment step and not have the existing deployed github package prevent publishing to maven central
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
When the deployment is restarted after having already partialy deployed,
the existing artifacts on github block the action from uploading the
artifacts to ossrh/mavencentral.
This commit allows the github action to fail, so that the maven central
artifacts are uploaded anyway. The downside is that failures to upload
to github will not be indicated correctly, but as maven central is our
main distribution channel, this should be ok.