### PR TITLE
Feature/number formatter with optional exponential separator

### DIFF
--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/NumberFormatterImpl.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/NumberFormatterImpl.java
@@ -144,10 +144,10 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
     private void toExponentialFormat(int h, int m, int l, int e) {
         appendDigit(h);
         if (decimalPlaces > 0) {
-            append(DOT);
+            append(dot);
             appendNDigits(m, l, decimalPlaces);
         } else if (decimalPlaces == ALL_DIGITS) {
-            append(DOT);
+            append(dot);
             append8Digits(m);
             lowDigits(l);
         }
@@ -168,7 +168,7 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
         if (decimalPlaces == 0) {
             return;
         }
-        append(DOT);
+        append(dot);
         if (decimalPlaces == ALL_DIGITS) {
             for (; i <= 8; ++i) {
                 t = 10 * y;
@@ -193,7 +193,7 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
         if (decimalPlaces == 0) {
             return;
         }
-        append(DOT);
+        append(dot);
         int spaceLeft = bytes.length - length;
         if (decimalPlaces == ALL_DIGITS) {
             for (; e < 0 && spaceLeft > 0; ++e) {
@@ -222,13 +222,13 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
         length = 0;
         append(ZERO);
         if (decimalPlaces > 0) {
-            append(DOT);
+            append(dot);
             for (int i = 0; i < decimalPlaces; i++) {
                 append(ZERO);
             }
         }
         if (isExponentialForm) {
-            append(EXP);
+            append(exp);
             append(ZERO);
         }
     }
@@ -306,11 +306,11 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
             length--;
         }
         // remove trailing comma
-        if (length >= DOT.length && 
+        if (length >= dot.length && 
                 Arrays.equals(
-                        bytes,  (length - DOT.length), length - DOT.length + 1, 
-                        DOT, 0, DOT.length)) {
-            length -= DOT.length;
+                        bytes,  (length - dot.length), length - dot.length + 1, 
+                        dot, 0, dot.length)) {
+            length -= dot.length;
         }
     }
 
@@ -331,7 +331,7 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
     }
 
     private void exponent(int e) {
-        append(EXP);
+        append(exp);
         if (e < 0) {
             append(MINUS);
             e = -e;
@@ -388,17 +388,17 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
     private static final int MASK_28 = (1 << 28) - 1;
 
     public NumberFormatterImpl setDecimalFormatSymbols(DecimalFormatSymbols symbols) {
-        String exp = symbols.getExponentSeparator();
-        if (exp.length() > MAX_EXP_LENGTH) {
+        String expString = symbols.getExponentSeparator();
+        if (expString.length() > MAX_EXP_LENGTH) {
             throw new IllegalArgumentException("Exponent separator can't be longer than " + MAX_EXP_LENGTH);
         }
-        this.EXP = Objects.equals(exp, "E") ? DEFAULT_EXP : exp.getBytes(CHARSET);
-        this.DOT = charToBytes(symbols.getDecimalSeparator());
+        this.exp = Objects.equals(expString, "E") ? DEFAULT_EXP : expString.getBytes(CHARSET);
+        this.dot = charToBytes(symbols.getDecimalSeparator());
         return this;
     }
 
-    byte[] DOT = charToBytes('.');
-    byte[] EXP = DEFAULT_EXP;
+    byte[] dot = charToBytes('.');
+    byte[] exp = DEFAULT_EXP;
     private static final byte[] DEFAULT_EXP = charToBytes('E');
     private static final byte ZERO = (byte) '0';
     private static final byte MINUS = (byte) '-';

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/NumberFormatterImpl.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/utils/NumberFormatterImpl.java
@@ -12,12 +12,15 @@ import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import javafx.util.StringConverter;
 
 public class NumberFormatterImpl extends StringConverter<Number> implements NumberFormatter {
     
     private static final Charset CHARSET = StandardCharsets.UTF_8;
+    
+    private static final Pattern UNICODE_WHITESPACE_PATTERN = Pattern.compile("(?U)\\s");
     
     public NumberFormatterImpl() {
         super();
@@ -32,7 +35,12 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
 
     @Override
     public Number fromString(final String string) {
-        return Double.parseDouble(string);
+        if (exponentialSeparator.length == 0) {
+            return Double.parseDouble(string);
+        }
+        
+        String cleanedString = UNICODE_WHITESPACE_PATTERN.matcher(string).replaceAll("");
+        return Double.parseDouble(cleanedString);
     }
 
     @Override
@@ -61,6 +69,12 @@ public class NumberFormatterImpl extends StringConverter<Number> implements Numb
         return this;
     }
     
+    /**
+     * Sets the separator to use between decimal places and exponential e.g. {@code 1_HERE_E-10}. This <em>can</em> break the
+     * functionality of {@link #fromString(String)} if a non-whitespace character is used. Default: none. 
+     * 
+     * @param separator Character to use
+     */
     public final void setExponentialSeparator(char separator) {
         exponentialSeparator = charToBytes(separator);
     }

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/format/DefaultFormatterTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/format/DefaultFormatterTest.java
@@ -9,7 +9,7 @@ import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
 class DefaultFormatterTest {
 
     @Test
-    void formatAndParsingWorks() throws Exception {
+    void formatAndParsingWorks() {
         DefaultFormatter formatter = new DefaultFormatter();
         formatter.updateFormatter(DoubleArrayList.wrap(new double[]{1e-5, 10}), 1.);
         
@@ -22,7 +22,7 @@ class DefaultFormatterTest {
     }
     
     @Test
-    void formatAndParsingWorksWithExponentialSeparator() throws Exception {
+    void formatAndParsingWorksWithExponentialSeparator() {
         DefaultFormatter formatter = new DefaultFormatter() {
             {
                 formatter.setExponentialSeparator('\u202F');

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/format/DefaultFormatterTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/axes/spi/format/DefaultFormatterTest.java
@@ -1,0 +1,41 @@
+package io.fair_acc.chartfx.axes.spi.format;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.fair_acc.dataset.spi.fastutil.DoubleArrayList;
+
+class DefaultFormatterTest {
+
+    @Test
+    void formatAndParsingWorks() throws Exception {
+        DefaultFormatter formatter = new DefaultFormatter();
+        formatter.updateFormatter(DoubleArrayList.wrap(new double[]{1e-5, 10}), 1.);
+        
+        final double value = 0.01;
+        String formatted = formatter.toString(value);
+        assertEquals("1E-2", formatted);
+        
+        Number parsed = formatter.fromString(formatted);
+        assertEquals(value, parsed.doubleValue());
+    }
+    
+    @Test
+    void formatAndParsingWorksWithExponentialSeparator() throws Exception {
+        DefaultFormatter formatter = new DefaultFormatter() {
+            {
+                formatter.setExponentialSeparator('\u202F');
+            }
+        };
+        formatter.updateFormatter(DoubleArrayList.wrap(new double[]{1e-5, 10}), 1.);
+        
+        final double value = 0.01;
+        String formatted = formatter.toString(value);
+        assertEquals("1\u202FE-2", formatted);
+        
+        Number parsed = formatter.fromString(formatted);
+        assertEquals(value, parsed.doubleValue());
+    }
+    
+}

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/utils/NumberFormatterImplTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/utils/NumberFormatterImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static io.fair_acc.chartfx.utils.NumberFormatterImpl.*;
 
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.DoubleFunction;
 
 import org.junit.jupiter.api.Test;
@@ -109,11 +110,26 @@ class NumberFormatterImplTest {
         assertEquals("0.01", formatter.apply(0.010000000000000004));
         assertEquals("0.00", formatter.apply(0.001000000000000004));
     }
-
-    private static DoubleFunction<String> createFormatter(boolean exponentialForm, int decimalPlaces) {
+    
+    @Test
+    void exponentialSeparator() {
+        Locale.setDefault(Locale.US);
+        var formatter = createFormatter(true, 5, Optional.of('\u202F'));
+        assertEquals("2.10000\u202FE0", formatter.apply(2.1));
+        assertEquals("1.00000\u202FE1", formatter.apply(10));
+        assertEquals("1.23457\u202FE14", formatter.apply(123.456789E12));
+        assertEquals("1.23457\u202FE-10", formatter.apply(123.456789E-12));
+    }
+    
+    private static DoubleFunction<String> createFormatter(boolean exponentialForm, int decimalPlaces, Optional<Character> exponentialSeparator) {
         var formatter = new NumberFormatterImpl();
         formatter.setExponentialForm(exponentialForm);
         formatter.setDecimalPlaces(decimalPlaces);
+        exponentialSeparator.ifPresent(sep -> formatter.setExponentialSeparator(sep));
         return formatter::toString;
+    }
+
+    private static DoubleFunction<String> createFormatter(boolean exponentialForm, int decimalPlaces) {
+        return createFormatter(exponentialForm, decimalPlaces, Optional.empty());
     }
 }

--- a/chartfx-chart/src/test/java/io/fair_acc/chartfx/utils/NumberFormatterImplTest.java
+++ b/chartfx-chart/src/test/java/io/fair_acc/chartfx/utils/NumberFormatterImplTest.java
@@ -55,6 +55,15 @@ class NumberFormatterImplTest {
         assertEquals("1.23456789E14", formatter.apply(123.456789E12));
         assertEquals("1.23456789E-10", formatter.apply(123.456789E-12));
     }
+    
+    @Test
+    void exponentialFormatParsing() {
+        Locale.setDefault(Locale.US);
+        var formatter = createFormatterImpl(true, ALL_DIGITS, Optional.empty());
+        assertEquals(0., formatter.fromString("0E0"));
+        assertEquals(2.1,formatter.fromString("2.1E0"));
+        assertEquals(123.456789E-12, formatter.fromString("1.23456789E-10"));
+    }
 
     @Test
     void plain5Decimals() {
@@ -114,22 +123,36 @@ class NumberFormatterImplTest {
     @Test
     void exponentialSeparator() {
         Locale.setDefault(Locale.US);
-        var formatter = createFormatter(true, 5, Optional.of('\u202F'));
-        assertEquals("2.10000\u202FE0", formatter.apply(2.1));
-        assertEquals("1.00000\u202FE1", formatter.apply(10));
-        assertEquals("1.23457\u202FE14", formatter.apply(123.456789E12));
-        assertEquals("1.23457\u202FE-10", formatter.apply(123.456789E-12));
+        var formatter = createFormatterImpl(true, 5, Optional.of('\u202F'));
+        assertEquals("2.10000\u202FE0", formatter.toString(2.1));
+        assertEquals("1.00000\u202FE1", formatter.toString(10));
+        assertEquals("1.23457\u202FE14", formatter.toString(123.456789E12));
+        assertEquals("1.23457\u202FE-10", formatter.toString(123.456789E-12));
     }
     
-    private static DoubleFunction<String> createFormatter(boolean exponentialForm, int decimalPlaces, Optional<Character> exponentialSeparator) {
+    @Test
+    void exponentialSeparatorParsing() {
+        Locale.setDefault(Locale.US);
+        var formatter = createFormatterImpl(true, 5, Optional.of('\u202F'));
+        assertEquals(2.1, formatter.fromString("2.10000\u202FE0"));
+        assertEquals(10., formatter.fromString("1.00000\u202FE1"));
+        assertEquals(1.23457E14, formatter.fromString("1.23457\u202FE14"));
+        assertEquals(1.23457E-10, formatter.fromString("1.23457\u202FE-10"));
+    }
+    
+    private static NumberFormatterImpl createFormatterImpl(
+            boolean exponentialForm,
+            int decimalPlaces,
+            Optional<Character> exponentialSeparator) {
         var formatter = new NumberFormatterImpl();
         formatter.setExponentialForm(exponentialForm);
         formatter.setDecimalPlaces(decimalPlaces);
         exponentialSeparator.ifPresent(sep -> formatter.setExponentialSeparator(sep));
-        return formatter::toString;
+        return formatter;
     }
 
     private static DoubleFunction<String> createFormatter(boolean exponentialForm, int decimalPlaces) {
-        return createFormatter(exponentialForm, decimalPlaces, Optional.empty());
+        var formatter = createFormatterImpl(exponentialForm, decimalPlaces, Optional.empty());
+        return formatter::toString;
     }
 }


### PR DESCRIPTION
`NumberFormatterImpl` works nicely but I wanted to be able provide a separator character before the exponent part. A good character would be NARROW NO-BREAK SPACE  (0x202f).
The current implementation does not allow a separator character and also only works with ASCII chars.

I tried to extend it to be able to use UTF-8 charset. The original implementation was clearly optimized for performance and I don't think this would be impacted by the change. If no UTF-8 character is used, there should be almost no change in runtime.
No default separator is used and the overall default behaviour unchanged.

Please consider the change for integration.