### PR TITLE
YWatchValueIndicator: prevent occlusion of value labels

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/YWatchValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/YWatchValueIndicator.java
@@ -35,19 +35,16 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
     protected static final String STYLE_CLASS_MARKER = "value-watch-indicator-marker";
     public static final String WATCH_INDICATOR_PREVENT_OCCLUSION = "WatchIndicatorPreventOcclusion";
 
-    protected final String valueFormat;
     protected String id;
 
     /**
      * Creates a new instance indicating given Y value belonging to the specified {@code yAxis}.
      *
      * @param axis the axis this indicator is associated with
-     * @param valueFormat a value string format for marker visualization
      * @param value a value to be marked
      */
-    public YWatchValueIndicator(final Axis axis, final String valueFormat, final double value) {
-        super(axis, value, String.format(valueFormat, value));
-        this.valueFormat = valueFormat;
+    public YWatchValueIndicator(final Axis axis, final double value) {
+        super(axis, value, axis.getTickMarkLabel(value));
 
         // marker is visible always for this indicator
         triangle.visibleProperty().unbind();
@@ -63,10 +60,35 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
      * The Y value is updated by listeners.
      *
      * @param axis the axis this indicator is associated with
-     * @param valueFormat a value string format for marker visualization
      */
+    public YWatchValueIndicator(final Axis axis) {
+        this(axis, 0.0);
+    }
+
+    /**
+     * Creates a new instance indicating given Y value belonging to the specified {@code yAxis}.
+     *
+     * @param axis the axis this indicator is associated with
+     * @param format formerly used to specify number format. Now the formating is controlled by the
+     * @param value a value to be marked
+     * @deprecated now uses number formatter of axis
+     */
+    @Deprecated()
+    public YWatchValueIndicator(final Axis axis, final String format, final double value) {
+        this(axis, value);
+    }
+
+    /**
+     * Creates a new instance for the specified {@code yAxis}.
+     * The Y value is updated by listeners.
+     *
+     * @param axis the axis this indicator is associated with
+     * @param valueFormat a value string format for marker visualization - deprecated
+     * @deprecated now uses number formatter of axis
+     */
+    @Deprecated
     public YWatchValueIndicator(final Axis axis, final String valueFormat) {
-        this(axis, valueFormat, 0.0);
+        this(axis, 0.0);
     }
 
     /**
@@ -183,7 +205,7 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
                     for (int j = i - 1; j >= 0; j--) { // check if lower markers have to be moved
                         final double diff2 = movedPosition[j + 1] - movedPosition[j];
                         if (labelHeight + padding > diff2) {
-                            movedPosition[j] -= 2 * halfHeight - diff2;
+                            movedPosition[j] -= 2 * halfHeight - diff2 + padding;
                         }
                     }
                 }
@@ -195,7 +217,7 @@ public class YWatchValueIndicator extends AbstractSingleValueIndicator implement
                 if (isRightSide) {
                     indicators[i].triangle.getPoints().setAll(0.0, 0.0, 10.0, halfHeightPos, width, halfHeightPos, width, halfHeightNeg, 10.0, halfHeightNeg);
                 } else {
-                    indicators[i].triangle.getPoints().setAll(0.0, 0.0, -10.0, halfHeightPos, -width, halfHeightPos, -width, halfHeightNeg, -10.0, -halfHeightNeg);
+                    indicators[i].triangle.getPoints().setAll(0.0, 0.0, -10.0, halfHeightPos, -width, halfHeightPos, -width, halfHeightNeg, -10.0, halfHeightNeg);
                 }
                 indicators[i].label.resizeRelocate(isRightSide ? x : x - labelWidth, indicators[i].triangle.getTranslateY() - 0.5 * labelHeight + offset, labelWidth, labelHeight);
             }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -90,6 +90,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("ValueIndicatorSample", new ValueIndicatorSample()));
         buttons.getChildren().add(new MyButton("WaterfallPerformanceSample", new WaterfallPerformanceSample()));
         buttons.getChildren().add(new MyButton("WriteDataSetToFileSample", new WriteDataSetToFileSample()));
+        buttons.getChildren().add(new MyButton("YWatchValueIndicatorSample", new YWatchValueIndicatorSample()));
         buttons.getChildren().add(new MyButton("ZoomerSample", new ZoomerSample()));
 
         final var scene = new Scene(root);

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/YWatchValueIndicatorSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/YWatchValueIndicatorSample.java
@@ -1,0 +1,83 @@
+package de.gsi.chart.samples;
+
+import java.util.Objects;
+
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import javafx.util.Duration;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.YWatchValueIndicator;
+import de.gsi.chart.ui.geometry.Side;
+import de.gsi.dataset.testdata.spi.CosineFunction;
+import de.gsi.dataset.testdata.spi.SineFunction;
+
+/**
+ * @author akrimm
+ */
+public class YWatchValueIndicatorSample extends Application {
+    private static final int N_SAMPLES = 1000;
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final StackPane root = new StackPane();
+
+        DefaultNumericAxis xAxis = new DefaultNumericAxis();
+        DefaultNumericAxis yAxis = new DefaultNumericAxis();
+        DefaultNumericAxis yAxis2 = new DefaultNumericAxis();
+        yAxis2.setSide(Side.RIGHT);
+        final XYChart chart = new XYChart(xAxis, yAxis);
+        root.getChildren().add(chart);
+        chart.getAxes().add(yAxis2);
+
+        chart.getDatasets().addAll(new SineFunction("sine", N_SAMPLES), new CosineFunction("cosine", N_SAMPLES));
+
+        final YWatchValueIndicator indicator1 = new YWatchValueIndicator(yAxis, 0.7);
+        indicator1.setId("valA");
+        final YWatchValueIndicator indicator2 = new YWatchValueIndicator(yAxis, 0.63);
+        indicator2.setId("valB");
+        final YWatchValueIndicator indicator3 = new YWatchValueIndicator(yAxis2, 0.18);
+        indicator3.setId("valA");
+        indicator3.setPreventOcclusion(true);
+        final YWatchValueIndicator indicator4 = new YWatchValueIndicator(yAxis2, 0.2);
+        indicator4.setId("valB");
+        final YWatchValueIndicator indicator5 = new YWatchValueIndicator(yAxis2, 0.21);
+        chart.getPlugins().addAll(indicator1, indicator2, indicator3, indicator4, indicator5);
+
+        // animate indicators
+        final Timeline timeline = new Timeline(new KeyFrame(Duration.millis(20), new EventHandler<ActionEvent>() {
+            double time = 0;
+            @Override
+            public void handle(ActionEvent t) {
+                time += 0.03;
+                indicator2.setValue(0.65 + 0.14 * Math.cos(time));
+                indicator4.setValue(0.21 + 0.18 * Math.cos(0.8 * time));
+            }
+        }));
+        timeline.setCycleCount(Animation.INDEFINITE);
+
+        final Scene scene = new Scene(root, 800, 600);
+        scene.getStylesheets().add(Objects.requireNonNull(YWatchValueIndicatorSample.class.getResource("YWatchValueIndicatorSample.css"), "stylesheet not found").toExternalForm());
+        primaryStage.setTitle(this.getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+        primaryStage.show();
+        timeline.play();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}

--- a/chartfx-samples/src/main/java/de/gsi/financial/samples/FinancialRealtimeCandlestickSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/financial/samples/FinancialRealtimeCandlestickSample.java
@@ -95,6 +95,7 @@ public class FinancialRealtimeCandlestickSample extends AbstractBasicFinancialAp
             SimpleOhlcvReplayDataSet replayDataSet = ((SimpleOhlcvReplayDataSet) ohlcvDataSet);
             // close prices visualization
             final YWatchValueIndicator closeIndicator = new YWatchValueIndicator(yAxis, priceFormat);
+            closeIndicator.setPreventOcclusion(true);
             closeIndicator.setId("price");
             closeIndicator.setLineVisible(false);
             closeIndicator.setEditable(false);

--- a/chartfx-samples/src/main/java/de/gsi/financial/samples/service/SCIDByNio.java
+++ b/chartfx-samples/src/main/java/de/gsi/financial/samples/service/SCIDByNio.java
@@ -36,7 +36,7 @@ public class SCIDByNio implements AutoCloseable {
     public void openNewChannel(String resource) throws IOException {
         timeZone = cal.get(Calendar.ZONE_OFFSET);
 
-        fileInputStream = new FileInputStream(FilenameUtils.getName(resource)); // lgtm[java/output-resource-leak]
+        fileInputStream = new FileInputStream(resource); // lgtm[java/output-resource-leak]
         fileChannel = fileInputStream.getChannel();
 
         bufferRecordDouble = ByteBuffer.allocate(8);

--- a/chartfx-samples/src/main/resources/de/gsi/chart/samples/YWatchValueIndicatorSample.css
+++ b/chartfx-samples/src/main/resources/de/gsi/chart/samples/YWatchValueIndicatorSample.css
@@ -1,0 +1,11 @@
+.valA-value-watch-indicator-marker {
+    -fx-stroke-width: 0.5;
+    -fx-stroke: black;
+    -fx-fill: #78015b;
+}
+
+.valB-value-watch-indicator-marker {
+    -fx-stroke-width: 0.5;
+    -fx-stroke: black;
+    -fx-fill: green;
+}


### PR DESCRIPTION
By default, if there are multiple YWatchValueIndicators close to each other, their label texts occlude each other. This PR implements an optional flag to move the value labels on a per axis basis.

Axis on the left shows the old and now default behaviour, the Axis on the right showcases the new feature:
![2021-06-29 15-23_marker_occlusion](https://user-images.githubusercontent.com/1202371/123816833-eecf0b00-d8f7-11eb-95bc-76831a602d69.gif)