### PR TITLE
Add javadoc and source jars creation to pom.xml

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/CandleStickRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/CandleStickRenderer.java
@@ -30,7 +30,7 @@ import de.gsi.dataset.spi.financial.api.ohlcv.IOhlcvItemAware;
 import de.gsi.dataset.utils.ProcessingProfiler;
 
 /**
- * <h1>Candlestick renderer</h1>
+ * <h2>Candlestick renderer</h2>
  *<p>
  * A candlestick chart (also called Japanese candlestick chart) is a style of financial chart used to describe price movements of a security,
  * derivative, or currency.

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/HighLowRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/HighLowRenderer.java
@@ -30,7 +30,7 @@ import de.gsi.dataset.spi.financial.api.ohlcv.IOhlcvItemAware;
 import de.gsi.dataset.utils.ProcessingProfiler;
 
 /**
- * <h1>High-Low renderer (OHLC-V/OI Chart)</h1>
+ * <h2>High-Low renderer (OHLC-V/OI Chart)</h2>
  *<p>
  * An open-high-low-close chart (also OHLC) is a type of chart typically used to illustrate movements in the price of a financial instrument over time.
  * Each vertical line on the chart shows the price range (the highest and lowest prices) over one unit of time, e.g., one day or one hour.

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/PositionFinancialRendererPaintAfterEP.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/PositionFinancialRendererPaintAfterEP.java
@@ -18,7 +18,7 @@ import de.gsi.chart.utils.StyleParser;
 import de.gsi.dataset.DataSet;
 
 /**
- * <h1>Position renderer PaintAfter Extension Point</h1>
+ * <h2>Position renderer PaintAfter Extension Point</h2>
  *<p>
  * A position is the amount of a security, asset, or property that is owned (or sold short) by some individual or other entity.
  * A trader or investor takes a position when they make a purchase through a buy order, signaling bullish intent; or if they sell short securities with bearish intent.

--- a/chartfx-chart/src/main/java/de/gsi/chart/ui/HiddenSidesPane.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/ui/HiddenSidesPane.java
@@ -31,9 +31,9 @@ import javafx.util.Duration;
  * The hidden node will appear (at its preferred width or height) with a short slide-in animation. The node will
  * disappear again as soon as the mouse cursor exits it. A hidden node / side can also be pinned by calling
  * {@link #setPinnedSide(Side)}. It will remain visible as long as it stays pinned.
- * <h3>Screenshot</h3> The following screenshots shows the right side node hovering over a table after it was made
+ * <h2>Screenshot</h2> The following screenshots shows the right side node hovering over a table after it was made
  * visible: <img src="hiddenSidesPane.png" alt="Screenshot of HiddenSidesPane">
- * <h3>Code Sample</h3>
+ * <h2>Code Sample</h2>
  *
  * <pre>
  * HiddenSidesPane pane = new HiddenSidesPane();
@@ -375,5 +375,4 @@ public class HiddenSidesPane extends Control {
     public final DoubleProperty triggerDistanceProperty() {
         return triggerDistance;
     }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/ui/SidesPane.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/ui/SidesPane.java
@@ -23,9 +23,9 @@ import de.gsi.chart.ui.geometry.Side;
  * The hidden node will appear (at its preferred width or height) with a short slide-in animation. The node will
  * disappear again as soon as the mouse cursor exits it. A hidden node / side can also be pinned by calling
  * {@link #setPinned(Side,Boolean)}. It will remain visible as long as it stays pinned.
- * <h3>Screenshot</h3> The following screenshots shows the right side node hovering over a table after it was made
+ * <h2>Screenshot</h2> The following screenshots shows the right side node hovering over a table after it was made
  * visible: <img src="hiddenSidesPane.png" alt="Screenshot of HiddenSidesPane">
- * <h3>Code Sample</h3>
+ * <h2>Code Sample</h2>
  *
  * <pre>
  * SidesPane pane = new SidesPane();

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,30 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${chartfx.surefire.version}</version>
                 <configuration>


### PR DESCRIPTION
Re-add the generation of javadoc and source jars (got accidentally removed during the move to gh-actions and pom cleanup).
Needed for maven central/ossrh to accept releases.