### PR TITLE
add visibility state and toggling of datasets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         if: matrix.java == env.JAVA_REFERENCE_VERSION
       - name: Codacy coverage Reporter
         if: matrix.java == env.JAVA_REFERENCE_VERSION
+        continue-on-error: true # codacy coverage sometimes fails for external PRs, ignore since it is not our main coverage tracking
         uses: codacy/codacy-coverage-reporter-action@0.2.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/Chart.java
@@ -77,10 +77,14 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
     protected BooleanBinding showingBinding;
     protected final BooleanProperty showing = new SimpleBooleanProperty(this, "showing", false);
     protected final ChangeListener<? super Boolean> showingListener = (ch2, o, n) -> showing.set(n);
-    /** When true any data changes will be animated. */
+    /**
+     * When true any data changes will be animated.
+     */
     private final BooleanProperty animated = new SimpleBooleanProperty(this, "animated", true);
     // TODO: Check whether 'this' or chart contents need to be added
-    /** Animator for animating stuff on the chart */
+    /**
+     * Animator for animating stuff on the chart
+     */
     protected final ChartLayoutAnimator animator = new ChartLayoutAnimator(this);
 
     /**
@@ -310,7 +314,7 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
 
     /**
      * Creates a new default Chart instance.
-     * 
+     *
      * @param axes axes to be added to the chart
      */
     public Chart(Axis... axes) {
@@ -985,6 +989,9 @@ public abstract class Chart extends HiddenSidesPane implements Observable {
         FXUtils.assertJavaFxThread();
         while (change.next()) {
             for (final DataSet set : change.getRemoved()) {
+                // remove Legend listeners from removed datasets
+                set.updateEventListener().removeIf(l -> l instanceof DefaultLegend.DatasetVisibilityListener);
+
                 set.removeListener(dataSetDataListener);
                 dataSetChanges = true;
             }

--- a/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
@@ -258,9 +258,7 @@ public class XYChart extends Chart {
         ObservableList<DataSet> dataSets = this.getAllDatasets();
         // check that all registered data sets have proper ranges defined
         dataSets.parallelStream()
-                .forEach(dataset -> dataset.getAxisDescriptions().parallelStream()
-                        .filter(axisD -> !axisD.isDefined())
-                        .forEach(axisDescription -> dataset.lock().writeLockGuard(() -> dataset.recomputeLimits(axisDescription.getDimIndex()))));
+                .forEach(dataset -> dataset.getAxisDescriptions().parallelStream().filter(axisD -> !axisD.isDefined()).forEach(axisDescription -> dataset.lock().writeLockGuard(() -> dataset.recomputeLimits(axisDescription.getDimIndex()))));
 
         final ArrayDeque<DataSet> lockQueue = new ArrayDeque<>(dataSets);
         recursiveLockGuard(lockQueue, () -> getAxes().forEach(chartAxis -> {

--- a/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
@@ -258,7 +258,6 @@ public class XYChart extends Chart {
         ObservableList<DataSet> dataSets = this.getAllDatasets();
         // check that all registered data sets have proper ranges defined
         dataSets.parallelStream()
-                .filter(DataSet::isVisible) // TODO (ennerf): this does not get the dataset out of the axis. Is there a general way to do this w/o modifying the dataset itself ?
                 .forEach(dataset -> dataset.getAxisDescriptions().parallelStream()
                         .filter(axisD -> !axisD.isDefined())
                         .forEach(axisDescription -> dataset.lock().writeLockGuard(() -> dataset.recomputeLimits(axisDescription.getDimIndex()))));
@@ -458,7 +457,7 @@ public class XYChart extends Chart {
         final boolean isHorizontal = axis.getSide().isHorizontal();
         final Side side = axis.getSide();
         axis.getAutoRange().clear();
-        dataSets.forEach(dataset -> dataset.lock().readLockGuard(() -> {
+        dataSets.stream().filter(DataSet::isVisible).forEach(dataset -> dataset.lock().readLockGuard(() -> {
             if (dataset.getDimension() > 2 && (side == Side.RIGHT || side == Side.TOP)) {
                 if (!dataset.getAxisDescription(DataSet.DIM_Z).isDefined()) {
                     dataset.recomputeLimits(DataSet.DIM_Z);

--- a/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/XYChart.java
@@ -257,8 +257,11 @@ public class XYChart extends Chart {
         // lock datasets to prevent writes while updating the axes
         ObservableList<DataSet> dataSets = this.getAllDatasets();
         // check that all registered data sets have proper ranges defined
-        dataSets.parallelStream().forEach(dataset -> dataset.getAxisDescriptions().parallelStream().filter(axisD -> !axisD.isDefined()) //
-                                                             .forEach(axisDescription -> dataset.lock().writeLockGuard(() -> dataset.recomputeLimits(axisDescription.getDimIndex()))));
+        dataSets.parallelStream()
+                .filter(DataSet::isVisible) // TODO (ennerf): this does not get the dataset out of the axis. Is there a general way to do this w/o modifying the dataset itself ?
+                .forEach(dataset -> dataset.getAxisDescriptions().parallelStream()
+                        .filter(axisD -> !axisD.isDefined())
+                        .forEach(axisDescription -> dataset.lock().writeLockGuard(() -> dataset.recomputeLimits(axisDescription.getDimIndex()))));
 
         final ArrayDeque<DataSet> lockQueue = new ArrayDeque<>(dataSets);
         recursiveLockGuard(lockQueue, () -> getAxes().forEach(chartAxis -> {

--- a/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
@@ -11,6 +11,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.css.PseudoClass;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -106,8 +107,16 @@ public class DefaultLegend extends FlowPane implements Legend {
 
     public LegendItem getNewLegendItem(final Renderer renderer, final DataSet series, final int seriesIndex) {
         final Canvas symbol = renderer.drawLegendSymbol(series, seriesIndex, SYMBOL_WIDTH, SYMBOL_HEIGHT);
-        return new LegendItem(series.getName(), symbol);
+        var item = new LegendItem(series.getName(), symbol);
+        if(renderer.supportsVisibility()){
+            item.setOnMouseClicked(event-> series.setVisible(!series.isVisible()));
+            item.pseudoClassStateChanged(disabledClass, !series.isVisible());
+            series.visibleProperty().addListener((obs, old, newValue) -> item.pseudoClassStateChanged(disabledClass, !newValue));
+        }
+        return item;
     }
+
+    private static final PseudoClass disabledClass = PseudoClass.getPseudoClass("disabled");
 
     @Override
     public Node getNode() {

--- a/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import de.gsi.dataset.event.UpdatedMetaDataEvent;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -110,7 +111,12 @@ public class DefaultLegend extends FlowPane implements Legend {
         var item = new LegendItem(series.getName(), symbol);
         item.setOnMouseClicked(event-> series.setVisible(!series.isVisible()));
         item.pseudoClassStateChanged(disabledClass, !series.isVisible());
-        series.visibleProperty().addListener((obs, old, newValue) -> item.pseudoClassStateChanged(disabledClass, !newValue));
+        series.addListener(evt -> {
+            // TODO: are listeners strong or weak references? Do we need any cleanup?
+            if (evt instanceof UpdatedMetaDataEvent) {
+                item.pseudoClassStateChanged(disabledClass, !series.isVisible());
+            }
+        });
         return item;
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
@@ -108,11 +108,9 @@ public class DefaultLegend extends FlowPane implements Legend {
     public LegendItem getNewLegendItem(final Renderer renderer, final DataSet series, final int seriesIndex) {
         final Canvas symbol = renderer.drawLegendSymbol(series, seriesIndex, SYMBOL_WIDTH, SYMBOL_HEIGHT);
         var item = new LegendItem(series.getName(), symbol);
-        if(renderer.supportsVisibility()){
-            item.setOnMouseClicked(event-> series.setVisible(!series.isVisible()));
-            item.pseudoClassStateChanged(disabledClass, !series.isVisible());
-            series.visibleProperty().addListener((obs, old, newValue) -> item.pseudoClassStateChanged(disabledClass, !newValue));
-        }
+        item.setOnMouseClicked(event-> series.setVisible(!series.isVisible()));
+        item.pseudoClassStateChanged(disabledClass, !series.isVisible());
+        series.visibleProperty().addListener((obs, old, newValue) -> item.pseudoClassStateChanged(disabledClass, !newValue));
         return item;
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/legend/spi/DefaultLegend.java
@@ -39,6 +39,7 @@ public class DefaultLegend extends FlowPane implements Legend {
     private static final int GAP = 5;
     private static final int SYMBOL_WIDTH = 20;
     private static final int SYMBOL_HEIGHT = 20;
+    private static final PseudoClass disabledClass = PseudoClass.getPseudoClass("disabled");
 
     // -------------- PRIVATE FIELDS ------------------------------------------
 
@@ -135,8 +136,6 @@ public class DefaultLegend extends FlowPane implements Legend {
             }
         }
     }
-
-    private static final PseudoClass disabledClass = PseudoClass.getPseudoClass("disabled");
 
     @Override
     public Node getNode() {

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
@@ -975,6 +975,10 @@ public class EditDataSet extends TableViewer {
         }
 
         public void applyDrag(final double deltaX, final double deltaY) {
+            if (!dataSet.isVisible()) {
+                return;
+            }
+
             double nX = getX();
             double nY = getY();
             int index = getIndex();
@@ -1016,6 +1020,10 @@ public class EditDataSet extends TableViewer {
         }
 
         public boolean delete() {
+            if (!dataSet.isVisible()) {
+                return false;
+            }
+
             final EditConstraints constraints = dataSet.getEditConstraints();
             int index = getIndex();
             if (constraints == null || constraints.canDelete(index)) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
@@ -67,5 +67,4 @@ public interface Renderer {
      * @return true (default) if data sets are supposed to be drawn
      */
     BooleanProperty showInLegendProperty();
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
@@ -67,4 +67,14 @@ public interface Renderer {
      * @return true (default) if data sets are supposed to be drawn
      */
     BooleanProperty showInLegendProperty();
+
+    /**
+     * Indicates whether the renderer supports dataset visibility.
+     *
+     * @return false (default) if the renderer does not support visibility.
+     */
+    default boolean supportsVisibility() {
+        return false;
+    }
+
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/Renderer.java
@@ -68,13 +68,4 @@ public interface Renderer {
      */
     BooleanProperty showInLegendProperty();
 
-    /**
-     * Indicates whether the renderer supports dataset visibility.
-     *
-     * @return false (default) if the renderer does not support visibility.
-     */
-    default boolean supportsVisibility() {
-        return false;
-    }
-
 }

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
@@ -411,7 +411,7 @@ public class ContourDataSetRenderer extends AbstractContourDataSetRendererParame
         List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
-            if (!(dataSet instanceof GridDataSet) || dataSet.getDimension() <= 2) {
+            if (!dataSet.isVisible() || !(dataSet instanceof GridDataSet) || dataSet.getDimension() <= 2) {
                 continue; // DataSet not applicable to ContourChartRenderer
             }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ContourDataSetRenderer.java
@@ -460,9 +460,9 @@ public class ContourDataSetRenderer extends AbstractContourDataSetRendererParame
 
     public static double convolution(final double[][] pixelMatrix) {
         final double gy = pixelMatrix[0][0] * -1 + pixelMatrix[0][1] * -2 + pixelMatrix[0][2] * -1 + pixelMatrix[2][0] + pixelMatrix[2][1] * 2
-                          + pixelMatrix[2][2] * 1;
+                        + pixelMatrix[2][2] * 1;
         final double gx = pixelMatrix[0][0] + pixelMatrix[0][2] * -1 + pixelMatrix[1][0] * 2 + pixelMatrix[1][2] * -2 + pixelMatrix[2][0]
-                          + pixelMatrix[2][2] * -1;
+                        + pixelMatrix[2][2] * -1;
         return Math.sqrt(Math.pow(gy, 2) + Math.pow(gx, 2));
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -128,11 +128,6 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
     }
 
     @Override
-    public boolean supportsVisibility() {
-        return true;
-    }
-
-    @Override
     public List<DataSet> render(final GraphicsContext gc, final Chart chart, final int dataSetOffset,
             final ObservableList<DataSet> datasets) {
         if (!(chart instanceof XYChart)) {
@@ -173,9 +168,7 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
             final int ldataSetIndex = dataSetIndex;
             stopStamp = ProcessingProfiler.getTimeStamp();
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
-
             if(!dataSet.isVisible()) {
-                localDataSetList.remove(dataSetIndex); // TODO (ennerf): is this correct and/or necessary?
                 continue;
             }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -163,7 +163,6 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
             ProcessingProfiler.getTimeDiff(start, "init");
         }
 
-        List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final int ldataSetIndex = dataSetIndex;
             stopStamp = ProcessingProfiler.getTimeStamp();
@@ -233,7 +232,6 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
                 return Optional.of(localCachedPoints);
             });
 
-            drawnDataSet.add(dataSet);
             cachedPoints.ifPresent(value -> {
                 // invoke data reduction algorithm
                 value.reduce(rendererDataReducerProperty().get(), isReducePoints(),
@@ -253,7 +251,7 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
         } // end of 'dataSetIndex' loop
         ProcessingProfiler.getTimeDiff(start);
 
-        return drawnDataSet;
+        return localDataSetList;
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -167,7 +167,7 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
             final int ldataSetIndex = dataSetIndex;
             stopStamp = ProcessingProfiler.getTimeStamp();
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
-            if(!dataSet.isVisible()) {
+            if (!dataSet.isVisible()) {
                 continue;
             }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ErrorDataSetRenderer.java
@@ -128,6 +128,11 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
     }
 
     @Override
+    public boolean supportsVisibility() {
+        return true;
+    }
+
+    @Override
     public List<DataSet> render(final GraphicsContext gc, final Chart chart, final int dataSetOffset,
             final ObservableList<DataSet> datasets) {
         if (!(chart instanceof XYChart)) {
@@ -168,6 +173,11 @@ public class ErrorDataSetRenderer extends AbstractErrorDataSetRendererParameter<
             final int ldataSetIndex = dataSetIndex;
             stopStamp = ProcessingProfiler.getTimeStamp();
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
+
+            if(!dataSet.isVisible()) {
+                localDataSetList.remove(dataSetIndex); // TODO (ennerf): is this correct and/or necessary?
+                continue;
+            }
 
             // N.B. print out for debugging purposes, please keep (used for
             // detecting redundant or too frequent render updates)

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
@@ -383,7 +383,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if(ds.isVisible()) {
+            if (ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -458,7 +458,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if(ds.isVisible()) {
+            if (ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -517,7 +517,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if(ds.isVisible()) {
+            if (ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
@@ -139,6 +139,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
                     // replace DataSet with sorted variety
                     // do not need to do this for Histograms as they are always sorted by design
                     LimitedIndexedTreeDataSet newDataSet = new LimitedIndexedTreeDataSet(dataSet.getName(), Integer.MAX_VALUE);
+                    newDataSet.setVisible(dataSet.isVisible());
                     newDataSet.set(dataSet);
                     localDataSetList.set(index, newDataSet);
                 }
@@ -215,7 +216,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if (ds.getDataCount() == 0) {
+            if (!ds.isVisible() || ds.getDataCount() == 0) {
                 continue;
             }
             final double scaleValue = isAnimate() ? scaling.getOrDefault(ds.getName(), 1.0) : 1.0;
@@ -328,7 +329,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if (ds.getDataCount() == 0) {
+            if (!ds.isVisible() || ds.getDataCount() == 0) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -382,6 +383,9 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
+            if(ds.isVisible()) {
+                continue;
+            }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
 
             final int dimIndexAbscissa = isVerticalDataSet ? DIM_Y : DIM_X;
@@ -454,6 +458,9 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
+            if(ds.isVisible()) {
+                continue;
+            }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
 
             final int dimIndexAbscissa = isVerticalDataSet ? DIM_Y : DIM_X;
@@ -510,6 +517,9 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
+            if(ds.isVisible()) {
+                continue;
+            }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
 
             final int dimIndexAbscissa = isVerticalDataSet ? DIM_Y : DIM_X;

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/HistogramRenderer.java
@@ -383,7 +383,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if (ds.isVisible()) {
+            if (!ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -458,7 +458,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if (ds.isVisible()) {
+            if (!ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -517,7 +517,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
         int lindex = dataSetOffset - 1;
         for (DataSet ds : dataSets) {
             lindex++;
-            if (ds.isVisible()) {
+            if (!ds.isVisible()) {
                 continue;
             }
             final boolean isVerticalDataSet = isVerticalDataSet(ds);
@@ -703,7 +703,7 @@ public class HistogramRenderer extends AbstractErrorDataSetRendererParameter<His
 
             for (final DataSet dataSet : localDataSetList) {
                 // scheme 1
-                //final Double val = scaling.put(dataSet.getName(), Math.min(scaling.computeIfAbsent(dataSet.getName(), ds -> 0.0) + 0.05, 1.0))
+                // final Double val = scaling.put(dataSet.getName(), Math.min(scaling.computeIfAbsent(dataSet.getName(), ds -> 0.0) + 0.05, 1.0))
                 // scheme 2
                 final Double val = scaling.put(dataSet.getName(), Math.min(scaling.computeIfAbsent(dataSet.getName(), ds -> 0.0) + 0.05, dataSet.getDataCount() + 1.0));
                 if (val != null && val < dataSet.getDataCount() + 1.0) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/LabelledMarkerRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/LabelledMarkerRenderer.java
@@ -253,7 +253,7 @@ public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMa
         List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
-            if(!dataSet.isVisible()) {
+            if (!dataSet.isVisible()) {
                 continue;
             }
             dataSet.lock().readLockGuard(() -> {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/LabelledMarkerRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/LabelledMarkerRenderer.java
@@ -253,6 +253,9 @@ public class LabelledMarkerRenderer extends AbstractDataSetManagement<LabelledMa
         List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
+            if(!dataSet.isVisible()) {
+                continue;
+            }
             dataSet.lock().readLockGuard(() -> {
                 // check for potentially reduced data range we are supposed to plot
                 final int indexMin = Math.max(0, dataSet.getIndex(DataSet.DIM_X, xMin));

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -173,7 +173,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         private static final long serialVersionUID = 3914728138839091421L;
         private final transient DataSetLock<DataSet> localLock = new DefaultDataSetLock<>(this);
         private final transient AtomicBoolean autoNotify = new AtomicBoolean(true);
-        private final BooleanProperty visible = new SimpleBooleanProperty(true);
         private final GridDataSet dataSet;
         private final int yIndex;
         private final double zMin;
@@ -191,11 +190,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
             this.zMin = zMin;
             this.zMax = zMax;
             yShift = dataSet.getShape(DIM_Y) > 0 ? mountainRangeExtra * dataSet.getAxisDescription(DIM_Z).getMax() * yIndex / dataSet.getShape(DIM_Y) : 0;
-        }
-
-        @Override
-        public BooleanProperty visibleProperty() {
-            return visible;
         }
 
         @Override
@@ -312,6 +306,16 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         @Override
         public DataSet set(final DataSet other, final boolean copy) {
             throw new UnsupportedOperationException("copy setter not implemented for Demux3dTo2dDataSet");
+        }
+
+        @Override
+        public boolean isVisible() {
+            return dataSet.isVisible();
+        }
+
+        @Override
+        public DataSet setVisible(boolean visible) {
+            return dataSet.setVisible(visible);
         }
 
         @Override

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -92,7 +92,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         final double zRangeMax = localDataSetList.stream().mapToDouble(ds -> ds.getAxisDescription(DIM_Z).getMax()).max().orElse(+1.0);
 
         // render in reverse order
-        List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (int dataSetIndex = localDataSetList.size() - 1; dataSetIndex >= 0; dataSetIndex--) {
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
 
@@ -101,7 +100,6 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
                 continue;
             }
 
-            drawnDataSet.add(dataSet);
             dataSet.lock().readLockGuardOptimistic(() -> {
                 xWeakIndexMap.clear();
                 yWeakIndexMap.clear();
@@ -129,7 +127,7 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         }
 
         ProcessingProfiler.getTimeDiff(start);
-        return drawnDataSet;
+        return localDataSetList;
     }
 
     /**

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -97,7 +97,7 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
             final DataSet dataSet = localDataSetList.get(dataSetIndex);
 
             // detect and fish-out 3D DataSet, ignore others
-            if (!(dataSet instanceof GridDataSet)) {
+            if (!dataSet.isVisible() || !(dataSet instanceof GridDataSet)) {
                 continue;
             }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -11,7 +11,9 @@ import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -173,6 +175,7 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
         private static final long serialVersionUID = 3914728138839091421L;
         private final transient DataSetLock<DataSet> localLock = new DefaultDataSetLock<>(this);
         private final transient AtomicBoolean autoNotify = new AtomicBoolean(true);
+        private final BooleanProperty visible = new SimpleBooleanProperty(true);
         private final GridDataSet dataSet;
         private final int yIndex;
         private final double zMin;
@@ -190,6 +193,11 @@ public class MountainRangeRenderer extends ErrorDataSetRenderer implements Rende
             this.zMin = zMin;
             this.zMax = zMax;
             yShift = dataSet.getShape(DIM_Y) > 0 ? mountainRangeExtra * dataSet.getAxisDescription(DIM_Z).getMax() * yIndex / dataSet.getShape(DIM_Y) : 0;
+        }
+
+        @Override
+        public BooleanProperty visibleProperty() {
+            return visible;
         }
 
         @Override

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/MountainRangeRenderer.java
@@ -1,6 +1,5 @@
 package de.gsi.chart.renderer.spi;
 
-import static de.gsi.dataset.DataSet.DIM_X;
 import static de.gsi.dataset.DataSet.DIM_Y;
 import static de.gsi.dataset.DataSet.DIM_Z;
 
@@ -11,9 +10,7 @@ import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
@@ -77,8 +77,10 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
         final double xmin = xAxis.getValueForDisplay(0);
         final double xmax = xAxis.getValueForDisplay(xAxisWidth);
         int index = 0;
-        List<DataSet> drawnDataSet = new ArrayList<>(localDataSetList.size());
         for (final DataSet ds : localDataSetList) {
+            if(!ds.isVisible()) {
+                continue;
+            }
             final int lindex = index;
             ds.lock().readLockGuardOptimistic(() -> {
                 // update categories in case of category axes for the first
@@ -159,7 +161,7 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
         }
         ProcessingProfiler.getTimeDiff(start);
 
-        return drawnDataSet;
+        return localDataSetList;
     }
 
     public void setMaxPoints(final int maxPoints) {

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/ReducingLineRenderer.java
@@ -78,7 +78,7 @@ public class ReducingLineRenderer extends AbstractDataSetManagement<ReducingLine
         final double xmax = xAxis.getValueForDisplay(xAxisWidth);
         int index = 0;
         for (final DataSet ds : localDataSetList) {
-            if(!ds.isVisible()) {
+            if (!ds.isVisible()) {
                 continue;
             }
             final int lindex = index;

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/CandleStickRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/CandleStickRenderer.java
@@ -138,7 +138,7 @@ public class CandleStickRenderer extends AbstractFinancialRenderer<CandleStickRe
         var index = 0;
 
         for (final DataSet ds : localDataSetList) {
-            if (ds.getDimension() < 7)
+            if (!ds.isVisible() || ds.getDimension() < 7)
                 continue;
             final int lindex = index;
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/HighLowRenderer.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/renderer/spi/financial/HighLowRenderer.java
@@ -136,7 +136,7 @@ public class HighLowRenderer extends AbstractFinancialRenderer<HighLowRenderer> 
         int index = 0;
 
         for (final DataSet ds : localDataSetList) {
-            if (ds.getDimension() < 7)
+            if (!ds.isVisible() || ds.getDimension() < 7)
                 continue;
             final int lindex = index;
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
@@ -167,5 +167,4 @@ public interface DataSet extends EventSource, Serializable {
      * @return itself (fluent design)
      */
     public DataSet setVisible(boolean visible);
-
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import de.gsi.dataset.event.EventSource;
 import de.gsi.dataset.locks.DataSetLock;
+import javafx.beans.property.BooleanProperty;
 
 /**
  * Basic interface for observable data sets.
@@ -152,4 +153,15 @@ public interface DataSet extends EventSource, Serializable {
     default DataSet set(final DataSet other) {
         return set(other, true);
     }
+
+    public default boolean isVisible() {
+        return visibleProperty().get();
+    }
+
+    public default void setVisible(boolean visible) {
+        visibleProperty().set(visible);
+    }
+
+    BooleanProperty visibleProperty();
+
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/DataSet.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import de.gsi.dataset.event.EventSource;
 import de.gsi.dataset.locks.DataSetLock;
-import javafx.beans.property.BooleanProperty;
 
 /**
  * Basic interface for observable data sets.
@@ -21,7 +20,7 @@ public interface DataSet extends EventSource, Serializable {
 
     /**
      * Gets the x value of the data point with the index i
-     * 
+     *
      * @param dimIndex the dimension index (ie. '0' equals 'X', '1' equals 'Y')
      * @param index data point index
      * @return the x value
@@ -30,7 +29,7 @@ public interface DataSet extends EventSource, Serializable {
 
     /**
      * Return the axis description of the i-th axis.
-     * 
+     *
      * @param dim 0: X-Axis, 1: Y-Axis, ...
      * @return Axis Label
      */
@@ -154,14 +153,19 @@ public interface DataSet extends EventSource, Serializable {
         return set(other, true);
     }
 
-    public default boolean isVisible() {
-        return visibleProperty().get();
-    }
+    /**
+     * Returns a boolean flag whether this {@code DataSet} should be rendered.
+     *
+     * @return true if the dataset should be rendered
+     */
+    public boolean isVisible();
 
-    public default void setVisible(boolean visible) {
-        visibleProperty().set(visible);
-    }
-
-    BooleanProperty visibleProperty();
+    /**
+     * Sets the visibility status of this {@code DataSet}.
+     *
+     * @param visible true: tells renderers to render this dataset
+     * @return itself (fluent design)
+     */
+    public DataSet setVisible(boolean visible);
 
 }

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -37,6 +37,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
     private final transient AtomicBoolean autoNotification = new AtomicBoolean(true);
     private String name;
     protected final int dimension;
+    private boolean isVisible = true;
     private final List<AxisDescription> axesDescriptions = new ArrayList<>();
     private final transient List<EventListener> updateListeners = Collections.synchronizedList(new LinkedList<>());
     private final transient DataSetLock<? extends DataSet> lock = new DefaultDataSetLock<>(this);
@@ -69,11 +70,6 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
         // forward axis description event to DataSet listener
         invokeListener(e);
         axisUpdating.set(false);
-    };
-    private final BooleanProperty visible = new SimpleBooleanProperty(true) {
-        {
-            addListener((observable, oldValue, newValue) -> fireInvalidated(new AxisChangeEvent(getThis())));
-        }
     };
 
     /**
@@ -378,8 +374,17 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
     }
 
     @Override
-    public BooleanProperty visibleProperty() {
-        return visible;
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    @Override
+    public D setVisible(boolean visible) {
+        if(visible != isVisible){
+            isVisible = visible;
+            fireInvalidated(new UpdatedMetaDataEvent(this, "changed visibility"));
+        }
+        return getThis();
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -1,26 +1,20 @@
 package de.gsi.dataset.spi;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.IntToDoubleFunction;
-
-import de.gsi.dataset.AxisDescription;
-import de.gsi.dataset.DataSet;
-import de.gsi.dataset.DataSetError;
-import de.gsi.dataset.DataSetMetaData;
-import de.gsi.dataset.EditConstraints;
-import de.gsi.dataset.EditableDataSet;
-import de.gsi.dataset.event.AxisChangeEvent;
-import de.gsi.dataset.event.AxisRecomputationEvent;
+import de.gsi.dataset.*;
 import de.gsi.dataset.event.EventListener;
-import de.gsi.dataset.event.UpdateEvent;
-import de.gsi.dataset.event.UpdatedMetaDataEvent;
+import de.gsi.dataset.event.*;
 import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
 import de.gsi.dataset.spi.utils.MathUtils;
 import de.gsi.dataset.spi.utils.StringHashMapList;
 import de.gsi.dataset.utils.AssertUtils;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntToDoubleFunction;
 
 /**
  * <p>
@@ -75,6 +69,11 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
         // forward axis description event to DataSet listener
         invokeListener(e);
         axisUpdating.set(false);
+    };
+    private final BooleanProperty visible = new SimpleBooleanProperty(true) {
+        {
+            addListener((observable, oldValue, newValue) -> fireInvalidated(new AxisChangeEvent(getThis())));
+        }
     };
 
     /**
@@ -376,6 +375,11 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
             }
         }
         return true;
+    }
+
+    @Override
+    public BooleanProperty visibleProperty() {
+        return visible;
     }
 
     /**

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/AbstractDataSet.java
@@ -1,20 +1,18 @@
 package de.gsi.dataset.spi;
 
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntToDoubleFunction;
+
 import de.gsi.dataset.*;
-import de.gsi.dataset.event.EventListener;
 import de.gsi.dataset.event.*;
+import de.gsi.dataset.event.EventListener;
 import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
 import de.gsi.dataset.spi.utils.MathUtils;
 import de.gsi.dataset.spi.utils.StringHashMapList;
 import de.gsi.dataset.utils.AssertUtils;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.IntToDoubleFunction;
 
 /**
  * <p>
@@ -27,7 +25,7 @@ import java.util.function.IntToDoubleFunction;
  * <li>It maintains ranges for all dimensions of the DataSet.
  * <li>It maintains the names and units for the axes
  * </ul>
- * 
+ *
  * @param <D> java generics handling of DataSet for derived classes (needed for fluent design)
  */
 public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends AbstractStylable<D> implements DataSet, DataSetMetaData {
@@ -74,7 +72,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * default constructor
-     * 
+     *
      * @param name the default name of the data set (meta data)
      * @param dimension dimension of this data set
      */
@@ -155,7 +153,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * checks for equal data labels, may be overwritten by derived classes
-     * 
+     *
      * @param other class
      * @return {@code true} if equal
      */
@@ -176,7 +174,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * checks for equal EditConstraints, may be overwritten by derived classes
-     * 
+     *
      * @param other class
      * @return {@code true} if equal
      */
@@ -195,7 +193,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * checks for equal 'get' error values, may be overwritten by derived classes
-     * 
+     *
      * @param other class
      * @param epsilon tolerance threshold
      * @return {@code true} if equal
@@ -244,7 +242,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * checks for equal meta data, may be overwritten by derived classes
-     * 
+     *
      * @param other class
      * @return {@code true} if equal
      */
@@ -281,7 +279,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * Indicates whether some other object is "equal to" this one.
-     * 
+     *
      * @param obj the reference object with which to compare.
      * @param epsilon tolerance parameter ({@code epsilon<=0} corresponds to numerically identical)
      * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
@@ -380,7 +378,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     @Override
     public D setVisible(boolean visible) {
-        if(visible != isVisible){
+        if (visible != isVisible) {
             isVisible = visible;
             fireInvalidated(new UpdatedMetaDataEvent(this, "changed visibility"));
         }
@@ -389,7 +387,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * Notifies listeners that the data has been invalidated. If the data is added to the chart, it triggers repaint.
-     * 
+     *
      * @param event the change event
      * @return itself (fluent design)
      */
@@ -539,7 +537,7 @@ public abstract class AbstractDataSet<D extends AbstractStylable<D>> extends Abs
 
     /**
      * Sets the name of data set (meta data)
-     * 
+     *
      * @param name the new name
      * @return itself (fluent design)
      */

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
@@ -6,7 +6,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javafx.beans.property.BooleanProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import javafx.beans.property.BooleanProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,6 +194,11 @@ public class TransposedDataSet implements DataSet {
     @Override
     public DataSet set(final DataSet other, final boolean copy) {
         throw new UnsupportedOperationException("copy setting transposed data set is not implemented");
+    }
+
+    @Override
+    public BooleanProperty visibleProperty() {
+        return this.dataSet.visibleProperty();
     }
 
     public void setTransposed(final boolean transposed) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/spi/TransposedDataSet.java
@@ -197,8 +197,13 @@ public class TransposedDataSet implements DataSet {
     }
 
     @Override
-    public BooleanProperty visibleProperty() {
-        return this.dataSet.visibleProperty();
+    public boolean isVisible() {
+        return dataSet.isVisible();
+    }
+
+    @Override
+    public DataSet setVisible(boolean visible) {
+        return dataSet.setVisible(visible);
     }
 
     public void setTransposed(final boolean transposed) {

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/ErrorTestDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/ErrorTestDataSet.java
@@ -12,6 +12,8 @@ import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
 import de.gsi.dataset.spi.DefaultAxisDescription;
 import de.gsi.dataset.utils.AssertUtils;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 
 /**
  * Simple test data set for testing renderers for many different parts of the parameter envelope
@@ -25,6 +27,7 @@ public class ErrorTestDataSet implements DataSetError {
     private final DataSetLock<ErrorTestDataSet> lock = new DefaultDataSetLock<>(this);
     private final AtomicBoolean autoNotification = new AtomicBoolean();
     private final List<EventListener> eventListeners = new ArrayList<>();
+    private final BooleanProperty visible = new SimpleBooleanProperty(true);
 
     private static final double STEP = 0.4; // multiples of this will be the step sizes in x direction
     private static final int N_STEP_SWEEP = 10; // how many times to increase step size before returning to original step size
@@ -39,6 +42,11 @@ public class ErrorTestDataSet implements DataSetError {
     public ErrorTestDataSet(final int nSamples, final ErrorType errorType) {
         this.nSamples = nSamples;
         this.errorType = errorType;
+    }
+
+    @Override
+    public BooleanProperty visibleProperty() {
+        return visible;
     }
 
     @Override

--- a/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/ErrorTestDataSet.java
+++ b/chartfx-dataset/src/main/java/de/gsi/dataset/testdata/spi/ErrorTestDataSet.java
@@ -12,8 +12,6 @@ import de.gsi.dataset.locks.DataSetLock;
 import de.gsi.dataset.locks.DefaultDataSetLock;
 import de.gsi.dataset.spi.DefaultAxisDescription;
 import de.gsi.dataset.utils.AssertUtils;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 
 /**
  * Simple test data set for testing renderers for many different parts of the parameter envelope
@@ -27,7 +25,6 @@ public class ErrorTestDataSet implements DataSetError {
     private final DataSetLock<ErrorTestDataSet> lock = new DefaultDataSetLock<>(this);
     private final AtomicBoolean autoNotification = new AtomicBoolean();
     private final List<EventListener> eventListeners = new ArrayList<>();
-    private final BooleanProperty visible = new SimpleBooleanProperty(true);
 
     private static final double STEP = 0.4; // multiples of this will be the step sizes in x direction
     private static final int N_STEP_SWEEP = 10; // how many times to increase step size before returning to original step size
@@ -42,11 +39,6 @@ public class ErrorTestDataSet implements DataSetError {
     public ErrorTestDataSet(final int nSamples, final ErrorType errorType) {
         this.nSamples = nSamples;
         this.errorType = errorType;
-    }
-
-    @Override
-    public BooleanProperty visibleProperty() {
-        return visible;
     }
 
     @Override
@@ -167,6 +159,16 @@ public class ErrorTestDataSet implements DataSetError {
 
     @Override
     public DataSet set(final DataSet other, final boolean copy) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public DataSet setVisible(boolean visible) {
         throw new UnsupportedOperationException();
     }
 

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
@@ -233,12 +233,6 @@ class DataSetBuilderTests {
     private static class MinimalDataSet implements DataSet {
         private static final long serialVersionUID = 1L;
         private final AtomicBoolean autoNotify = new AtomicBoolean();
-        private final BooleanProperty visible = new SimpleBooleanProperty(true);
-
-        @Override
-        public BooleanProperty visibleProperty() {
-            return visible;
-        }
 
         @Override
         public AtomicBoolean autoNotification() {
@@ -329,6 +323,16 @@ class DataSetBuilderTests {
         @Override
         public DataSet set(final DataSet other, final boolean copy) {
             throw new UnsupportedOperationException("copy setting transposed data set is not implemented");
+        }
+
+        @Override
+        public boolean isVisible() {
+            return true;
+        }
+
+        @Override
+        public DataSet setVisible(boolean visible) {
+            return null;
         }
     }
 }

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import org.junit.jupiter.api.Test;
 
 import de.gsi.dataset.AxisDescription;
@@ -231,6 +233,12 @@ class DataSetBuilderTests {
     private static class MinimalDataSet implements DataSet {
         private static final long serialVersionUID = 1L;
         private final AtomicBoolean autoNotify = new AtomicBoolean();
+        private final BooleanProperty visible = new SimpleBooleanProperty(true);
+
+        @Override
+        public BooleanProperty visibleProperty() {
+            return visible;
+        }
 
         @Override
         public AtomicBoolean autoNotification() {

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/DataSetBuilderTests.java
@@ -13,8 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import org.junit.jupiter.api.Test;
 
 import de.gsi.dataset.AxisDescription;
@@ -27,7 +25,7 @@ import de.gsi.dataset.locks.DataSetLock;
 
 /**
  * Checks for the DataSetBuilder
- * 
+ *
  * @author Alexander Krimm
  */
 class DataSetBuilderTests {

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/HistogramTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/HistogramTests.java
@@ -30,6 +30,10 @@ class HistogramTests {
 
         assertNotNull(dataSet.getWarningList());
         assertThrows(UnsupportedOperationException.class, () -> dataSet.set(dataSet, false));
+        // test visibility
+        assertTrue(dataSet.isVisible());
+        dataSet.setVisible(false);
+        assertFalse(dataSet.isVisible());
     }
 
     @Test

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/MultiDimDoubleDataSetTests.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/MultiDimDoubleDataSetTests.java
@@ -1,8 +1,7 @@
 package de.gsi.dataset.spi;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +12,7 @@ import de.gsi.dataset.DataSet;
  * TODO: Test EventListeners
  * setValues
  * dataCount for dimIndex>dimensions
- * 
+ *
  * @author Alexander Krimm
  */
 class MultiDimDoubleDataSetTests {
@@ -89,6 +88,10 @@ class MultiDimDoubleDataSetTests {
                 trimArray(dataset.getValues(DataSet.DIM_X), dataset.getDataCount()));
         assertArrayEquals(new double[] { 6, 7, 8 },
                 trimArray(dataset.getValues(DataSet.DIM_Y), dataset.getDataCount()));
+        // test visibility
+        assertTrue(dataset.isVisible());
+        dataset.setVisible(false);
+        assertFalse(dataset.isVisible());
     }
 
     private static double[] trimArray(final double[] values, final int dataCount) {

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/spi/TransposedDataSetTest.java
@@ -102,6 +102,10 @@ class TransposedDataSetTest {
         assertEquals("fx-color: red", transposed2.getStyle());
         assertNull(transposed2.getStyle(0));
         assertNull(transposed2.getDataLabel(0));
+        // visibility
+        assertTrue(transposed2.isVisible());
+        transposed2.setVisible(false);
+        assertFalse(transposed2.isVisible());
     }
 
     @Test

--- a/chartfx-dataset/src/test/java/de/gsi/dataset/testdata/spi/ErrorTestDataSetTest.java
+++ b/chartfx-dataset/src/test/java/de/gsi/dataset/testdata/spi/ErrorTestDataSetTest.java
@@ -48,6 +48,8 @@ class ErrorTestDataSetTest {
         assertThrows(UnsupportedOperationException.class, () -> dsUnderTest.getIndex(DIM_Z, 5.4));
         assertThrows(IndexOutOfBoundsException.class, () -> dsUnderTest.getErrorPositive(DIM_Z, 5));
         assertDoesNotThrow(() -> dsUnderTest.recomputeLimits(DIM_X));
+        assertTrue(dsUnderTest.isVisible());
+        assertThrows(UnsupportedOperationException.class, () -> dsUnderTest.setVisible(false));
         // getIndex
         // getValue
     }

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/RunChartSamples.java
@@ -88,6 +88,7 @@ public class RunChartSamples extends Application {
         buttons.getChildren().add(new MyButton("TimeAxisSample", new TimeAxisSample()));
         buttons.getChildren().add(new MyButton("TransposedDataSetSample", new TransposedDataSetSample()));
         buttons.getChildren().add(new MyButton("ValueIndicatorSample", new ValueIndicatorSample()));
+        buttons.getChildren().add(new MyButton("VisibiltiyToggleSample", new VisibilityToggleSample()));
         buttons.getChildren().add(new MyButton("WaterfallPerformanceSample", new WaterfallPerformanceSample()));
         buttons.getChildren().add(new MyButton("WriteDataSetToFileSample", new WriteDataSetToFileSample()));
         buttons.getChildren().add(new MyButton("YWatchValueIndicatorSample", new YWatchValueIndicatorSample()));

--- a/chartfx-samples/src/main/java/de/gsi/chart/samples/VisibilityToggleSample.java
+++ b/chartfx-samples/src/main/java/de/gsi/chart/samples/VisibilityToggleSample.java
@@ -1,0 +1,103 @@
+package de.gsi.chart.samples;
+
+import javax.swing.*;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.gsi.chart.XYChart;
+import de.gsi.chart.axes.spi.DefaultNumericAxis;
+import de.gsi.chart.plugins.CrosshairIndicator;
+import de.gsi.chart.plugins.EditAxis;
+import de.gsi.chart.plugins.Zoomer;
+import de.gsi.chart.utils.FXUtils;
+import de.gsi.dataset.event.UpdatedDataEvent;
+import de.gsi.dataset.event.UpdatedMetaDataEvent;
+import de.gsi.dataset.spi.DoubleDataSet;
+
+/**
+ * Simple example of how to use chart class
+ *
+ * @author rstein
+ */
+public class VisibilityToggleSample extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(VisibilityToggleSample.class);
+    private static final int N_SAMPLES = 100; // default number of data points
+
+    @Override
+    public void start(final Stage primaryStage) {
+        final XYChart chart = new XYChart();
+        chart.getPlugins().addAll(new Zoomer(), new EditAxis()); // standard plugin, useful for most cases
+
+        final DoubleDataSet dataSet1 = new DoubleDataSet("data set #1");
+        final DoubleDataSet dataSet2 = new DoubleDataSet("data set #2");
+
+        // some custom listeners (optional)
+        dataSet1.addListener(evt -> LOGGER.atInfo().log("dataSet1 - event: " + evt.toString()));
+        dataSet2.addListener(evt -> LOGGER.atInfo().log("dataSet2 - event: " + evt.toString()));
+
+        chart.getDatasets().addAll(dataSet1, dataSet2); // for two data sets
+
+        final double[] xValues = new double[N_SAMPLES];
+        final double[] yValues1 = new double[N_SAMPLES];
+        dataSet2.autoNotification().set(false); // to suppress auto notification
+        for (int n = 0; n < N_SAMPLES; n++) {
+            final double x = n;
+            final double y1 = Math.cos(Math.toRadians(10.0 * n));
+            final double y2 = Math.sin(Math.toRadians(10.0 * n));
+            xValues[n] = x;
+            yValues1[n] = y1;
+            dataSet2.add(n, y2); // style #1 how to set data, notifies re-draw for every 'add'
+        }
+        dataSet1.set(xValues, yValues1); // style #2 how to set data, notifies once per set
+        // to manually trigger an update (optional):
+        dataSet2.autoNotification().set(true); // to suppress auto notification
+        dataSet2.invokeListener(new UpdatedDataEvent(dataSet2 /* pointer to update source */, "manual update event"));
+
+        final BorderPane borderPane = new BorderPane(chart);
+        final HBox toolbar = new HBox();
+        final CheckBox visibility1 = new CheckBox("show Dataset 1");
+        visibility1.setSelected(true);
+        visibility1.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            dataSet1.setVisible(newValue);
+        });
+        dataSet1.addListener(event -> {
+            if (event instanceof UpdatedMetaDataEvent) {
+                FXUtils.runFX(() -> visibility1.setSelected(dataSet1.isVisible()));
+            }
+        });
+        final CheckBox visibility2 = new CheckBox("show Dataset 2");
+        visibility2.setSelected(true);
+        visibility2.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            dataSet2.setVisible(newValue);
+        });
+        dataSet2.addListener(event -> {
+            if (event instanceof UpdatedMetaDataEvent) {
+                FXUtils.runFX(() -> visibility2.setSelected(dataSet2.isVisible()));
+            }
+        });
+        toolbar.getChildren().addAll(visibility1, visibility2);
+        borderPane.setTop(toolbar);
+        final Scene scene = new Scene(borderPane, 800, 600);
+        primaryStage.setTitle(getClass().getSimpleName());
+        primaryStage.setScene(scene);
+        primaryStage.show();
+        primaryStage.setOnCloseRequest(evt -> Platform.exit());
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(final String[] args) {
+        Application.launch(args);
+    }
+}


### PR DESCRIPTION
This is an outline for what the toggle feature could look like. It's not ready for merging. Below are some questions I've run into so far:

1. What's the best way to omitt the hidden datasets in the axis range computation? Ideally something that could work on the Chart baseclass?
 
2. Is there a good way to deal with access to the dataset, e.g., `EditDataSet` without supporting it in every plugin?

