### PR TITLE
fixes #383: inverted non-auto-range axes defaulting to +-1

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -100,7 +100,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     // cache for minor tick marks (N.B. usually w/o string label)
     protected final transient Map<Double, TickMark> tickMarkDoubleCache = new SoftHashMap<>(MAX_TICK_COUNT * DEFAULT_MINOR_TICK_COUNT);
 
-    public AbstractAxis() {
+    protected AbstractAxis() {
         super();
         setMouseTransparent(false);
         setPickOnBounds(true);
@@ -158,7 +158,6 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         });
 
         invertAxisProperty().addListener((ch, o, n) -> Platform.runLater(() -> {
-            clear();
             invalidateCaches();
             forceRedraw();
         }));
@@ -167,7 +166,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         HBox.setHgrow(this, Priority.ALWAYS);
     }
 
-    public AbstractAxis(final double lowerBound, final double upperBound) {
+    protected AbstractAxis(final double lowerBound, final double upperBound) {
         this();
         set(lowerBound, upperBound);
         setAutoRanging(false);
@@ -380,7 +379,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     public void recomputeTickMarks() {
         final double axisLength = getSide().isVertical() ? getHeight() : getWidth(); // [pixel]
-        AxisRange newAxisRange = getRange();
+        final var newAxisRange = getRange();
         final double mTickUnit = computePreferredTickUnit(axisLength);
         if (getRange().getMin() != getMin() || getRange().getMax() != getMax()) {
             set(getRange().getMin(), getRange().getMax());
@@ -479,7 +478,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
      */
     protected double calculateNewScale(final double length, final double lowerBound, final double upperBound) {
         double newScale;
-        final Side side = getSide();
+        final var side = getSide();
         final double diff = upperBound - lowerBound;
         if (side.isVertical()) {
             newScale = diff == 0 ? -length : -(length / diff);
@@ -501,7 +500,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
      */
     @Override
     protected double computePrefHeight(final double width) {
-        final Side side = getSide();
+        final var side = getSide();
         if ((side == null) || (side == Side.CENTER_HOR) || side.isVertical()) {
             // default axis size for uninitalised axis
             return 150;
@@ -525,9 +524,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         final String axisLabelText = axisLabel.getText();
         final double labelHeight = (axisLabelText == null) || axisLabelText.isEmpty() ? 0 : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
         final double shiftedLabels = ((getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT) && isLabelOverlapping())
-                                                     || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
-                                             ? labelHeight
-                                             : 0.0;
+                                                  || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
+                                           ? labelHeight
+                                           : 0.0;
         return tickMarkLength + maxLabelHeightLocal + labelHeight + shiftedLabels;
     }
 
@@ -539,7 +538,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
      */
     @Override
     protected double computePrefWidth(final double height) {
-        final Side side = getSide();
+        final var side = getSide();
         if ((side == null) || (side == Side.CENTER_VER) || side.isHorizontal()) {
             // default axis size for uninitalised axis
             return 150;
@@ -561,9 +560,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         final double labelHeight = (axisLabelText == null) || axisLabelText.isEmpty() ? 0 : axisLabel.prefHeight(-1) + (2 * getAxisLabelGap());
 
         final double shiftedLabels = ((getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT) && isLabelOverlapping())
-                                                     || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
-                                             ? labelHeight
-                                             : 0.0;
+                                                  || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
+                                           ? labelHeight
+                                           : 0.0;
         return maxLabelWidthLocal + tickMarkLength + labelHeight + shiftedLabels;
     }
 
@@ -581,7 +580,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     protected abstract AxisRange computeRange(double minValue, double maxValue, double axisLength, double labelSize);
 
     protected List<TickMark> computeTickMarks(final AxisRange range, final boolean majorTickMark) {
-        final Side side = getSide();
+        final var side = getSide();
         final List<TickMark> oldTickMarks = majorTickMark ? getTickMarks() : getMinorTickMarks();
         if (side == null) {
             return oldTickMarks;
@@ -624,7 +623,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             final double tickPosition = getDisplayPosition(tickValue);
             final String tickMarkLabel = majorTickMark ? getTickMarkLabel(tickValue) : "";
 
-            final TickMark tick = getNewTickMark(tickValue, tickPosition, tickMarkLabel);
+            final var tick = getNewTickMark(tickValue, tickPosition, tickMarkLabel);
             newTickMarkList.add(tick);
 
             maxLabelHeight = Math.max(maxLabelHeight, tick.getHeight());
@@ -633,7 +632,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             if (majorTickMark && shouldAnimate()) {
                 tick.setOpacity(0);
 
-                final FadeTransition ft = new FadeTransition(Duration.millis(750), tick);
+                final var ft = new FadeTransition(Duration.millis(750), tick);
                 tick.opacityProperty().addListener((ch, o, n) -> {
                     clearAxisCanvas(canvas.getGraphicsContext2D(), width, height);
                     drawAxis(canvas.getGraphicsContext2D(), width, height);
@@ -680,9 +679,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // vertical axis)
         final double tickLabelSize = isHorizontal ? maxLabelHeight : maxLabelWidth;
         final double shiftedLabels = ((getOverlapPolicy() == AxisLabelOverlapPolicy.SHIFT_ALT) && isLabelOverlapping())
-                                                     || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
-                                             ? tickLabelSize + tickLabelGap
-                                             : 0.0;
+                                                  || (getOverlapPolicy() == AxisLabelOverlapPolicy.FORCED_SHIFT_ALT)
+                                           ? tickLabelSize + tickLabelGap
+                                           : 0.0;
 
         // save css-styled label parameters
         gc.save();
@@ -834,7 +833,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         // numerical number and not actual readability), thus sticking to 'for'
         // loops
 
-        final TickMark firstTick = tickMarks.get(0);
+        final var firstTick = tickMarks.get(0);
         gc.setGlobalAlpha(firstTick.getOpacity());
         int counter = ((int) firstTick.getValue()) % 2;
 
@@ -1130,7 +1129,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             return;
         }
 
-        final Side side = getSide();
+        final var side = getSide();
         if (side == null) {
             return;
         }
@@ -1143,7 +1142,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         final boolean tickUnitDiffers = getTickUnit() != preferredTickUnit;
         final boolean lengthDiffers = oldAxisLength != axisLength;
         final boolean rangeDiffers = oldAxisMin != getMin() || oldAxisMax != getMax() || oldTickUnit != getTickUnit();
-        boolean recomputedTicks = false;
+        var recomputedTicks = false;
         if (lengthDiffers || rangeDiffers || tickUnitDiffers) {
             recomputedTicks = true;
 
@@ -1192,13 +1191,13 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
                 // fall through to SKIP_ALT
                 // $FALL-THROUGH$
             case SKIP_ALT:
-                int numLabelsToSkip = 0;
+                var numLabelsToSkip = 0;
                 if ((maxLabelSize > 0) && (axisLength < totalLabelsSize)) {
                     numLabelsToSkip = (int) (projectedLengthFromIndividualMarks / axisLength);
                     labelOverlap = true;
                 }
                 if (numLabelsToSkip > 0) {
-                    int tickIndex = 0;
+                    var tickIndex = 0;
                     for (final TickMark m : majorTickMarks) {
                         if (m.isVisible()) {
                             m.setVisible((tickIndex++ % numLabelsToSkip) == 0);
@@ -1233,7 +1232,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
         }
 
         // draw minor / major tick marks on canvas
-        final GraphicsContext gc = canvas.getGraphicsContext2D();
+        final var gc = canvas.getGraphicsContext2D();
         clearAxisCanvas(gc, canvas.getWidth(), canvas.getHeight());
         drawAxis(gc, axisWidth, axisHeight);
 
@@ -1247,10 +1246,10 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     private static boolean checkOverlappingLabels(final int start, final int stride,
             ObservableList<TickMark> majorTickMarks, Side side, double gap, boolean isInverted, boolean makeInvisible) {
-        boolean labelHidden = false;
+        var labelHidden = false;
         TickMark lastVisible = null;
         for (int i = start; i < majorTickMarks.size(); i += stride) {
-            final TickMark current = majorTickMarks.get(i);
+            final var current = majorTickMarks.get(i);
             if (!current.isVisible()) {
                 continue;
             }
@@ -1266,13 +1265,12 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     protected double measureTickMarkLength(final Double major) {
         // N.B. this is a known performance hot-spot -> start optimisation here
-        final TickMark tick = getNewTickMark(major, 0.0 /* NA */, getTickMarkLabel(major));
+        final var tick = getNewTickMark(major, 0.0 /* NA */, getTickMarkLabel(major));
         return getSide().isHorizontal() ? tick.getWidth() : tick.getHeight();
     }
 
     protected void recomputeTickMarks(final AxisRange range) { // NOPMD -- complexity is unavoidable
-        final Side side = getSide();
-        if (side == null) {
+        if (getSide() == null) {
             return;
         }
 
@@ -1325,9 +1323,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
             if (!callCssUpdater) {
                 callCssUpdater = true;
                 // repaint 20 ms later in case this was just a burst operation
-                final KeyFrame kf1 = new KeyFrame(Duration.millis(20), e -> requestLayout());
+                final var kf1 = new KeyFrame(Duration.millis(20), e -> requestLayout());
 
-                final Timeline timeline = new Timeline(kf1);
+                final var timeline = new Timeline(kf1);
                 Platform.runLater(timeline::play);
             }
 

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import de.gsi.chart.utils.PeriodicScreenCapture;
 import de.gsi.financial.samples.*;
+import de.gsi.misc.samples.LimitsSample;
 
 /**
  * @author rstein
@@ -34,9 +35,9 @@ public class RunChartSamples extends Application {
 
     @Override
     public void start(final Stage primaryStage) {
-        final BorderPane root = new BorderPane();
+        final var root = new BorderPane();
 
-        final FlowPane buttons = new FlowPane();
+        final var buttons = new FlowPane();
         buttons.setAlignment(Pos.CENTER_LEFT);
         root.setCenter(buttons);
         root.setBottom(makeScreenShot);
@@ -69,6 +70,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("HistogramSample", new HistogramSample()));
         buttons.getChildren().add(new MyButton("HistoryDataSetRendererSample", new HistoryDataSetRendererSample()));
         buttons.getChildren().add(new MyButton("LabelledMarkerSample", new LabelledMarkerSample()));
+        buttons.getChildren().add(new MyButton("LimitsSample", new LimitsSample()));
         buttons.getChildren().add(new MyButton("LogAxisSample", new LogAxisSample()));
         buttons.getChildren().add(new MyButton("MetaDataRendererSample", new MetaDataRendererSample()));
         buttons.getChildren().add(new MyButton("MountainRangeRendererSample", new MountainRangeRendererSample()));
@@ -80,6 +82,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("RollingBufferSortedTreeSample", new RollingBufferSortedTreeSample()));
         buttons.getChildren().add(new MyButton("ScatterAndBubbleRendererSample", new ScatterAndBubbleRendererSample()));
         buttons.getChildren().add(new MyButton("SimpleChartSample", new SimpleChartSample()));
+        buttons.getChildren().add(new MyButton("SimpleInvertedChartSample", new SimpleInvertedChartSample()));
         buttons.getChildren().add(new MyButton("TimeAxisRangeSample", new TimeAxisRangeSample()));
         buttons.getChildren().add(new MyButton("TimeAxisSample", new TimeAxisSample()));
         buttons.getChildren().add(new MyButton("TransposedDataSetSample", new TransposedDataSetSample()));
@@ -88,9 +91,9 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("WriteDataSetToFileSample", new WriteDataSetToFileSample()));
         buttons.getChildren().add(new MyButton("ZoomerSample", new ZoomerSample()));
 
-        final Scene scene = new Scene(root);
+        final var scene = new Scene(root);
 
-        primaryStage.setTitle(this.getClass().getSimpleName());
+        primaryStage.setTitle(getClass().getSimpleName());
         primaryStage.setScene(scene);
         primaryStage.setOnCloseRequest(evt -> Platform.exit());
         primaryStage.show();
@@ -103,7 +106,7 @@ public class RunChartSamples extends Application {
         Application.launch(args);
     }
 
-    protected class MyButton extends Button {
+    protected class MyButton extends Button { // NOPMD NOSONAR -- 8 parents
         public MyButton(final String buttonText, final Application run) {
             super(buttonText);
             setOnAction(e -> {
@@ -117,17 +120,13 @@ public class RunChartSamples extends Application {
                             try {
                                 Thread.sleep(2000);
                                 Platform.runLater(() -> {
-                                    LOGGER.atInfo()
-                                            .log("make screen shot to file of " + run.getClass().getSimpleName());
-                                    final PeriodicScreenCapture screenCapture = new PeriodicScreenCapture(path,
-                                            run.getClass().getSimpleName(), stage.getScene(), DEFAULT_DELAY,
-                                            DEFAULT_PERIOD, false);
-                                    screenCapture.performScreenCapture();
+                                    LOGGER.atInfo().log("make screen shot to file of " + run.getClass().getSimpleName());
+                                    new PeriodicScreenCapture(path, run.getClass().getSimpleName(), stage.getScene(),
+                                            DEFAULT_DELAY, DEFAULT_PERIOD, false)
+                                            .performScreenCapture();
                                 });
-                            } catch (final InterruptedException e12) {
-                                if (LOGGER.isErrorEnabled()) {
-                                    LOGGER.atError().setCause(e12).log("InterruptedException");
-                                }
+                            } catch (final InterruptedException e12) { // NOPMD NOSONAR - intercepting exception is OK in this logged context
+                                LOGGER.atError().setCause(e12).log("InterruptedException");
                             }
                         }).start();
                     }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/SimpleInvertedChartSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/SimpleInvertedChartSample.java
@@ -1,0 +1,104 @@
+package de.gsi.chart.samples;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.CrosshairIndicator;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.dataset.event.UpdatedDataEvent;
+import de.gsi.dataset.spi.DoubleDataSet;
+
+/**
+ * Simple example of how to use the chart class with inverted axes
+ *
+ * @author rstein
+ */
+public class SimpleInvertedChartSample extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleInvertedChartSample.class);
+    private static final int N_SAMPLES = 100; // default number of data points
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final var xAxis = new DefaultNumericAxis();
+        xAxis.setAutoRanging(false);
+        xAxis.setAutoGrowRanging(false);
+        xAxis.set(0, 100);
+
+        final var yAxis = new DefaultNumericAxis();
+        yAxis.setAutoRangePadding(0.5); // here: 50% padding on top and bottom of axis
+        yAxis.setAutoRanging(false);
+        yAxis.setAutoGrowRanging(false);
+        yAxis.set(-2.0, +2.0); // auto-range padding is overwritten by user-defined range
+
+        final var chart = new XYChart(xAxis, yAxis);
+        chart.getPlugins().addAll(new Zoomer(), new CrosshairIndicator(), new EditAxis()); // standard plugin, useful for most cases
+
+        final var dataSet1 = new DoubleDataSet("data set #1");
+        final var dataSet2 = new DoubleDataSet("data set #2");
+
+        // some custom listeners (optional)
+        dataSet1.addListener(evt -> LOGGER.atInfo().log("dataSet1 - event: " + evt.toString()));
+        dataSet2.addListener(evt -> LOGGER.atInfo().log("dataSet2 - event: " + evt.toString()));
+
+        // chart.getDatasets().add(dataSet1); // for single data set
+        chart.getDatasets().addAll(dataSet1, dataSet2); // for two data sets
+
+        final var xValues = new double[N_SAMPLES];
+        final var yValues1 = new double[N_SAMPLES];
+        dataSet2.autoNotification().set(false); // to suppress auto notification
+        for (var x = 0; x < N_SAMPLES; x++) {
+            final double y1 = Math.cos(Math.toRadians(10.0 * x));
+            final double y2 = Math.sin(Math.toRadians(10.0 * x));
+            xValues[x] = x;
+            yValues1[x] = y1;
+            dataSet2.add(x, y2); // style #1 how to set data, notifies re-draw for every 'add'
+        }
+        dataSet1.set(xValues, yValues1); // style #2 how to set data, notifies once per set
+        // to manually trigger an update (optional):
+        dataSet2.autoNotification().set(true); // to suppress auto notification
+        dataSet2.invokeListener(new UpdatedDataEvent(dataSet2 /* pointer to update source */, "manual update event"));
+
+        // alternatively (optional via default constructor):
+        // final DoubleDataSet dataSet3 = new DoubleDataSet("data set #1", xValues, yValues1, N_SAMPLES, false)
+
+        VBox.setVgrow(chart, Priority.ALWAYS);
+        final var autoX = new CheckBox("auto-range ");
+        autoX.selectedProperty().bindBidirectional(xAxis.autoRangingProperty());
+        final var autoY = new CheckBox("auto-range ");
+        autoY.selectedProperty().bindBidirectional(yAxis.autoRangingProperty());
+
+        final var invertAxisX = new CheckBox("invert ");
+        invertAxisX.setSelected(false);
+        invertAxisX.selectedProperty().bindBidirectional(xAxis.invertAxisProperty());
+
+        final var invertAxisY = new CheckBox("invert ");
+        invertAxisY.setSelected(false);
+        invertAxisY.selectedProperty().bindBidirectional(yAxis.invertAxisProperty());
+
+        final var scene = new Scene(new VBox(new HBox(new Label("X axis: "), autoX, invertAxisX, new Label(" Y axis: "), autoY, invertAxisY), chart), 800, 600);
+        primaryStage.setTitle(getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/misc/samples/LimitsSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/misc/samples/LimitsSample.java
@@ -1,0 +1,71 @@
+package de.gsi.misc.samples;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.chart.renderer.ErrorStyle;
+import de.gsi.chart.renderer.spi.ErrorDataSetRenderer;
+import de.gsi.chart.ui.HiddenSidesPane;
+import de.gsi.dataset.spi.DoubleErrorDataSet;
+import de.gsi.math.MathBaseFast;
+
+/**
+ * Sample to illustrate limits
+ *
+ * @author rstein
+ */
+public class LimitsSample extends Application {
+    private static final int N_SAMPLES = 100;
+    private static final int WIDTH = 1200;
+    private static final int HEIGHT = 600;
+
+    @Override
+    public void start(final Stage primaryStage) {
+        var xAxis = new DefaultNumericAxis("time", "s");
+        var yAxis = new DefaultNumericAxis("y-value", "a.u.");
+        var chart = new XYChart(xAxis, yAxis);
+        final HiddenSidesPane hiddenSidePane = chart.getPlotArea();
+        hiddenSidePane.setTriggerDistance(0);
+
+        chart.getPlugins().add(new Zoomer());
+        chart.getPlugins().add(new EditAxis());
+        ErrorDataSetRenderer rendererValue = (ErrorDataSetRenderer) chart.getRenderers().get(0);
+        rendererValue.setDrawMarker(true);
+        var rendererLimits = new ErrorDataSetRenderer();
+        rendererLimits.setErrorType(ErrorStyle.ERRORSURFACE);
+        rendererLimits.setDrawMarker(false);
+        chart.getRenderers().add(rendererLimits);
+
+        var upperLimit = new DoubleErrorDataSet("upper limit");
+        upperLimit.setStyle("showInLegend=false; strokeColor=darkgreen");
+        var lowerLimit = new DoubleErrorDataSet("lower limit");
+        lowerLimit.setStyle("showInLegend=false; strokeColor=darkred");
+        var dataSet = new DoubleErrorDataSet("some dataset");
+        dataSet.setStyle("markerSize=3; markerColor=violet; markerType=diamond");
+        rendererValue.getDatasets().add(dataSet);
+        rendererLimits.getDatasets().addAll(upperLimit, lowerLimit);
+
+        for (var i = 0; i < N_SAMPLES; i++) {
+            final double time = i * 0.01;
+            final double value = MathBaseFast.sin(2.0 * Math.PI * time);
+            final double confidenceInterval = 0.2 * MathBaseFast.cos(2.0 * Math.PI * time);
+
+            dataSet.add(time, value, confidenceInterval, confidenceInterval);
+            upperLimit.add(time, value + 2, 0, Double.POSITIVE_INFINITY);
+            lowerLimit.add(time, value - 2, Double.POSITIVE_INFINITY, 0);
+        }
+
+        final var scene = new Scene(chart, WIDTH, HEIGHT);
+
+        primaryStage.setTitle(LimitsSample.class.getSimpleName());
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+}


### PR DESCRIPTION
N.B. axis range clearing doesn't seem to be necessary when inverting the axis
* added sample to illustrate the use of inverted axes (and also fix)
* added another (unrelated) sample to illustrate plotting of limits
* minor code clean-up (usage of 'var', unavoidable PMD/SONARLINT suppression).