### PR TITLE
Fix axis range for padded axes

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -445,7 +445,7 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
 
     /**
      * This calculates the upper and lower bound based on the data provided to invalidateRange() method. This must not
-     * effect the state of the axis, changing any properties of the axis. Any results of the auto-ranging should be
+     * affect the state of the axis, changing any properties of the axis. Any results of the auto-ranging should be
      * returned in the range object. This will we passed to set(Range) if it has been decided to adopt this range for
      * this axis.
      *

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxis.java
@@ -393,6 +393,20 @@ public abstract class AbstractAxis extends AbstractAxisParameter implements Axis
     }
 
     /**
+     * on auto-ranging this returns getAutoRange(), otherwise the user-specified range getUserRange() (ie. limits based
+     * on [lower,upper]Bound)
+     *
+     * @return actual range that is being used.
+     */
+    @Override
+    public AxisRange getRange() {
+        if (isAutoRanging() || isAutoGrowRanging()) {
+            return autoRange(getLength());
+        }
+        return getUserRange();
+    }
+
+    /**
      * Request that the axis is laid out in the next layout pass. This replaces requestLayout() as it has been
      * overridden to do nothing so that changes to children's bounds etc do not cause a layout. This was done as a
      * optimisation as the Axis knows the exact minimal set of changes that really need layout to be updated. So we only

--- a/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/axes/spi/AbstractAxisParameter.java
@@ -643,20 +643,6 @@ public abstract class AbstractAxisParameter extends Pane implements Axis {
         return overlapPolicyProperty().get();
     }
 
-    /**
-     * on auto-ranging this returns getAutoRange(), otherwise the user-specified range getUserRange() (ie. limits based
-     * on [lower,upper]Bound)
-     *
-     * @return actual range that is being used.
-     */
-    @Override
-    public AxisRange getRange() {
-        if (isAutoRanging() || isAutoGrowRanging()) {
-            return getAutoRange();
-        }
-        return getUserRange();
-    }
-
     public double getScale() {
         return scaleProperty().get();
     }

--- a/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
+++ b/chartfx-chart/src/test/java/de/gsi/chart/axes/spi/AbstractAxisParameterTests.java
@@ -31,16 +31,15 @@ class AbstractAxisParameterTests {
         AbstractAxisParameter axis = new EmptyAbstractAxisParameter();
         axis.set(0.0, 10.0);
 
+        assertNull(axis.getRange());
+
         assertTrue(axis.isAutoRanging());
-        assertEquals(axis.getAutoRange(), axis.getRange());
         axis.setAutoRanging(false);
-        assertEquals(axis.getUserRange(), axis.getRange());
         assertFalse(axis.isAutoRanging());
         assertFalse(axis.isAutoGrowRanging());
 
         axis.setAutoGrowRanging(true);
         assertTrue(axis.isAutoGrowRanging());
-        assertEquals(axis.getAutoRange(), axis.getRange());
         axis.setAutoGrowRanging(false);
         assertFalse(axis.isAutoGrowRanging());
 
@@ -324,6 +323,11 @@ class AbstractAxisParameterTests {
         @Override
         public void drawAxis(GraphicsContext gc, double axisWidth, double axisHeight) {
             // deliberately not implemented
+        }
+
+        @Override
+        public AxisRange getRange() {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
solves #469 by also using the computed autoRange() result which includes the padding when calculating the tick marks. Still needs some more testing to verify that this doesn't break somewhere else.