### PR TITLE
fix build on jdk21-25

### DIFF
--- a/chartfx-chart/pom.xml
+++ b/chartfx-chart/pom.xml
@@ -101,6 +101,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        <option>--add-exports=javafx.graphics/com.sun.javafx.tk=${project.moduleName}</option>
+                        <option>--add-exports=javafx.controls/com.sun.javafx.scene.control.skin=${project.moduleName}</option>
+                        <option>--add-exports=org.controlsfx.controls/impl.org.controlsfx.skin=${project.moduleName}</option>
+                    </additionalOptions>
+                </configuration>
+            </plugin>
             <plugin> <!-- Converts Sass files to CSS -->
                 <groupId>us.hebi.sass</groupId>
                 <artifactId>sass-cli-maven-plugin</artifactId>

--- a/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/ObservableDeque.java
+++ b/chartfx-chart/src/main/java/io/fair_acc/chartfx/ui/ObservableDeque.java
@@ -280,4 +280,20 @@ public class ObservableDeque<E> extends ObservableListBase<E> implements Deque<E
     public Iterator<E> descendingIterator() {
         return deque.descendingIterator();
     }
+
+    /**
+     * Unsupported: we need to override this method because of a name clash between
+     * java.util.List and java.util.Deque. Both define a method called reversed() but with
+     * different return types. This method was introduced in Java 21. Read more about it here:
+     * https://inside.java/2023/05/12/quality-heads-up/
+     */
+    public ObservableDeque<E> reversed() {
+        /*
+         * Throw an exception. A better solution would be a complete implementation
+         * of a reversed observable deque. However, that is quite a bit of work and if not needed
+         * then why do it. To see an example for this approach, see LinkedList.reversed().
+         */
+        throw new UnsupportedOperationException("reversed() not supported");
+    }
+
 }

--- a/chartfx-samples/pom.xml
+++ b/chartfx-samples/pom.xml
@@ -76,6 +76,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        <option>--add-exports=javafx.graphics/com.sun.javafx.scene=${project.moduleName}</option>
+                        <option>--add-exports=javafx.graphics/com.sun.javafx.tk=${project.moduleName}</option>
+                    </additionalOptions>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <configuration>

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxDatasetSamplerProject.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxDatasetSamplerProject.java
@@ -9,31 +9,22 @@ import fxsampler.FXSamplerProject;
 import fxsampler.model.WelcomePage;
 
 public class ChartFxDatasetSamplerProject implements FXSamplerProject {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getProjectName() {
         return "ChartFx - Datasets";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getSampleBasePackage() {
         return "io.fair_acc.sample.dataset";
     }
 
-    ///** {@inheritDoc} */
     //@Override
     // public String getModuleName() {
     //    return "io.fair-acc";
     //}
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public WelcomePage getWelcomePage() {
         VBox vBox = new VBox();

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxFinancialSamplerProject.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxFinancialSamplerProject.java
@@ -9,31 +9,22 @@ import fxsampler.FXSamplerProject;
 import fxsampler.model.WelcomePage;
 
 public class ChartFxFinancialSamplerProject implements FXSamplerProject {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getProjectName() {
         return "ChartFx - Financial Plots";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getSampleBasePackage() {
         return "io.fair_acc.sample.financial";
     }
 
-    ///** {@inheritDoc} */
     //@Override
     // public String getModuleName() {
     //    return "io.fair-acc";
     //}
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public WelcomePage getWelcomePage() {
         VBox vBox = new VBox();

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxMathSamplerProject.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxMathSamplerProject.java
@@ -9,31 +9,22 @@ import fxsampler.FXSamplerProject;
 import fxsampler.model.WelcomePage;
 
 public class ChartFxMathSamplerProject implements FXSamplerProject {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getProjectName() {
         return "ChartFx - Math";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getSampleBasePackage() {
         return "io.fair_acc.sample.math";
     }
 
-    ///** {@inheritDoc} */
     //@Override
     // public String getModuleName() {
     //    return "io.fair-acc";
     //}
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public WelcomePage getWelcomePage() {
         VBox vBox = new VBox();

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxMiscSamplerProject.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxMiscSamplerProject.java
@@ -9,31 +9,23 @@ import fxsampler.FXSamplerProject;
 import fxsampler.model.WelcomePage;
 
 public class ChartFxMiscSamplerProject implements FXSamplerProject {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getProjectName() {
         return "ChartFx - Misc";
     }
 
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getSampleBasePackage() {
         return "io.fair_acc.sample.misc";
     }
 
-    ///** {@inheritDoc} */
     //@Override
     // public String getModuleName() {
     //    return "io.fair-acc";
     //}
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public WelcomePage getWelcomePage() {
         VBox vBox = new VBox();

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxSamplerProject.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/ChartFxSamplerProject.java
@@ -21,31 +21,22 @@ import fxsampler.FXSamplerProject;
 import fxsampler.model.WelcomePage;
 
 public class ChartFxSamplerProject implements FXSamplerProject {
-    /**
-     * {@inheritDoc}
-     */
+
     @Override
     public String getProjectName() {
         return "ChartFx";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getSampleBasePackage() {
         return "io.fair_acc.sample.chart";
     }
 
-    ///** {@inheritDoc} */
     //@Override
     // public String getModuleName() {
     //    return "io.fair-acc";
     //}
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public WelcomePage getWelcomePage() {
         VBox vBox = new VBox();

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/LaunchJFX.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/LaunchJFX.java
@@ -19,8 +19,7 @@ import org.slf4j.LoggerFactory;
  * "Variable", "${project_classpath}", but there is no way to add the current projects dependencies to the classpath,
  * yet.
  *
- * @see <a href="https://stackoverflow.com/a/55300492" target="_top"> Stackoverflow: How to add JavaFX runtime to
- *      Eclipse in Java11 (2b) </a>
+ * See <a href="https://stackoverflow.com/a/55300492">Stackoverflow: How to add JavaFX runtime to Eclipse in Java11 (2b)</a>
  * @author akrimm
  */
 public class LaunchJFX { // NOMEN EST OMEN

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/dataset/legacy/DoubleDataSet.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/dataset/legacy/DoubleDataSet.java
@@ -17,7 +17,7 @@ import io.fair_acc.dataset.utils.AssertUtils;
  * User provides X and Y coordinates or only Y coordinates. In the former case X coordinates have value of data point
  * index. This version being optimised for native double arrays.
  *
- * @see DoubleErrorDataSet for an equivalent implementation with asymmetric errors in Y
+ * Check {@link DoubleErrorDataSet} for an equivalent implementation with asymmetric errors in Y
  * @author rstein
  * @deprecated this is kept for reference/performance comparisons only
  */

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/dataset/legacy/DoubleErrorDataSet.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/dataset/legacy/DoubleErrorDataSet.java
@@ -14,7 +14,7 @@ import io.fair_acc.dataset.utils.AssertUtils;
  * User provides X and Y coordinates or only Y coordinates. In the former case X coordinates have value of data point
  * index. This version being optimised for native double arrays.
  *
- * @see DoubleDataSet for an equivalent implementation without errors
+ * Check {@link DoubleDataSet} for an equivalent implementation without errors
  * @author rstein
  * @deprecated this is kept for reference/performance comparisons only
  */

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/ConcurrentDateFormatAccess.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/ConcurrentDateFormatAccess.java
@@ -6,7 +6,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * @see SimpleDateFormat is not thread safe. For parallel processing of data streams is necessary to use threadlocal processing.
+ * Note: {@link SimpleDateFormat} is not thread safe. For parallel processing of data streams is necessary to use threadlocal processing.
  */
 public class ConcurrentDateFormatAccess {
     private final String simpleDateFormatString;

--- a/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/SCIDByNio.java
+++ b/chartfx-samples/src/main/java/io/fair_acc/sample/financial/service/SCIDByNio.java
@@ -288,9 +288,7 @@ public class SCIDByNio implements AutoCloseable {
     }
 
     /**
-     * Thanks to @see
-     * http://svn.codehaus.org/groovy/modules/scriptom/branches/SCRIPTOM
-     * -1.5.4-ANT/src/com/jacob/com/DateUtilities.java
+     * Thanks to <a href="http://svn.codehaus.org/groovy/modules/scriptom/branches/SCRIPTOM-1.5.4-ANT/src/com/jacob/com/DateUtilities.java">DateUtilities.java</a>
      *
      * @param comTime time in windows time for convert to java format
      * @return java format of windows format with usage of specific timezone

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,20 @@
 
     <profiles>
         <profile>
+            <id>disable-javadoc-on-jdk25</id>
+            <activation>
+                <jdk>[25,)</jdk> <!-- >= jdk25 -->
+            </activation>
+            <properties>
+                <!--
+                javadoc25 got really strict and crashes on 'samples', but the error message
+                does not say why. It's unlikely that we need javadoc for non-release builds,
+                so we can just disable it until we know the cause.
+                  -->
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>releaseGithub</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -150,12 +150,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version> <!-- use old version to ignore module system errors -->
+                    <version>3.6.3</version>
                     <configuration>
+                        <source>17</source>
                         <links>
                             <link>https://openjfx.io/javadoc/12/</link>
                         </links>
-                        <doclint>none</doclint> <!-- TODO: fix javadoc errors -->
+                        <doclint>none</doclint> <!-- Prevents minor HTML errors from breaking the build -->
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This PR fixes the non-test compilation for jdk17 / jdk21 / jdk25: `mvn clean package -DskipTests`. I tried getting tests to run as well, but that's going to be an enormous rabbit hole.

### Changes

* added @dlemmermann's fix for Deque in #655
* fixed various jdk21 javadoc issues like removing `@inheritDoc` from non-existant documentation, and references to classes that were not accessible.
* for jdk25 I added a profile to disable javadoc entirely because the `samples` module crashes and I really don't know why.


### Jdk25 Javadoc error

```
[INFO] Reactor Summary for chartfx-parent master-SNAPSHOT:
[INFO]
[INFO] chartfx-parent ..................................... SUCCESS [  0.821 s]
[INFO] chartfx-bench ...................................... SUCCESS [  2.179 s]
[INFO] chartfx-generate ................................... SUCCESS [  0.487 s]
[INFO] chartfx-dataset .................................... SUCCESS [  5.265 s]
[INFO] chartfx_math ....................................... SUCCESS [  3.487 s]
[INFO] chartfx-chart ...................................... SUCCESS [  6.544 s]
[INFO] chartfx-acc ........................................ SUCCESS [  1.545 s]
[INFO] chartfx-samples .................................... FAILURE [  2.726 s]
[INFO] chartfx-report ..................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.189 s
[INFO] Finished at: 2026-02-25T20:35:12+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.6.3:jar (attach-javadocs) on project samples: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1
[ERROR] error: An internal exception has occurred.
[ERROR]         (java.lang.NullPointerException: Cannot invoke "com.sun.source.util.DocTreePath.getTreePath()" because "path" is null)
[ERROR] Please file a bug against the javadoc tool via the Java bug reporting page
[ERROR] (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
[ERROR] for duplicates. Include error messages and the following diagnostic in your report. Thank you.
[ERROR] java.lang.NullPointerException: Cannot invoke "com.sun.source.util.DocTreePath.getTreePath()" because "path" is null
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.JavadocLog.getDiagnosticSource(JavadocLog.java:660)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.JavadocLog.print(JavadocLog.java:247)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.Messages.report(Messages.java:238)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.Messages.warning(Messages.java:158)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.SeeTaglet.lambda$seeTagOutput$0(SeeTaglet.java:180)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.LinkTaglet.linkSeeReferenceOutput(LinkTaglet.java:191)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.SeeTaglet.seeTagOutput(SeeTaglet.java:174)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.SeeTaglet.seeTagOutput(SeeTaglet.java:108)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.SeeTaglet.getAllBlockTagOutput(SeeTaglet.java:92)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.TagletWriter.getBlockTagOutput(TagletWriter.java:263)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDocletWriter.getBlockTagOutput(HtmlDocletWriter.java:396)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDocletWriter.getBlockTagOutput(HtmlDocletWriter.java:382)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDocletWriter.addTagsInfo(HtmlDocletWriter.java:368)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.PropertyWriter.addTags(PropertyWriter.java:226)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.PropertyWriter.buildTagInfo(PropertyWriter.java:148)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.PropertyWriter.buildPropertyDoc(PropertyWriter.java:89)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.PropertyWriter.buildDetails(PropertyWriter.java:65)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ClassWriter.buildMemberDetails(ClassWriter.java:337)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ClassWriter.buildClassDoc(ClassWriter.java:137)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.ClassWriter.buildPage(ClassWriter.java:114)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDoclet.generateClassFiles(HtmlDoclet.java:425)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.generateClassFiles(AbstractDoclet.java:246)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDoclet.generateClassFiles(HtmlDoclet.java:211)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.generateFiles(AbstractDoclet.java:179)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.HtmlDoclet.generateFiles(HtmlDoclet.java:353)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.AbstractDoclet.run(AbstractDoclet.java:82)
[ERROR]         at jdk.javadoc/jdk.javadoc.doclet.StandardDoclet.run(StandardDoclet.java:109)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:591)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:399)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:348)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:57)
[ERROR]         at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:46)
[ERROR] 1 error
```

