### PR TITLE
Fix data reduction for data containing NaN values

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ as jvm flags. Adding the following to the java command line call or your IDEs ru
 modules available and accessible to chartfx:
 
 ```
---add-modules=javafx.swing,javafx.graphics,javafx.fxml,javafx.media,javafx.web
+--add-modules=javafx.graphics,javafx.fxml,javafx.media
 --add-reads javafx.graphics=ALL-UNNAMED
 --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED
 --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED
@@ -370,7 +370,13 @@ modules available and accessible to chartfx:
 --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED
 --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED`
+--add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED
 ```
+
+As these parameters might change as dependencies get updated and depending on the way your project is set up,
+please check the following resources if you encounter problems with module accessibility:
+- [ControlsFX wiki about module visibility problems](https://github.com/controlsfx/controlsfx/wiki/Using-ControlsFX-with-JDK-9-and-above#understanding-exceptions)
+- [Blogpost with a brief explanation about the different parameters and how to use them](https://nipafx.dev/five-command-line-options-hack-java-module-system/)
 
 ### Extending chartfx
 If you find yourself missing some feature or not being able to access specific chart internals, the way to go is often to

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -84,13 +84,13 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
 
         final int dsLayoutIndexOffset = layoutOffset == null ? 0 : layoutOffset; // TODO: rationalise
 
-        final int plotingIndex = dsLayoutIndexOffset + (dsIndexLocal == null ? dsIndex : dsIndexLocal);
+        final int plottingIndex = dsLayoutIndexOffset + (dsIndexLocal == null ? dsIndex : dsIndexLocal);
 
         gc.save();
 
-        DefaultRenderColorScheme.setLineScheme(gc, dataSet.getStyle(), plotingIndex);
+        DefaultRenderColorScheme.setLineScheme(gc, dataSet.getStyle(), plottingIndex);
         DefaultRenderColorScheme.setGraphicsContextAttributes(gc, dataSet.getStyle());
-        DefaultRenderColorScheme.setFillScheme(gc, dataSet.getStyle(), plotingIndex);
+        DefaultRenderColorScheme.setFillScheme(gc, dataSet.getStyle(), plottingIndex);
         if (getErrorType() == ErrorStyle.ERRORBARS) {
             final double x = width / 2.0;
             final double y = height / 2.0;

--- a/chartfx-chart/src/test/java/de/gsi/chart/renderer/datareduction/DefaultDataReducerTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/renderer/datareduction/DefaultDataReducerTests.java
@@ -1,0 +1,194 @@
+package de.gsi.chart.renderer.datareduction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests to verify that the DataReductionAlgorithm is working correctly
+ *
+ * @author akrimm
+ */
+public class DefaultDataReducerTests {
+    @Test
+    void testProperties() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        dataReducer.setMinPointPixelDistance(3);
+        assertEquals(3, dataReducer.getMinPointPixelDistance());
+        assertEquals(3, dataReducer.minPointPixelDistanceProperty().get());
+        assertThrows(IllegalArgumentException.class, () -> dataReducer.setMinPointPixelDistance(-1));
+    }
+
+    @Test
+    void testNoErrors() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, null, null, styles, selected, min, max);
+        assertEquals(xValues.length, result);
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, null, null, styles, selected, min, max);
+        assertEquals(Math.ceil(xValues.length / 2.0) + 1, result2); // inconsistency: min distance is counted from first point after integrated points
+        assertArrayEquals(new double[] { 0, 4, 10, 18, 26, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, 3, 5, 7, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+
+    @Test
+    void testNoErrorsNaN() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, Double.NaN, 4, 5, 6, Double.NaN, Double.NaN, 9 };
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, null, null, styles, selected, min, max);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, null, null, styles, selected, min, max);
+        assertEquals(8, result2); // check if duplicate NaN should be removed
+        assertArrayEquals(new double[] { 0, 4, 8, 12, 18, 24, 28, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, Double.NaN, 4, 5, Double.NaN, Double.NaN, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+
+    @Test
+    void testYErrors() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        final double[] yErrorsNeg = new double[xValues.length];
+        final double[] yErrorsPos = new double[xValues.length];
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(6, result2); // check if duplicate NaN should be removed
+        assertArrayEquals(new double[] { 0, 4, 10, 18, 26, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, 3, 5, 7, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+
+    @Test
+    void testYErrorsNaNs() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, Double.NaN, 4, 5, 6, Double.NaN, Double.NaN, 9 };
+        final double[] yErrorsNeg = new double[xValues.length];
+        final double[] yErrorsPos = new double[xValues.length];
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, null, null, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(8, result2); // check if duplicate NaN should be removed
+        assertArrayEquals(new double[] { 0, 4, 8, 12, 18, 24, 28, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, Double.NaN, 4, 5, Double.NaN, Double.NaN, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+    @Test
+    void testXYErrors() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        final double[] xErrorsNeg = new double[xValues.length];
+        final double[] xErrorsPos = new double[xValues.length];
+        final double[] yErrorsNeg = new double[xValues.length];
+        final double[] yErrorsPos = new double[xValues.length];
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, xErrorsPos, xErrorsNeg, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, xErrorsPos, xErrorsNeg, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(6, result2); // check if duplicate NaN should be removed
+        assertArrayEquals(new double[] { 0, 4, 10, 18, 26, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, 3, 5, 7, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+
+    @Test
+    void testXYErrorsNaN() {
+        final DefaultDataReducer dataReducer = new DefaultDataReducer();
+        // test nop action (no reduction)
+        dataReducer.setMinPointPixelDistance(3);
+        final double[] xValues = new double[] { 0, 4, 8, 12, 16, 20, 24, 28, 32 };
+        final double[] yValues = new double[] { 1, 2, Double.NaN, 4, 5, 6, Double.NaN, Double.NaN, 9 };
+        final double[] xErrorsNeg = new double[xValues.length];
+        final double[] xErrorsPos = new double[xValues.length];
+        final double[] yErrorsNeg = new double[xValues.length];
+        final double[] yErrorsPos = new double[xValues.length];
+        final String[] styles = new String[xValues.length];
+        final boolean[] selected = new boolean[xValues.length];
+        final int min = 0;
+        final int max = xValues.length;
+        final double[] xValuesResult = xValues.clone();
+        final double[] yValuesResult = yValues.clone();
+        final int result = dataReducer.reducePoints(xValuesResult, yValuesResult, xErrorsPos, xErrorsNeg, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        assertArrayEquals(xValues, xValuesResult);
+        assertArrayEquals(yValues, yValuesResult);
+
+        // reduce every second point
+        dataReducer.setMinPointPixelDistance(6);
+        assertEquals(xValues.length, result); // could possibly remove the duplicate NaN
+        final int result2 = dataReducer.reducePoints(xValuesResult, yValuesResult, xErrorsPos, xErrorsNeg, yErrorsPos, yErrorsNeg, styles, selected, min, max);
+        assertEquals(8, result2); // check if duplicate NaN should be removed
+        assertArrayEquals(new double[] { 0, 4, 8, 12, 18, 24, 28, 32 }, Arrays.copyOfRange(xValuesResult, 0, result2));
+        assertArrayEquals(new double[] { 1, 2, Double.NaN, 4, 5, Double.NaN, Double.NaN, 9 }, Arrays.copyOfRange(yValuesResult, 0, result2));
+    }
+}


### PR DESCRIPTION
For charts with the ErrorDataSetRenderer with setNaNAllowed(true) and data reduction enabled, there the last data point before a gap caused by a NaN value was dropped (see #413 ).
Additionally when zooming out, there where spurious lines after the gap caused by the reduction algorithm not being correctly reset encountered by me and also independently reported by @dedeibel.

This PR adds a unit test for the DefaultDataReducer for all different error modes, fixes the bugs in the DefaultDataReducer and also adds the relevant parameters and sample data to the ErrorDataSetRendererStylingSample.

I compared performance with the ErrorDataSetRendererSample and the ErrorDataSetRendererStylingSample and could not make out a measurable difference.

Additionally I updated the jpms java-vm arguments in the README and linked to some troubleshooting resources there in response to #409.