### PR TITLE
Fix padded auto grow axis

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
@@ -448,8 +448,8 @@ public class XYChart extends Chart {
             return;
         }
         final boolean oldAutoState = axis.autoNotification().getAndSet(false);
-        final double oldMin = axis.getMin();
-        final double oldMax = axis.getMax();
+        final double oldMin = axis.getAutoRange().getMin();
+        final double oldMax = axis.getAutoRange().getMax();
         final double oldLength = axis.getLength();
 
         final boolean isHorizontal = axis.getSide().isHorizontal();
@@ -482,8 +482,8 @@ public class XYChart extends Chart {
         }
 
         if (axis.isAutoGrowRanging()) {
-            axis.getAutoRange().add(axis.getMin());
-            axis.getAutoRange().add(axis.getMax());
+            axis.getAutoRange().add(oldMin);
+            axis.getAutoRange().add(oldMax);
         }
 
         axis.getAutoRange().setAxisLength(axis.getLength() == 0 ? 1 : axis.getLength(), side);

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -338,7 +338,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     }
 
     /**
-     * Called when data has changed and the range may not be valid any more. This is only called by the chart if
+     * Called when data has changed and the range may not be valid anymore. This is only called by the chart if
      * isAutoRanging() returns true. If we are auto ranging it will cause layout to be requested and auto ranging to
      * happen on next layout pass.
      *
@@ -439,11 +439,9 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
      * @return Range information, this is implementation dependent
      */
     protected AxisRange autoRange(final double length) {
-        // guess a sensible starting size for label size, that is approx 2 lines
-        // vertically or 2 charts horizontally
+        // guess a sensible starting size for label size, that is approx 2 lines vertically or 2 charts horizontally
         if (isAutoRanging() || isAutoGrowRanging()) {
-            // guess a sensible starting size for label size, that is approx 2
-            // lines vertically or 2 charts horizontally
+            // guess a sensible starting size for label size, that is approx 2 lines vertically or 2 charts horizontally
             final double labelSize = getTickLabelFont().getSize() * 1.2; // N.B. was '2' in earlier implementations
             return autoRange(getAutoRange().getMin(), getAutoRange().getMax(), length, labelSize);
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -347,10 +347,11 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     @Override
     public void invalidateRange(final List<Number> data) {
         final boolean oldState = autoNotification().getAndSet(false);
-        getAutoRange().set(autoRange(getLength())); // derived axes may potentially pad and round limits
-        if (set(getAutoRange().getMin(), getAutoRange().getMax())) {
+        final AxisRange autoRange = autoRange(getLength()); // derived axes may potentially pad and round limits
+        if (set(autoRange.getMin(), autoRange.getMax())) {
             getAutoRange().setAxisLength(getLength() == 0 ? 1 : getLength(), getSide());
-            setScale(getAutoRange().getScale());
+            //setScale(getAutoRange().getScale());
+            setScale(calculateNewScale(getLength(), autoRange.getMin(), autoRange.getMax()));
             updateAxisLabelAndUnit();
             // update cache in derived classes
             updateCachedVariables();

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/PaddedAutoGrowAxisSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/PaddedAutoGrowAxisSample.java
@@ -1,0 +1,75 @@
+package de.gsi.chart.samples;
+
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.chart.utils.FXUtils;
+import de.gsi.dataset.spi.CircularDoubleErrorDataSet;
+import de.gsi.math.Math;
+
+/**
+ * Auto grow-ranging example.
+ *
+ * @author ennerf
+ * @author akrimm
+ */
+
+public class PaddedAutoGrowAxisSample extends Application {
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        var xAxis = new DefaultNumericAxis();
+        var yAxis = new DefaultNumericAxis();
+        var chart = new XYChart(xAxis, yAxis);
+        chart.getPlugins().add(new EditAxis());
+        chart.getPlugins().add(new Zoomer());
+
+        yAxis.setAutoRangePadding(0.05);
+        yAxis.setAutoRanging(false);
+        yAxis.setAutoGrowRanging(true);
+        yAxis.set(0, 10);
+
+        var ds = new CircularDoubleErrorDataSet("", 150);
+        chart.getDatasets().addAll(ds);
+        new Thread(() -> {
+            while (true) {
+                ds.reset();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(100);
+                    FXUtils.runAndWait(() -> {
+                        yAxis.set(0, 10);
+                        yAxis.getAutoRange().clear();
+                    });
+                    TimeUnit.MILLISECONDS.sleep(100);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                for (int i = 0; i < 500; i++) {
+                    ds.add(i, 40 * Math.sin(i * 0.1) + 100 * Math.sin(i * 0.02), 0, 0);
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(40);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }).start();
+
+        Scene scene = new Scene(chart, 800, 600);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}


### PR DESCRIPTION
With padding enabled auto grow ranging was broken (see #465, thanks to
@ennerf for reporting) because the padding was applied to the auto
range stored in the axis. Because of this the padding was added each
time the axis range was updated with grow ranging enabled.

This commit changes Abstract axis to directly use the result of
`autoRange()` instead of overwriting the autoRange property with it.

In XYChart the autoGrow code had to be changed to use the previous
computed range instead of the displayed range (which would include the
padding, leading to pileup).

fixes #465

Also adds PaddedAutoGrowAxisSample based on the sample from the bugreport extended by adding a few plugins and a little bit more interesting data to check a few additional cornercases.

Note that the padding at zero is not added, which is intended behaviour; padding never pushes the bounds below/above zero.