### PR TITLE
Tie-break closest point in rendering order and allow overriding more methods in `DataPointTooltip`

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -111,7 +111,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
                 .flatMap(renderer -> Stream.of(renderer.getDatasets(), xyChartDatasets) //
                                              .flatMap(List::stream) // combine global and renderer specific Datasets
                                              .flatMap(dataset -> getPointsCloseToCursor(dataset, renderer, mouseLocation))) // get points in range of cursor
-                .reduce((p1, p2) -> p1.distanceFromMouse < p2.distanceFromMouse ? p1 : p2); // find closest point
+                .reduce((p1, p2) -> !(p1.distanceFromMouse > p2.distanceFromMouse) ? p1 : p2); // find closest point, tie-breaking in favor of earlier data sets to match rendering order
     }
 
     private Stream<DataPoint> getPointsCloseToCursor(final DataSet dataset, final Renderer renderer, final Point2D mouseLocation) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -111,7 +111,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
                 .flatMap(renderer -> Stream.of(renderer.getDatasets(), xyChartDatasets) //
                                              .flatMap(List::stream) // combine global and renderer specific Datasets
                                              .flatMap(dataset -> getPointsCloseToCursor(dataset, renderer, mouseLocation))) // get points in range of cursor
-                .reduce((p1, p2) -> !(p1.distanceFromMouse > p2.distanceFromMouse) ? p1 : p2); // find closest point, tie-breaking in favor of earlier data sets to match rendering order
+                .reduce((p1, p2) -> p1.distanceFromMouse <= p2.distanceFromMouse ? p1 : p2); // find closest point, tie-breaking in favor of earlier data sets to match rendering order
     }
 
     protected Stream<DataPoint> getPointsCloseToCursor(final DataSet dataset, final Renderer renderer, final Point2D mouseLocation) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -89,7 +89,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         setPickingDistance(pickingDistance);
     }
 
-    private Optional<DataPoint> findDataPoint(final MouseEvent event, final Bounds plotAreaBounds) {
+    protected Optional<DataPoint> findDataPoint(final MouseEvent event, final Bounds plotAreaBounds) {
         if (!plotAreaBounds.contains(event.getX(), event.getY())) {
             return Optional.empty();
         }
@@ -99,7 +99,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         return findNearestDataPointWithinPickingDistance(mouseLocation);
     }
 
-    private Optional<DataPoint> findNearestDataPointWithinPickingDistance(final Point2D mouseLocation) {
+    protected Optional<DataPoint> findNearestDataPointWithinPickingDistance(final Point2D mouseLocation) {
         final Chart chart = getChart();
         if (!(chart instanceof XYChart)) {
             return Optional.empty();
@@ -114,7 +114,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
                 .reduce((p1, p2) -> !(p1.distanceFromMouse > p2.distanceFromMouse) ? p1 : p2); // find closest point, tie-breaking in favor of earlier data sets to match rendering order
     }
 
-    private Stream<DataPoint> getPointsCloseToCursor(final DataSet dataset, final Renderer renderer, final Point2D mouseLocation) {
+    protected Stream<DataPoint> getPointsCloseToCursor(final DataSet dataset, final Renderer renderer, final Point2D mouseLocation) {
         // Get Axes for the Renderer
         final Axis xAxis = findXAxis(renderer);
         final Axis yAxis = findYAxis(renderer);
@@ -160,7 +160,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         return renderer.getAxes().stream().filter(ax -> ax.getSide().isHorizontal()).findFirst().orElse(null);
     }
 
-    private DataPoint getDataPointFromDataSet(final Renderer renderer, final DataSet dataset, final Axis xAxis, final Axis yAxis, final Point2D mouseLocation, final int index) {
+    protected DataPoint getDataPointFromDataSet(final Renderer renderer, final DataSet dataset, final Axis xAxis, final Axis yAxis, final Point2D mouseLocation, final int index) {
         final double xValue = dataset.get(DataSet.DIM_X, index);
         final double yValue = dataset.get(DataSet.DIM_Y, index);
 
@@ -178,7 +178,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
                 distanceFromMouseLocation);
     }
 
-    private String formatDataPoint(final DataPoint dataPoint) {
+    protected String formatDataPoint(final DataPoint dataPoint) {
         return formatData(dataPoint.renderer, new Tuple<>(dataPoint.x, dataPoint.y));
     }
 

--- a/chartfx-chart/src/test/java/de/gsi/chart/plugins/DataPointTooltipTest.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/plugins/DataPointTooltipTest.java
@@ -35,6 +35,7 @@ import de.gsi.dataset.testdata.spi.CosineFunction;
 class DataPointTooltipTest {
     private XYChart chart;
     private CosineFunction ds1;
+    private CosineFunction ds1Copy;
     private DataSet ds2;
     private Axis xAxis1;
     private Axis yAxis1;
@@ -61,6 +62,9 @@ class DataPointTooltipTest {
         ds1 = new CosineFunction("Cosine", 50);
         ds1.addDataLabel(17, "SpecialPoint");
         renderer1.getDatasets().add(ds1);
+        ds1Copy = new CosineFunction("Cosine", 50);
+        ds1Copy.addDataLabel(17, "Special Point Copy");
+        renderer1.getDatasets().add(ds1Copy);
 
         // unordered dataset
         xAxis2 = new DefaultNumericAxis("xAxis2", "V");


### PR DESCRIPTION
Closes #454.

I got a tooltip-related test failure from `testThatTooltipIsShown` on check-out, which persists after my small changes:

<details>
<summary>Trace</summary>

```
--- Exception in Async Thread ---
java.lang.reflect.InvocationTargetException: null
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
        java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        java.base/java.lang.reflect.Method.invoke(Method.java:564)
        org.testfx.service.adapter.impl.PublicGlassRobotAdapter.lambda$getScreenCapture$8(PublicGlassRobotAdapter.java:120)
        java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:428)
        java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:427)
        com.sun.glass.ui.monocle.RunnableProcessor.runLoop(RunnableProcessor.java:92)
        com.sun.glass.ui.monocle.RunnableProcessor.run(RunnableProcessor.java:51)
        java.base/java.lang.Thread.run(Thread.java:832)
java.lang.UnsupportedOperationException: null
        java.base/java.nio.IntBuffer.array(IntBuffer.java:1336)
        com.sun.glass.ui.monocle.MonocleRobot.getScreenCapture(MonocleRobot.java:223)
        com.sun.glass.ui.GlassRobot.getScreenCapture(GlassRobot.java:202)
        javafx.scene.robot.Robot.getScreenCapture(Robot.java:313)
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
        java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        java.base/java.lang.reflect.Method.invoke(Method.java:564)
        org.testfx.service.adapter.impl.PublicGlassRobotAdapter.lambda$getScreenCapture$8(PublicGlassRobotAdapter.java:120)
        java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:428)
        java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
        com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:427)
        com.sun.glass.ui.monocle.RunnableProcessor.runLoop(RunnableProcessor.java:92)
        com.sun.glass.ui.monocle.RunnableProcessor.run(RunnableProcessor.java:51)
        java.base/java.lang.Thread.run(Thread.java:832)
--- Trace of caller of unhandled exception in Async Thread ---
        java.base/java.lang.Thread.getStackTrace(Thread.java:1598)
        org.testfx.util.WaitForAsyncUtils$ASyncFXCallable.<init>(WaitForAsyncUtils.java:649)
        org.testfx.util.WaitForAsyncUtils.asyncFx(WaitForAsyncUtils.java:257)
        org.testfx.util.WaitForAsyncUtils.waitForAsyncFx(WaitForAsyncUtils.java:442)
        org.testfx.service.adapter.impl.PublicGlassRobotAdapter.getScreenCapture(PublicGlassRobotAdapter.java:118)
        org.testfx.service.adapter.impl.GlassRobotAdapter.getCaptureRegion(GlassRobotAdapter.java:72)
        org.testfx.robot.impl.BaseRobotImpl.captureRegion(BaseRobotImpl.java:107)
        org.testfx.service.support.impl.CaptureSupportImpl.captureRegion(CaptureSupportImpl.java:61)
        org.testfx.util.DebugUtils.lambda$captureBounds$11(DebugUtils.java:339)
        org.testfx.util.DebugUtils.lambda$saveTestImage$14(DebugUtils.java:552)
        java.base/java.util.function.Function.lambda$compose$0(Function.java:68)
        java.base/java.util.function.Function.lambda$compose$0(Function.java:68)
        java.base/java.util.function.Function.lambda$compose$0(Function.java:68)
        java.base/java.util.function.Function.lambda$compose$0(Function.java:68)
        org.testfx.api.FxAssert.verifyThatImpl(FxAssert.java:162)
        org.testfx.api.FxAssert.verifyThat(FxAssert.java:129)
        de.gsi.chart.plugins.DataPointTooltipTest.testThatTooltipIsShown(DataPointTooltipTest.java:90)
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
        java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        java.base/java.lang.reflect.Method.invoke(Method.java:564)
        org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
        org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
        org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
        org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
        org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
        org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
        org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
        org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
        org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:210)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:206)
        org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:131)
        org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:65)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
        org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
        java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
        org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
        java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
        org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
        org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
        org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
        org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
        org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
        org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
        org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
        org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
        org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
        org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
        org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
        org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
        org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:188)
        org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:154)
        org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:128)
        org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
        org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
        org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
```

</details>

To be honest, I don't have much of an idea what's happening there. Apart from the error, do you want explicit testing for the now-fixed tie-breaking behaviour or do you prefer to leave this open for change in the future? In the former case, I think it is sufficient to duplicate one of the data sets in the existing test exactly and test that the current tooltips are unchanged regardless, though due to the above error I couldn't actually run that test.