### PR TITLE
Fix YWatchValueIndicatorTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: Java CI
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 env:
   JAVA_REFERENCE_VERSION: 11
 

--- a/chartfx-chart/src/test/java/de/gsi/chart/plugins/YWatchValueIndicatorTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/plugins/YWatchValueIndicatorTest.java
@@ -72,7 +72,7 @@ class YWatchValueIndicatorTest {
     void setMarkerValue() {
         chart.getPlugins().add(valueWatchIndicatorTested);
         valueWatchIndicatorTested.setMarkerValue(35.15);
-        assertEquals("35.15", valueWatchIndicatorTested.getText());
+        assertEquals(" 35.2", valueWatchIndicatorTested.getText());
         assertEquals(35.15, valueWatchIndicatorTested.getValue(), 1e-2);
     }
 


### PR DESCRIPTION
Failed to adjust the expected string for the Indicator to the value returned by the tick label formatter in yesterday's PR, resulting in test failures.