### PR TITLE
Allow the ci to be run for external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: Java CI
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 env:
   JAVA_REFERENCE_VERSION: 11
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,7 +2,11 @@
 name: Static analysis with Coverity
 
 on:
-  workflow_dispatch: # allow to request runs manually from the actions tab
+  workflow_run: # to allow coverity to be run for forked branches, run this on the head branch but checkout the original head
+    workflows:
+      - dispatch_coverity
+    types:
+      - completed
   push:
     tags: 11\.[0-9]+\.[0-9]+ # run on each version release
   schedule:
@@ -14,7 +18,16 @@ jobs:
     runs-on: ubuntu-18.04
     environment: coverity # environment needs to be manually triggered only use on demand
     steps:
+      - name: Checkout branch on that the Coverity scan was dispatched
+        uses: actions/checkout@v2
+        if: ${{ github.event_name == 'workflow_run' }}
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 25
       - uses: actions/checkout@v2
+        if: ${{ github.event_name != 'workflow_run' }}
+        with:
+          fetch-depth: 25
       - name: Set version environment for version string
         run: |
           export REV=${GITHUB_REF#refs/*/}

--- a/.github/workflows/dispatch_coverity.yml
+++ b/.github/workflows/dispatch_coverity.yml
@@ -1,0 +1,12 @@
+---
+name: dispatch_coverity
+
+on: workflow_dispatch
+
+jobs:
+  dispatch_coverity:
+    name: Dispatch static analysis with coverity
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Dispatch
+        run: echo "Dispatching Coverity run"


### PR DESCRIPTION
Uses the workflows defined on mater to run pull requests so that the
secrets are available.
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
For the coverity scan action we have to add an indirection via
workflow_dispatch -> workflow_run to have them run with the api token.
https://stackoverflow.com/a/65081720/2411625