### PR TITLE
Use user agent css files and YValueWatchIndicator improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK ${{ env.JAVA_REFERENCE_VERSION }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'adopt'
       - name: Test with Maven
         run: mvn -Dgpg.skip=true --no-transfer-progress --batch-mode -Drevision=${REVISION} -Dchangelist=${CHANGELIST} package
       - name: CodeCov coverage Reporter
@@ -79,9 +80,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up the JDK ${{ env.JAVA_REFERENCE_VERSION }}
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2.1.0
         with:
           java-version: ${{ env.JAVA_REFERENCE_VERSION }}
+          distribution: 'adopt'
           gpg-private-key: ${{ secrets.GPG_KEY }}
           gpg-passphrase: GPG_PASS
       - name: Deploy to Github Packages
@@ -91,9 +93,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE }}
       - name: Set up JDK to publish to OSSRH
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2.1.0
         with:
           java-version: ${{ env.JAVA_REFERENCE_VERSION }}
+          distribution: 'adopt'
           server-id: ossrh
           server-username: SONATYPE_USER
           server-password: SONATYPE_PASS

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -47,9 +47,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
           java-version: 11
+          distribution: 'adopt'
       - name: Download Coverity Build Tool
         run: |
           wget -q https://scan.coverity.com/download/java/Linux --post-data "token=$TOKEN&project=chart-fx" -O cov-analysis-linux64.tar.gz

--- a/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
@@ -325,8 +325,6 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
             }
         }
 
-        getStylesheets().add(Chart.CHART_CSS);
-
         setTriggerDistance(Chart.DEFAULT_TRIGGER_DISTANCE);
         setMinSize(0, 0);
         setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
@@ -492,6 +490,11 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
         axesAndCanvasPane.getStyleClass().add("chart-content");
 
         registerShowingListener(); // NOPMD - unlikely but allowed override
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return CHART_CSS;
     }
 
     @Override

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
@@ -321,7 +321,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
      */
     public AbstractAxisParameter() {
         super();
-        getStylesheets().add(AbstractAxisParameter.CHART_CSS);
         getStyleClass().setAll("axis");
         majorTickStyle.getStyleClass().add("axis-tick-mark");
         minorTickStyle.getStyleClass().add("axis-minor-tick-mark");
@@ -371,6 +370,11 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
         maxProperty().addListener(scaleChangeListener);
         widthProperty().addListener(scaleChangeListener);
         heightProperty().addListener(scaleChangeListener);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return AbstractAxisParameter.CHART_CSS;
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/YWatchValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/YWatchValueIndicator.java
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) 2017 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
-
 package de.gsi.chart.plugins;
 
-import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.input.MouseEvent;
@@ -75,7 +70,7 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
      * @param value Update marker label and its Y Axis position by this double value.
      */
     public void setMarkerValue(final double value) {
-        setText(String.format(valueFormat, value));
+        setText(getAxis().getTickMarkLabel(value));
         setValue(value);
     }
 
@@ -129,15 +124,17 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
         final double minY = plotAreaBounds.getMinY();
         final double maxY = plotAreaBounds.getMaxY();
 
+        final double halfHeight = label.getHeight() / 2;
+        final double width = label.getWidth() + 10;
         final double yPos = minY + getAxis().getDisplayPosition(getValue());
         final double axisPos;
         final boolean isRightSide = getAxis().getSide().equals(Side.RIGHT);
         if (isRightSide) {
             axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(0, 0)).getX() + 2;
-            triangle.getPoints().setAll(0.0, 0.0, 10.0, 10.0, 50.0, 10.0, 50.0, -10.0, 10.0, -10.0);
+            triangle.getPoints().setAll(0.0, 0.0, 10.0, halfHeight, width, halfHeight, width, -halfHeight, 10.0, -halfHeight);
         } else {
             axisPos = getChart().getPlotForeground().sceneToLocal(getAxis().getCanvas().localToScene(getAxis().getWidth(), 0)).getX() - 2;
-            triangle.getPoints().setAll(0.0, 0.0, -10.0, 10.0, -50.0, 10.0, -50.0, -10.0, -10.0, -10.0);
+            triangle.getPoints().setAll(0.0, 0.0, -10.0, halfHeight, -width, halfHeight, -width, -halfHeight, -10.0, -halfHeight);
         }
         final double yPosGlobal = getChart().getPlotForeground().sceneToLocal(getChart().getCanvas().localToScene(0, yPos)).getY();
 
@@ -149,7 +146,7 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
         } else {
             layoutLine(minX, yPos, maxX, yPos);
             layoutMarker(axisPos, yPosGlobal, minX, yPos);
-            layoutWatchLabel(new BoundingBox(minX, yPos, maxX - minX, 0), axisPos, isRightSide);
+            layoutWatchLabel(axisPos, yPosGlobal, isRightSide);
         }
     }
 
@@ -161,21 +158,15 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
         super.layoutLine(startX, startY, endX, endY);
     }
 
-    protected void layoutWatchLabel(final Bounds bounds, double axisPos, boolean isRightSide) {
+    protected void layoutWatchLabel(final double x, double y, boolean isRightSide) {
         if (label.getText() == null || label.getText().isEmpty()) {
             getChartChildren().remove(label);
             return;
         }
 
-        double xPos = bounds.getMinX();
-        double yPos = bounds.getMinY();
-
         final double width = label.prefWidth(-1);
         final double height = label.prefHeight(width);
-        final double baseLine = label.getBaselineOffset();
-
-        double padding = isRightSide ? 0 : width + label.getPadding().getRight();
-        label.resizeRelocate(xPos + axisPos - padding, yPos + baseLine, width, height);
+        label.resizeRelocate(isRightSide ? x : x - width, y - 0.5 * height, width, height);
         label.toFront();
 
         if (!getChart().getPlotForeground().getChildren().contains(label)) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/GridRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/GridRenderer.java
@@ -60,7 +60,6 @@ public class GridRenderer extends Pane implements Renderer {
     public GridRenderer() {
         super();
 
-        getStylesheets().add(GridRenderer.CHART_CSS);
         getStyleClass().setAll(GridRenderer.STYLE_CLASS_GRID_RENDERER);
         horMajorGridStyleNode = new Line();
         horMajorGridStyleNode.getStyleClass().add(GridRenderer.STYLE_CLASS_MAJOR_GRID_LINE);
@@ -111,6 +110,11 @@ public class GridRenderer extends Pane implements Renderer {
         horizontalGridLinesVisibleProperty().addListener(change);
         verticalGridLinesVisibleProperty().addListener(change);
         drawOnTopProperty().addListener(change);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return GridRenderer.CHART_CSS;
     }
 
     protected void drawEuclideanGrid(final GraphicsContext gc, XYChart xyChart) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/ui/BorderedTitledPane.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/ui/BorderedTitledPane.java
@@ -1,5 +1,7 @@
 package de.gsi.chart.ui;
 
+import java.util.Objects;
+
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -20,7 +22,6 @@ public class BorderedTitledPane extends StackPane {
     private final StackPane contentPane;
 
     public BorderedTitledPane(final String titleString, final Node content) {
-        getStylesheets().add(getClass().getResource("titled-border.css").toExternalForm());
         getStyleClass().add("bordered-titled-border");
         if (content == null) {
             throw new IllegalArgumentException("content must not be null");
@@ -35,6 +36,11 @@ public class BorderedTitledPane extends StackPane {
         contentPane.getChildren().add(content);
 
         getChildren().addAll(contentPane, title);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(getClass().getResource("titled-border.css")).toExternalForm();
     }
 
     public StackPane getContentPane() {

--- a/chartfx-chart/src/main/java/de/gsi/chart/viewer/DataViewWindow.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/viewer/DataViewWindow.java
@@ -281,9 +281,6 @@ public class DataViewWindow extends BorderPane implements EventSource {
         GridPane.setVgrow(this, Priority.ALWAYS);
 
         getStyleClass().setAll(CSS_WINDOW);
-        final String css = DataViewWindow.class.getResource(WINDOW_CSS).toExternalForm();
-        getStylesheets().clear();
-        getStylesheets().add(css);
 
         contentProperty().addListener((ch, o, newNode) -> setLocalCenter(newNode));
         DragResizerUtil.makeResizable(this);
@@ -373,6 +370,11 @@ public class DataViewWindow extends BorderPane implements EventSource {
 
         setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
         setContent(content);
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(DataViewWindow.class.getResource(WINDOW_CSS)).toExternalForm();
     }
 
     public final void addCloseWindowButton() {

--- a/chartfx-chart/src/main/java/de/gsi/chart/viewer/DataViewer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/viewer/DataViewer.java
@@ -2,6 +2,7 @@ package de.gsi.chart.viewer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javafx.beans.DefaultProperty;
 import javafx.beans.property.BooleanProperty;
@@ -128,7 +129,6 @@ public class DataViewer extends BorderPane {
         super();
         HBox.setHgrow(this, Priority.ALWAYS);
         VBox.setVgrow(this, Priority.ALWAYS);
-        getStylesheets().add(getClass().getResource("DataViewer.css").toExternalForm());
 
         dataViewRoot.getSubDataViews().addListener(subDataViewChangeListener);
         dataViewRoot.activeSubViewProperty().addListener(activeSubDataViewChangeListener);
@@ -144,6 +144,11 @@ public class DataViewer extends BorderPane {
         toolBar = new ToolBar(separator1, viewList, separator2, spacer);
         this.setCenter(dataViewRoot);
         requestLayout();
+    }
+
+    @Override
+    public String getUserAgentStylesheet() {
+        return Objects.requireNonNull(getClass().getResource("DataViewer.css")).toExternalForm();
     }
 
     public DataViewer(final DataView... views) {

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/CssStylingSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/CssStylingSample.java
@@ -1,0 +1,110 @@
+package de.gsi.chart.samples;
+
+import java.util.Objects;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.CrosshairIndicator;
+import de.gsi.chart.plugins.DataPointTooltip;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.dataset.testdata.spi.CosineFunction;
+import de.gsi.dataset.testdata.spi.GaussFunction;
+import de.gsi.dataset.testdata.spi.RandomWalkFunction;
+
+/**
+ * Simple example of how to use css to change the appearance of the chart.
+ * 
+ * @author akrimm
+ */
+public class CssStylingSample extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CssStylingSample.class);
+    private static final int N_SAMPLES = 100; // default number of data points
+    public static final ObservableList<String> CSS_LIST = FXCollections.observableArrayList("none", "CustomCss1.css", "CustomCss2.css");
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final ComboBox<String> globalCssBox = new ComboBox<String>(CSS_LIST);
+        globalCssBox.getSelectionModel().select(0);
+
+        final DefaultNumericAxis yAxis = new DefaultNumericAxis();
+        yAxis.setAutoRanging(true); // default: true
+        yAxis.setAutoRangePadding(0.5); // here: 50% padding on top and bottom of axis
+
+        final XYChart chart = new XYChart(new DefaultNumericAxis(), yAxis);
+        chart.getPlugins().addAll(new Zoomer(), new CrosshairIndicator(), new EditAxis()); // standard plugin, useful for most cases
+
+        chart.getDatasets().addAll(new GaussFunction("Gauss", N_SAMPLES), new CosineFunction("Cosine", N_SAMPLES)); // for two data sets
+        final ComboBox<String> cssBox = new ComboBox<String>(CSS_LIST);
+        cssBox.getSelectionModel().select(0);
+        VBox.setVgrow(chart, Priority.ALWAYS);
+
+        final DefaultNumericAxis yAxisRight = new DefaultNumericAxis();
+        yAxisRight.setAutoRanging(true); // default: true
+        yAxisRight.setAutoRangePadding(0.5); // here: 50% padding on top and bottom of axis
+
+        final XYChart chartRight = new XYChart(new DefaultNumericAxis(), yAxisRight);
+        chartRight.getPlugins().addAll(new Zoomer(), new DataPointTooltip(), new EditAxis()); // standard plugin, useful for most cases
+
+        chartRight.getDatasets().addAll(new RandomWalkFunction("RandomWalk", N_SAMPLES));
+        final ComboBox<String> cssBoxRight = new ComboBox<String>(CSS_LIST);
+        cssBoxRight.getSelectionModel().select(0);
+        VBox.setVgrow(chartRight, Priority.ALWAYS);
+
+        final HBox hBox = new HBox( //
+                new VBox(new HBox(new Label("Stylesheet for left HBox: "), cssBox), chart), //
+                new VBox(new HBox(new Label("Stylesheet for right HBox: "), cssBoxRight), chartRight) //
+        );
+        VBox.setVgrow(hBox, Priority.ALWAYS);
+        hBox.getChildren().forEach(child -> HBox.setHgrow(child, Priority.ALWAYS));
+        final Scene scene = new Scene(new VBox(new HBox(new Label("Stylesheet for Scene: "), globalCssBox), hBox), 800, 600);
+        primaryStage.setTitle(getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+
+        globalCssBox.valueProperty().addListener((prop, oldVal, newVal) -> {
+            if ("none".equals(newVal)) {
+                scene.getStylesheets().clear();
+            } else {
+                scene.getStylesheets().setAll(Objects.requireNonNull(CssStylingSample.class.getResource(newVal), "could not load css file: " + newVal).toExternalForm());
+            }
+        });
+        cssBox.valueProperty().addListener((prop, oldVal, newVal) -> {
+            if ("none".equals(newVal)) {
+                chart.getStylesheets().clear();
+            } else {
+                chart.getStylesheets().setAll(Objects.requireNonNull(CssStylingSample.class.getResource(newVal), "could not load css file: " + newVal).toExternalForm());
+            }
+        });
+        cssBoxRight.valueProperty().addListener((prop, oldVal, newVal) -> {
+            if ("none".equals(newVal)) {
+                chartRight.getStylesheets().clear();
+            } else {
+                chartRight.getStylesheets().setAll(Objects.requireNonNull(CssStylingSample.class.getResource(newVal), "could not load css file: " + newVal).toExternalForm());
+            }
+        });
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -48,6 +48,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("ChartIndicatorSample", new ChartIndicatorSample()));
         buttons.getChildren().add(new MyButton("ChartPerformanceGraph", new ChartPerformanceGraph()));
         buttons.getChildren().add(new MyButton("ContourChartSample", new ContourChartSample()));
+        buttons.getChildren().add(new MyButton("CssStylingSample", new CssStylingSample()));
         buttons.getChildren().add(new MyButton("CustomColourSchemeSample", new CustomColourSchemeSample()));
         buttons.getChildren().add(new MyButton("CustomFragmentedRendererSample", new CustomFragmentedRendererSample()));
         buttons.getChildren().add(new MyButton("DataViewerSample", new DataViewerSample()));

--- a/chartfx-samples/src/main/resources/de/gsi/chart/samples/CustomCss1.css
+++ b/chartfx-samples/src/main/resources/de/gsi/chart/samples/CustomCss1.css
@@ -1,0 +1,21 @@
+.chart-crosshair-path {
+  -fx-stroke-width: 3.0;
+  -fx-stroke: green;
+}
+
+.chart-zoom-rect {
+  -fx-fill: lime;
+  -fx-stroke: pink;
+  -fx-stroke-type: inside;
+  -fx-stroke-width: 5.0;
+  -fx-opacity: 0.1;
+}
+
+.chart-datapoint-tooltip-label {
+  -fx-background-color: purple;
+  -fx-border-color: black;
+  -fx-border-radius: 9.0;
+  -fx-font-size: 22.0;
+  -fx-font-weight: lighter;
+  -fx-text-alignment: left;
+}

--- a/chartfx-samples/src/main/resources/de/gsi/chart/samples/CustomCss2.css
+++ b/chartfx-samples/src/main/resources/de/gsi/chart/samples/CustomCss2.css
@@ -1,0 +1,16 @@
+.chart-crosshair-path {
+  -fx-stroke-width: 3.0;
+  -fx-stroke: orange;
+}
+
+.chart-major-grid-lines {
+  -fx-stroke: derive(red, -10%);
+  -fx-stroke-dash-array: 1.5, 2.5;
+  -fx-stroke-width: 0.5;
+  -fx-grid-on-top: true;
+}
+.axis-label {
+  -fx-stroke: blue;
+  -fx-axis-label-alignment: right;
+  -fx-font-family: "Times New Roman";
+}


### PR DESCRIPTION
#  Use user agent style sheet for default css

When adding the default css to the charts getStylesheets() list, it
effectively makes it impossible for users to overwrite values in
chart.css from their scene's stylesheet. By setting it as the chart's
user style sheet, the default chart.css has a lower priority than the
stylesheets added by the user.

# YWatchValueIndicator improvements

- Use formater of axis instead of fixed formater
- Calculate size of the Marker based on label size.

# Open Points:
- Testing with real applications and not just the samples
- <strike>Add a sample which provides its own css file </strike>
- The EditAxisPlugin and the GridRenderer (only for taking snapshots of the grid lines to cache dashed lines) still add stylesheets to the scenegraph, check if this can be avoided.

fixes #427