### PR TITLE
Prevent relayouting of the chart on indicator change

### DIFF
--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractRangeValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractRangeValueIndicator.java
@@ -72,6 +72,7 @@ public abstract class AbstractRangeValueIndicator extends AbstractValueIndicator
         setUpperBound(upperBound);
 
         rectangle.setMouseTransparent(true);
+        rectangle.setManaged(false);
         getChartChildren().addAll(rectangle, label);
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractSingleValueIndicator.java
@@ -81,7 +81,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
 
     /**
      * Creates a new instance of AbstractSingleValueIndicator.
-     * 
+     *
      * @param axis reference axis
      * @param value a X value to be indicated
      * @param text the text to be shown by the label. Value of {@link #textProperty()}.
@@ -171,6 +171,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         triangle.visibleProperty().bind(editableIndicatorProperty());
         triangle.mouseTransparentProperty().bind(editableIndicatorProperty().not());
         triangle.setPickOnBounds(true);
+        triangle.setManaged(false); // prevent the triangle from relayouting the whole chart
         triangle.setOpacity(0.7);
         final double a = AbstractSingleValueIndicator.triangleHalfWidth;
         triangle.getPoints().setAll(-a, -a, -a, +a, +a, +a, +a, -a);
@@ -208,7 +209,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
 
     /**
      * Sets the line coordinates.
-     * 
+     *
      * @param startX start x coordinate
      * @param startY start y coordinate
      * @param endX stop x coordinate
@@ -230,7 +231,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
 
     /**
      * Sets the marker coordinates.
-     * 
+     *
      * @param startX start x coordinate
      * @param startY start y coordinate
      * @param endX stop x coordinate
@@ -246,7 +247,7 @@ public abstract class AbstractSingleValueIndicator extends AbstractValueIndicato
         triangle.toFront();
         // triangle has to be put onto the plot foreground to be able to put it on top of axes
         // is removed when the chart is changed
-        //addChildNodeIfNotPresent(triangle);
+        // addChildNodeIfNotPresent(triangle);
         if (!getChart().getPlotForeground().getChildren().contains(triangle)) {
             getChart().getPlotForeground().getChildren().add(triangle);
         }

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractValueIndicator.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/AbstractValueIndicator.java
@@ -151,6 +151,7 @@ public abstract class AbstractValueIndicator extends ChartPlugin {
     protected void addChildNodeIfNotPresent(final Node node) {
         if (!getChartChildren().contains(node)) {
             getChartChildren().add(0, node); // add elements always at the bottom so they cannot steal focus
+            node.setManaged(false);
         }
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/ChartOverlay.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/ChartOverlay.java
@@ -54,6 +54,7 @@ public class ChartOverlay extends ChartPlugin {
      * @param node value of the {@link #nodeProperty()}
      */
     public ChartOverlay(final OverlayArea area, final Node node) {
+        node.setManaged(false);
         setOverlayArea(area);
         nodeProperty().addListener((obs, oldNode, newNode) -> {
             getChartChildren().remove(oldNode);

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/ChartOverlay.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/ChartOverlay.java
@@ -54,12 +54,12 @@ public class ChartOverlay extends ChartPlugin {
      * @param node value of the {@link #nodeProperty()}
      */
     public ChartOverlay(final OverlayArea area, final Node node) {
-        node.setManaged(false);
         setOverlayArea(area);
         nodeProperty().addListener((obs, oldNode, newNode) -> {
             getChartChildren().remove(oldNode);
             if (newNode != null) {
                 getChartChildren().add(newNode);
+                node.setManaged(false);
             }
             layoutChildren();
         });

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/DataPointTooltip.java
@@ -76,6 +76,7 @@ public class DataPointTooltip extends AbstractDataFormattingPlugin {
         label.getStyleClass().add(DataPointTooltip.STYLE_CLASS_LABEL);
         label.setWrapText(true);
         label.setMinWidth(0);
+        label.setManaged(false);
         registerInputEventHandler(MouseEvent.MOUSE_MOVED, mouseMoveHandler);
     }
 

--- a/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
+++ b/chartfx-chart/src/main/java/de/gsi/chart/plugins/EditDataSet.java
@@ -56,9 +56,9 @@ import de.gsi.dataset.EditConstraints;
 import de.gsi.dataset.EditableDataSet;
 
 /**
- * 
+ *
  * Simple plugin to interact with DataSets implementing {@link de.gsi.dataset.EditableDataSet}.
- * 
+ *
  * @author rstein
  */
 public class EditDataSet extends TableViewer {
@@ -343,7 +343,7 @@ public class EditDataSet extends TableViewer {
 
     /**
      * Handles series that have data sorted or not sorted with respect to X coordinate.
-     * 
+     *
      * @param dataSet data set
      * @param searchedX X coordinates
      * @return pair of neighbouring data points
@@ -544,7 +544,7 @@ public class EditDataSet extends TableViewer {
 
     /**
      * Returns the value of the {@link #editEnableProperty()}
-     * 
+     *
      * @return true: can edit point
      */
     public final boolean isEditable() {
@@ -683,7 +683,7 @@ public class EditDataSet extends TableViewer {
 
     /**
      * Creates an event handler that handles a mouse press on the node.
-     * 
+     *
      * @param dataPoint corresponding to clicked data point
      * @return the event handler.
      */
@@ -932,7 +932,7 @@ public class EditDataSet extends TableViewer {
             super();
             getStyleClass().add(STYLE_CLASS_SELECT_PATH);
             // this.setPickOnBounds(true);
-            // setManaged(false);
+            setManaged(false);
 
             final EditConstraints constraints = dataSet.getEditConstraints();
             if (constraints == null) {


### PR DESCRIPTION
Set the layout property of the indicator triangle to unmanaged s.t.
changes on the triangle will not invalidate the layout of its parent foreground pane.

Since the position of the triangle is already computed manually and
guaranteed to stay inside of the plot bounds, this should be the correct
solution here.

From the openjfx documentation for the `managed` property:
> Defines whether or not this node's layout will be managed by it's parent.
> If the node is managed, it's parent will factor the node's geometry
> into its own preferred size and layoutBounds calculations and will lay it
> out during the scene's layout pass. If a managed node's layoutBounds changes,
> it will automatically trigger relayout up the scene-graph to the nearest
> layout root (which is typically the scene's root node).
>
> If the node is unmanaged, its parent will ignore the child in both preferred
> size computations and layout. Changes in layoutBounds will not trigger
> relayout above it. If an unmanaged node is of type Parent, it will act as a
> "layout root", meaning that calls to Parent.requestLayout() beneath it will
> cause only the branch rooted by the node to be relayed out, thereby isolating
> layout changes to that root and below. It's the application's responsibility
> to set the size and position of an unmanaged node.
>
> By default all nodes are managed.
https://openjfx.io/javadoc/17/javafx.graphics/javafx/scene/Node.html#managedProperty

solves #476

@ennerf does this solve your indicator performance issue?

This might also apply to other nodes in the chart, especially with all the plugins that work on the overlay so we should check if there are more nodes to set to unmanaged.