### PR TITLE
Initial build fix. Maven structure declares dependencies to chartfx-generate explicitly 

### DIFF
--- a/chartfx-dataset/pom.xml
+++ b/chartfx-dataset/pom.xml
@@ -21,6 +21,12 @@
 	</description>
 
     <dependencies>
+        <!-- Artificial dependency for Maven to build generator plugin prior to this one. -->
+        <dependency>
+            <groupId>de.gsi.generate</groupId>
+            <artifactId>chartfx-generate</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>

--- a/chartfx-generate/src/main/java/de/gsi/generate/CodeGenerator.java
+++ b/chartfx-generate/src/main/java/de/gsi/generate/CodeGenerator.java
@@ -23,7 +23,7 @@ import org.apache.maven.project.MavenProject;
  * By default it looks for input files in src/main/codegen and writes the generated code to
  * target/generated-sources/codegen.
  *
- * There are two different types of template classes. Classes ending in `Gen` are are rewritten, by repeating the
+ * There are two different types of template classes. Classes ending in `Gen` are rewritten, by repeating the
  * blocks inside `//// codegen: originalType -&gt; outputType1, outputType2, ...` and `//// end codegen` for each
  * output type within the file. This is mostly useful for utility functions.
  * Classes ending in `Proto` have to start with a `//// codegen container: originalType -&gt; outputType1, ....` line

--- a/chartfx-math/pom.xml
+++ b/chartfx-math/pom.xml
@@ -22,6 +22,12 @@
     </description>
 
     <dependencies>
+        <!-- Artificial dependency for Maven to build generator plugin prior to this one. -->
+        <dependency>
+            <groupId>de.gsi.generate</groupId>
+            <artifactId>chartfx-generate</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>de.gsi.dataset</groupId>
             <artifactId>chartfx-dataset</artifactId>


### PR DESCRIPTION
The entire project cannot be build on a new environment with no de.gsi artefacts in local .m2.
The error is:
```
[ERROR] Failed to parse plugin descriptor for de.gsi.generate:chartfx-generate:master-SNAPSHOT (E:\dev\zzz\chart-fx\chartfx-generate\target\classes): No plugin descriptor found at META-INF/maven/plugin.xml
```
Project dependencies:
```
de.gsi.acc:chartfx-acc
	de.gsi.chart:chartfx-chart
	de.gsi:microservice
de.gsi.chart:chartfx-chart
	de.gsi.dataset:chartfx-dataset
	de.gsi.math:chartfx-math
de.gsi.math:chartfx-math
	de.gsi.dataset:chartfx-dataset
	build/plugins/plugin de.gsi.generate:chartfx-generate
de.gsi:microservice
	de.gsi.dataset:chartfx-dataset
de.gsi.dataset:chartfx-dataset
	build/plugins/plugin de.gsi.generate:chartfx-generate
de.gsi.generate:chartfx-generate
```
As one can see chartfx-dataset and chartfx-math use chartfx-generate as a plugin not as a dependency. Maven builds module graph on dependencies only.

PR introduces artificial dependencies for Maven to build dependency graph correctly.